### PR TITLE
Auto update 2026-06-28

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780756231,
-        "narHash": "sha256-tXQxKdG5716uB9/LIkLQqQwHKf5mRSpHoZhz3lyI2Cg=",
+        "lastModified": 1782073106,
+        "narHash": "sha256-dnS5SaZlPqR1E0dPXaPc+lFkBwLUbAgbwsVMk7uA6dY=",
         "owner": "hyprwm",
         "repo": "aquamarine",
-        "rev": "6ecde03f47172753fe5a2f334f9d3facfb7e6784",
+        "rev": "6d6e2384f381def4ea4ea81543cba4bbdac72457",
         "type": "github"
       },
       "original": {
@@ -110,11 +110,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782494978,
-        "narHash": "sha256-OeywKPIMtEy8CrYKgJPljJqb3EX9h8I6+5PEuHFIyG8=",
+        "lastModified": 1782540557,
+        "narHash": "sha256-9A46MkRhAk9pKjLWELOvMwZmyquwDEmuE6khwvc7whY=",
         "owner": "Gako358",
         "repo": "emacs-flake",
-        "rev": "8567f95d2ae6183a3be43b820663dce5161201da",
+        "rev": "4458731477e674be552ff6ae3db8b579fb4b5e33",
         "type": "github"
       },
       "original": {
@@ -316,11 +316,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1781622756,
-        "narHash": "sha256-JrPh4M6S7aPsEE9tOENuZrxC6o2szSLlK+t4+nLke9s=",
+        "lastModified": 1782562157,
+        "narHash": "sha256-a7+T6QSeowynwZ1ZJJbP8T8ntAytvrui8kFGJmIZt2c=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "08018c72174a4df5657f8d94178ac69fb9c243e5",
+        "rev": "a9cf7546a938c737b079e738de73934a13de9784",
         "type": "github"
       },
       "original": {
@@ -336,11 +336,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781989573,
-        "narHash": "sha256-npfH7Zv7t1akX/ArqCNro4zU4ViPlghLaPnbEfHbCxk=",
+        "lastModified": 1782522538,
+        "narHash": "sha256-CvOaUvJ+mXlxU3m2cPWKcOAhtKETsPUYhq+Xa5ewBp4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "78e7d8b13ecd7f5256a5c11ce216876164099d9f",
+        "rev": "8d8a6cc50ddc60748791a14ee1163c865ec57635",
         "type": "github"
       },
       "original": {
@@ -415,11 +415,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776426399,
-        "narHash": "sha256-RUESLKNikIeEq9ymGJ6nmcDXiSFQpUW1IhJ245nL3xM=",
+        "lastModified": 1782566056,
+        "narHash": "sha256-haEZcHzYrePnjFOYSWTbxm/Nrla0aPslJfmvdCvqtVc=",
         "owner": "hyprwm",
         "repo": "hyprgraphics",
-        "rev": "68d064434787cf1ed4a2fe257c03c5f52f33cf84",
+        "rev": "c6e7b9f673f4360bc813d3dc75028f75ee88d3f8",
         "type": "github"
       },
       "original": {
@@ -480,11 +480,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1781888691,
-        "narHash": "sha256-TmrOChAzMwvktV2xM9glJRSsZWyOqBFeCyfbEoZiwUc=",
+        "lastModified": 1782635098,
+        "narHash": "sha256-0/PdEhnLw2KAbCYoyYjFh1Orwf8Tlmg7rxYA8k0AX9w=",
         "owner": "hyprwm",
         "repo": "hyprland",
-        "rev": "d486a5fe69c9800e75aed76ae4beb3183ac8886d",
+        "rev": "b8d910d874d07548bf20529b7ad1f02e9b3c8e35",
         "type": "github"
       },
       "original": {
@@ -547,11 +547,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776426575,
-        "narHash": "sha256-KI6nIfVihn/DPaeB5Et46Xg3dkNHrrEtUd5LBBVomB0=",
+        "lastModified": 1782563850,
+        "narHash": "sha256-rs/EzgrgPHbCtJjFZN4aR1HYldH/0NtGAempWVpWQTs=",
         "owner": "hyprwm",
         "repo": "hyprland-guiutils",
-        "rev": "a968d211048e3ed538e47b84cb3649299578f19d",
+        "rev": "5ba080ee036c30cb2485f2647ff8a61f7aa08178",
         "type": "github"
       },
       "original": {
@@ -758,11 +758,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772462885,
-        "narHash": "sha256-5pHXrQK9zasMnIo6yME6EOXmWGFMSnCITcfKshhKJ9I=",
+        "lastModified": 1782554491,
+        "narHash": "sha256-+p3MlyN/nqRefcf2IckPlGRUn9+hielqpS9XClbLleM=",
         "owner": "hyprwm",
         "repo": "hyprtoolkit",
-        "rev": "9af245a69fa6b286b88ddfc340afd288e00a6998",
+        "rev": "bdba25ced39ea39ab004a8f31593ba0b0ff1ca35",
         "type": "github"
       },
       "original": {
@@ -828,11 +828,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780251518,
-        "narHash": "sha256-fG9xbb1SOAAJ+2kJRakp3ch+BmA/3dEg/K3PoAZTKkw=",
+        "lastModified": 1782035033,
+        "narHash": "sha256-pUtCphVzH1iNUTMGdJr4+e/yzUXA6/DZwsn+cyfIVJU=",
         "owner": "hyprwm",
         "repo": "hyprutils",
-        "rev": "40ede2e7bdec80ba5d4c443160d905e9f841ae5f",
+        "rev": "9d8bf6e810597152eef8906c670b96679af2faec",
         "type": "github"
       },
       "original": {
@@ -1056,11 +1056,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1780749050,
-        "narHash": "sha256-3av0pIjlOWQ6rDbNOmpUSvbNnJkGORQKKjb4LtCZsIY=",
+        "lastModified": 1782467914,
+        "narHash": "sha256-pGvFkM8N0xEkIIXDe5YYfbEAvHrk4IxBrjB/x8OomhE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a799d3e3886da994fa307f817a6bc705ae538eeb",
+        "rev": "e73de5be04e0eff4190a1432b946d469c794e7b4",
         "type": "github"
       },
       "original": {
@@ -1088,11 +1088,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1781577229,
-        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
+        "lastModified": 1782467914,
+        "narHash": "sha256-pGvFkM8N0xEkIIXDe5YYfbEAvHrk4IxBrjB/x8OomhE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
+        "rev": "e73de5be04e0eff4190a1432b946d469c794e7b4",
         "type": "github"
       },
       "original": {
@@ -1104,11 +1104,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1781577229,
-        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
+        "lastModified": 1782467914,
+        "narHash": "sha256-pGvFkM8N0xEkIIXDe5YYfbEAvHrk4IxBrjB/x8OomhE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
+        "rev": "e73de5be04e0eff4190a1432b946d469c794e7b4",
         "type": "github"
       },
       "original": {
@@ -1140,11 +1140,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1782021783,
-        "narHash": "sha256-Y8DYy9SUVi6y9redtuW5SJaUJDWwgsUkFWscyIz64uE=",
+        "lastModified": 1782637429,
+        "narHash": "sha256-6LlAl8QH0SQ2VpmlxsKr23i6DTN9ma4ltSqlu8sNWOs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "53c170e5351e7f81c1546f276c04be96070ed374",
+        "rev": "4ad71fa230d0686b4a0d4818c9b201b05fd4a0e2",
         "type": "github"
       },
       "original": {
@@ -1209,11 +1209,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778507602,
-        "narHash": "sha256-kTwur1wV+01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs=",
+        "lastModified": 1781733627,
+        "narHash": "sha256-U3yTuGBnmXvXoQI3qkpfEDsn9RovQPAjN7ndRco+3u0=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a",
+        "rev": "3bbec39bc90eadfa031e6f3b77272f3f60803e39",
         "type": "github"
       },
       "original": {
@@ -1316,11 +1316,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781943681,
-        "narHash": "sha256-NFHmA7H47adqiyp+0iEOyZOQhmigDqA/NBAlf4imB6U=",
+        "lastModified": 1782165805,
+        "narHash": "sha256-478kKQBvK6SYTOdN2h9jhKJv94nbXRbFMfuL1WshErg=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "420f8d2e9882911f65cfac15cc706f639ba96cca",
+        "rev": "56b24064fdcaedca53553b1a6d607fd23b613a24",
         "type": "github"
       },
       "original": {
@@ -1387,11 +1387,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780133819,
-        "narHash": "sha256-0YPKIY3dlnR7SPq7Z8ekFVvzFsfeiAtEj+QUI3KHrlI=",
+        "lastModified": 1782311043,
+        "narHash": "sha256-07zLc2M3/ax+JsjxGTft17/Joua41LHE9/9AC/F9zeU=",
         "owner": "hyprwm",
         "repo": "xdg-desktop-portal-hyprland",
-        "rev": "4a170c0ba96fd37374f93d8f91c9ed91814828ac",
+        "rev": "882ad01e195ce201b07c618bbee44a0cad8b9e5a",
         "type": "github"
       },
       "original": {
@@ -1407,11 +1407,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781847955,
-        "narHash": "sha256-1OSYOGuJp/NoODmSHjsz+6TB/kSilJ+BsFihjY7TTnc=",
+        "lastModified": 1782624757,
+        "narHash": "sha256-pqFaCAV+g8H+p0kE4vYn9ZgcEFvt644zGy7SyCdf9c8=",
         "owner": "youwen5",
         "repo": "zen-browser-flake",
-        "rev": "4bca251cd556677f7b765ff324d1638ae215be13",
+        "rev": "907465791e7064d86d37964dd95e23280dfb68da",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automatic flake update on 2026-06-28.

Review the per-host package changes below before merging.

## Input changes

```
unpacking 'github:nix-community/disko/de5708739256238fb912c62f03988815db89ec9a' into the Git cache...
unpacking 'github:Gako358/emacs-flake/4458731477e674be552ff6ae3db8b579fb4b5e33' into the Git cache...
unpacking 'github:hercules-ci/flake-parts/f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb' into the Git cache...
unpacking 'github:nixos/nixos-hardware/a9cf7546a938c737b079e738de73934a13de9784' into the Git cache...
unpacking 'github:nix-community/home-manager/8d8a6cc50ddc60748791a14ee1163c865ec57635' into the Git cache...
unpacking 'github:hyprwm/hypridle/ff41dd6d94734d6e68649e95dffc788b16ecd6b5' into the Git cache...
unpacking 'github:hyprwm/hyprland/b8d910d874d07548bf20529b7ad1f02e9b3c8e35' into the Git cache...
unpacking 'github:hyprwm/contrib/bf1a7cdb086587e6bed6e8ecd285a81c01a11c54' into the Git cache...
unpacking 'github:hyprwm/hyprland-plugins/1f90c674d51a1ef83c725cd6d02280b4c969fdf7' into the Git cache...
unpacking 'github:hyprwm/hyprpaper/c011bd20886ea3301474e77d7fa4d22ab013ece0' into the Git cache...
unpacking 'github:nix-community/impermanence/7b1d382faf603b6d264f58627330f9faa5cba149' into the Git cache...
unpacking 'github:vic/import-tree/d321337efd0f23a9eb14a42adb7b2c29313ab274' into the Git cache...
unpacking 'github:nix-community/lanzaboote/6650fb7c6b48177c8200e21ffac99a4adc72b08d' into the Git cache...
unpacking 'github:misterio77/nix-colors/b01f024090d2c4fc3152cd0cf12027a7b8453ba1' into the Git cache...
unpacking 'github:nixos/nixpkgs/e73de5be04e0eff4190a1432b946d469c794e7b4' into the Git cache...
unpacking 'github:nix-community/NUR/4ad71fa230d0686b4a0d4818c9b201b05fd4a0e2' into the Git cache...
unpacking 'github:nix-community/plasma-manager/a524a6160e6df89f7673ba293cf7d78b559eb1a5' into the Git cache...
unpacking 'github:cachix/pre-commit-hooks.nix/3bbec39bc90eadfa031e6f3b77272f3f60803e39' into the Git cache...
unpacking 'github:gako358/scram/cd8a014d65ce34d28f318ca27040db8d0779f55a' into the Git cache...
unpacking 'github:Mic92/sops-nix/56b24064fdcaedca53553b1a6d607fd23b613a24' into the Git cache...
unpacking 'github:youwen5/zen-browser-flake/907465791e7064d86d37964dd95e23280dfb68da' into the Git cache...
warning: updating lock file "/home/runner/work/dotfiles/dotfiles/flake.lock":
• Updated input 'emacs-flake':
    'github:Gako358/emacs-flake/8567f95d2ae6183a3be43b820663dce5161201da?narHash=sha256-OeywKPIMtEy8CrYKgJPljJqb3EX9h8I6%2B5PEuHFIyG8%3D' (2026-06-26)
  → 'github:Gako358/emacs-flake/4458731477e674be552ff6ae3db8b579fb4b5e33?narHash=sha256-9A46MkRhAk9pKjLWELOvMwZmyquwDEmuE6khwvc7whY%3D' (2026-06-27)
• Updated input 'hardware':
    'github:nixos/nixos-hardware/08018c72174a4df5657f8d94178ac69fb9c243e5?narHash=sha256-JrPh4M6S7aPsEE9tOENuZrxC6o2szSLlK%2Bt4%2BnLke9s%3D' (2026-06-16)
  → 'github:nixos/nixos-hardware/a9cf7546a938c737b079e738de73934a13de9784?narHash=sha256-a7%2BT6QSeowynwZ1ZJJbP8T8ntAytvrui8kFGJmIZt2c%3D' (2026-06-27)
• Updated input 'home-manager':
    'github:nix-community/home-manager/78e7d8b13ecd7f5256a5c11ce216876164099d9f?narHash=sha256-npfH7Zv7t1akX/ArqCNro4zU4ViPlghLaPnbEfHbCxk%3D' (2026-06-20)
  → 'github:nix-community/home-manager/8d8a6cc50ddc60748791a14ee1163c865ec57635?narHash=sha256-CvOaUvJ%2BmXlxU3m2cPWKcOAhtKETsPUYhq%2BXa5ewBp4%3D' (2026-06-27)
• Updated input 'hyprland':
    'github:hyprwm/hyprland/d486a5fe69c9800e75aed76ae4beb3183ac8886d?narHash=sha256-TmrOChAzMwvktV2xM9glJRSsZWyOqBFeCyfbEoZiwUc%3D' (2026-06-19)
  → 'github:hyprwm/hyprland/b8d910d874d07548bf20529b7ad1f02e9b3c8e35?narHash=sha256-0/PdEhnLw2KAbCYoyYjFh1Orwf8Tlmg7rxYA8k0AX9w%3D' (2026-06-28)
• Updated input 'hyprland/aquamarine':
    'github:hyprwm/aquamarine/6ecde03f47172753fe5a2f334f9d3facfb7e6784?narHash=sha256-tXQxKdG5716uB9/LIkLQqQwHKf5mRSpHoZhz3lyI2Cg%3D' (2026-06-06)
  → 'github:hyprwm/aquamarine/6d6e2384f381def4ea4ea81543cba4bbdac72457?narHash=sha256-dnS5SaZlPqR1E0dPXaPc%2BlFkBwLUbAgbwsVMk7uA6dY%3D' (2026-06-21)
• Updated input 'hyprland/hyprgraphics':
    'github:hyprwm/hyprgraphics/68d064434787cf1ed4a2fe257c03c5f52f33cf84?narHash=sha256-RUESLKNikIeEq9ymGJ6nmcDXiSFQpUW1IhJ245nL3xM%3D' (2026-04-17)
  → 'github:hyprwm/hyprgraphics/c6e7b9f673f4360bc813d3dc75028f75ee88d3f8?narHash=sha256-haEZcHzYrePnjFOYSWTbxm/Nrla0aPslJfmvdCvqtVc%3D' (2026-06-27)
• Updated input 'hyprland/hyprland-guiutils':
    'github:hyprwm/hyprland-guiutils/a968d211048e3ed538e47b84cb3649299578f19d?narHash=sha256-KI6nIfVihn/DPaeB5Et46Xg3dkNHrrEtUd5LBBVomB0%3D' (2026-04-17)
  → 'github:hyprwm/hyprland-guiutils/5ba080ee036c30cb2485f2647ff8a61f7aa08178?narHash=sha256-rs/EzgrgPHbCtJjFZN4aR1HYldH/0NtGAempWVpWQTs%3D' (2026-06-27)
• Updated input 'hyprland/hyprland-guiutils/hyprtoolkit':
    'github:hyprwm/hyprtoolkit/9af245a69fa6b286b88ddfc340afd288e00a6998?narHash=sha256-5pHXrQK9zasMnIo6yME6EOXmWGFMSnCITcfKshhKJ9I%3D' (2026-03-02)
  → 'github:hyprwm/hyprtoolkit/bdba25ced39ea39ab004a8f31593ba0b0ff1ca35?narHash=sha256-%2Bp3MlyN/nqRefcf2IckPlGRUn9%2BhielqpS9XClbLleM%3D' (2026-06-27)
• Updated input 'hyprland/hyprutils':
    'github:hyprwm/hyprutils/40ede2e7bdec80ba5d4c443160d905e9f841ae5f?narHash=sha256-fG9xbb1SOAAJ%2B2kJRakp3ch%2BBmA/3dEg/K3PoAZTKkw%3D' (2026-05-31)
  → 'github:hyprwm/hyprutils/9d8bf6e810597152eef8906c670b96679af2faec?narHash=sha256-pUtCphVzH1iNUTMGdJr4%2Be/yzUXA6/DZwsn%2BcyfIVJU%3D' (2026-06-21)
• Updated input 'hyprland/nixpkgs':
    'github:NixOS/nixpkgs/a799d3e3886da994fa307f817a6bc705ae538eeb?narHash=sha256-3av0pIjlOWQ6rDbNOmpUSvbNnJkGORQKKjb4LtCZsIY%3D' (2026-06-06)
  → 'github:NixOS/nixpkgs/e73de5be04e0eff4190a1432b946d469c794e7b4?narHash=sha256-pGvFkM8N0xEkIIXDe5YYfbEAvHrk4IxBrjB/x8OomhE%3D' (2026-06-26)
• Updated input 'hyprland/pre-commit-hooks':
    'github:cachix/git-hooks.nix/61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a?narHash=sha256-kTwur1wV%2B01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs%3D' (2026-05-11)
  → 'github:cachix/git-hooks.nix/3bbec39bc90eadfa031e6f3b77272f3f60803e39?narHash=sha256-U3yTuGBnmXvXoQI3qkpfEDsn9RovQPAjN7ndRco%2B3u0%3D' (2026-06-17)
• Updated input 'hyprland/xdph':
    'github:hyprwm/xdg-desktop-portal-hyprland/4a170c0ba96fd37374f93d8f91c9ed91814828ac?narHash=sha256-0YPKIY3dlnR7SPq7Z8ekFVvzFsfeiAtEj%2BQUI3KHrlI%3D' (2026-05-30)
  → 'github:hyprwm/xdg-desktop-portal-hyprland/882ad01e195ce201b07c618bbee44a0cad8b9e5a?narHash=sha256-07zLc2M3/ax%2BJsjxGTft17/Joua41LHE9/9AC/F9zeU%3D' (2026-06-24)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/567a49d1913ce81ac6e9582e3553dd90a955875f?narHash=sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H%2BCNW1Ck8B%2B8%3D' (2026-06-16)
  → 'github:nixos/nixpkgs/e73de5be04e0eff4190a1432b946d469c794e7b4?narHash=sha256-pGvFkM8N0xEkIIXDe5YYfbEAvHrk4IxBrjB/x8OomhE%3D' (2026-06-26)
• Updated input 'nur':
    'github:nix-community/NUR/53c170e5351e7f81c1546f276c04be96070ed374?narHash=sha256-Y8DYy9SUVi6y9redtuW5SJaUJDWwgsUkFWscyIz64uE%3D' (2026-06-21)
  → 'github:nix-community/NUR/4ad71fa230d0686b4a0d4818c9b201b05fd4a0e2?narHash=sha256-6LlAl8QH0SQ2VpmlxsKr23i6DTN9ma4ltSqlu8sNWOs%3D' (2026-06-28)
• Updated input 'nur/nixpkgs':
    'github:nixos/nixpkgs/567a49d1913ce81ac6e9582e3553dd90a955875f?narHash=sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H%2BCNW1Ck8B%2B8%3D' (2026-06-16)
  → 'github:nixos/nixpkgs/e73de5be04e0eff4190a1432b946d469c794e7b4?narHash=sha256-pGvFkM8N0xEkIIXDe5YYfbEAvHrk4IxBrjB/x8OomhE%3D' (2026-06-26)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/420f8d2e9882911f65cfac15cc706f639ba96cca?narHash=sha256-NFHmA7H47adqiyp%2B0iEOyZOQhmigDqA/NBAlf4imB6U%3D' (2026-06-20)
  → 'github:Mic92/sops-nix/56b24064fdcaedca53553b1a6d607fd23b613a24?narHash=sha256-478kKQBvK6SYTOdN2h9jhKJv94nbXRbFMfuL1WshErg%3D' (2026-06-22)
• Updated input 'zen-browser':
    'github:youwen5/zen-browser-flake/4bca251cd556677f7b765ff324d1638ae215be13?narHash=sha256-1OSYOGuJp/NoODmSHjsz%2B6TB/kSilJ%2BBsFihjY7TTnc%3D' (2026-06-19)
  → 'github:youwen5/zen-browser-flake/907465791e7064d86d37964dd95e23280dfb68da?narHash=sha256-pqFaCAV%2Bg8H%2Bp0kE4vYn9ZgcEFvt644zGy7SyCdf9c8%3D' (2026-06-28)
```

## Per-host package diff

<details><summary><b>aanallein</b></summary>

```
<<< result-old
>>> result-new
Version changes:
[U.]  #01  aardvark-dns            1.17.1 -> 2.0.0
[U.]  #02  at-spi2-core            2.60.1, 2.60.1-dev -> 2.60.4, 2.60.4-dev
[U.]  #03  audit                   4.1.2-unstable-2025-09-06-lib x2 -> 4.1.4-lib x2
[U*]  #04  bind                    9.20.23-host, 9.20.23-lib, 9.20.23-man -> 9.20.24-host, 9.20.24-lib, 9.20.24-man
[U*]  #05  cpupower                6.18.35, 6.18.35_fish-completions -> 6.18.36, 6.18.36_fish-completions
[U*]  #06  docker                  29.5.3 -> 29.6.0
[U*]  #07  docker-compose          5.1.4 -> 5.2.0
[U.]  #08  docker-containerd       29.5.3 -> 29.6.0
[U.]  #09  docker-runc             29.5.3 -> 29.6.0
[U.]  #10  docker-tini             29.5.3 -> 29.6.0
[U.]  #11  e2fsprogs               1.47.3, 1.47.3-bin -> 1.47.4, 1.47.4-bin
[C.]  #12  expat                   2.6.4, 2.8.0 x2, 2.8.0-dev -> 2.6.4, 2.8.1 x2, 2.8.1-dev
[U.]  #13  ffmpeg-headless         8.1-data x2, 8.1-lib x2 -> 8.1.1-data x2, 8.1.1-lib x2
[U.]  #14  fftw-double             3.3.10 x2 -> 3.3.11 x2
[U.]  #15  fftw-single             3.3.10 x2 -> 3.3.11 x2
[U*]  #16  fish                    4.7.1, 4.7.1-doc, 4.7.1_fish-completions x2 -> 4.8.0, 4.8.0-doc, 4.8.0_fish-completions x2
[U.]  #17  freetype                2.14.2 x2, 2.14.2-dev -> 2.14.3 x2, 2.14.3-dev
[C-]  #18  fuse                    2.9.9-bin, 2.9.9-man, 3.17.4, 3.17.4-bin, 3.17.4-man -> 3.17.4
[U*]  #19  getent-glibc            2.42-61 -> 2.42-67
[U.]  #20  gh                      2.94.0, 2.94.0-fish-completions -> 2.95.0, 2.95.0-fish-completions
[C*]  #21  glibc                   2.40-66, 2.42-61 x2, 2.42-61-bin, 2.42-61-dev, 2.42-61-getent -> 2.40-66, 2.42-67 x2, 2.42-67-bin, 2.42-67-dev, 2.42-67-getent
[U*]  #22  glibc-locales           2.42-61 -> 2.42-67
[U.]  #23  imagemagick             7.1.2-23, 7.1.2-23-fish-completions -> 7.1.2-24, 7.1.2-24-fish-completions
[U.]  #24  initrd-linux            6.18.35 -> 6.18.36
[C.]  #25  krb5                    1.21.3-lib, 1.22.1-lib x2 -> 1.21.3-lib, 1.22.2-lib x2
[U.]  #26  lhasa                   0.5.0 -> 0.6.0
[U.]  #27  libde265                1.0.18 -> 1.1.1
[U.]  #28  libgcrypt               1.11.2-lib x2 -> 1.12.2-lib x2
[U.]  #29  libheif                 1.21.2-lib -> 1.23.0-lib
[U.]  #30  libkrun                 1.18.1 -> 1.19.0
[U.]  #31  libpng-apng             1.6.56 x2, 1.6.56-dev -> 1.6.58 x2, 1.6.58-dev
[U.]  #32  libxml2                 2.15.2 x2, 2.15.2-bin, 2.15.2-dev -> 2.15.3 x2, 2.15.3-bin, 2.15.3-dev
[U.]  #33  linux                   6.18.35, 6.18.35-modules x2 -> 6.18.36, 6.18.36-modules x2
[U.]  #34  linux-firmware          20260519-zstd -> 20260622-zstd
[U.]  #35  mesa                    26.1.2 x2 -> 26.1.3 x2
[U.]  #36  moby                    29.5.3 -> 29.6.0
[U.]  #37  netavark                1.17.2 -> 2.0.0
[U.]  #38  nixos-system-aanallein  26.11.20260616.567a49d -> 26.11.20260626.e73de5b
[U.]  #39  openapv                 0.2.1.2 x2 -> 0.2.1.3 x2
[U.]  #40  openexr                 3.4.10 -> 3.4.11
[U.]  #41  perl5.42.0-HTTP-Daemon  6.16 -> 6.17
[U*]  #42  podman                  5.8.2, 5.8.2-man -> 5.8.3, 5.8.3-man
[C.]  #43  publicsuffix-list       0-unstable-2025-02-12, 0-unstable-2026-03-26 x2 -> 0-unstable-2025-02-12, 0-unstable-2026-05-13 x2
[U.]  #44  qtbase                  6.11.0, 6.11.0-dev -> 6.11.1, 6.11.1-dev
[U.]  #45  qtsvg                   6.11.0, 6.11.0-dev -> 6.11.1, 6.11.1-dev
[U.]  #46  qttranslations          6.11.0 -> 6.11.1
[U*]  #47  rsync                   3.4.1, 3.4.1_fish-completions -> 3.4.4, 3.4.4_fish-completions
[U.]  #48  runc                    1.4.2 -> 1.4.3
[U.]  #49  sd-switch               0.6.3 -> 0.6.4
[U*]  #50  strace                  7.0, 7.0-man -> 7.1, 7.1-man
[C*]  #51  systemd                 <none>, 260.1 x2, 260.1-dev, 260.1-man -> <none>, 260.2 x2, 260.2-dev, 260.2-man
[U.]  #52  systemd-minimal         260.1 x2 -> 260.2 x2
[U.]  #53  systemd-minimal-libs    260.1 x2, 260.1-dev -> 260.2 x2, 260.2-dev
[U.]  #54  unbound                 1.25.0-lib x2 -> 1.25.1-lib x2
[U*]  #55  wireplumber             0.5.14, 0.5.14-doc, 0.5.14_fish-completions -> 0.5.15, 0.5.15-doc, 0.5.15_fish-completions
Added packages:
[A.]  #1  polkitd.conf  <none>
Removed packages:
[R.]  #1  etc-fuse.conf                                           <none>
[R.]  #2  security-wrapper-fusermount-x86_64-unknown-linux-musl   <none>
[R.]  #3  security-wrapper-fusermount3-x86_64-unknown-linux-musl  <none>
Closure size: 1842 -> 1836 (1754 paths added, 1760 paths removed, delta -6, disk usage +17.9MiB).
```

</details>

<details><summary><b>rhuidean</b></summary>

```
<<< result-old
>>> result-new
Version changes:
[U.]  #001  aardvark-dns            1.17.1 -> 2.0.0
[U*]  #002  at-spi2-core            2.60.1 x2, 2.60.1-dev -> 2.60.4 x2, 2.60.4-dev
[U.]  #003  audit                   4.1.2-unstable-2025-09-06-lib x2 -> 4.1.4-lib x2
[U*]  #004  bind                    9.20.23-host, 9.20.23-lib, 9.20.23-man -> 9.20.24-host, 9.20.24-lib, 9.20.24-man
[U.]  #005  breeze                  6.6.5 -> 6.7.1
[U*]  #006  cpupower                6.18.35, 6.18.35_fish-completions -> 6.18.36, 6.18.36_fish-completions
[U.]  #007  discord                 1.0.141, 1.0.141-fish-completions -> 1.0.143, 1.0.143-fish-completions
[U*]  #008  docker                  29.5.3 -> 29.6.0
[U*]  #009  docker-compose          5.1.4 -> 5.2.0
[U.]  #010  docker-containerd       29.5.3 -> 29.6.0
[U.]  #011  docker-runc             29.5.3 -> 29.6.0
[U.]  #012  docker-tini             29.5.3 -> 29.6.0
[U.]  #013  e2fsprogs               1.47.3, 1.47.3-bin, 1.47.3-man -> 1.47.4, 1.47.4-bin, 1.47.4-man
[U.]  #014  evolution-data-server   3.60.1 x2 -> 3.60.2 x2
[C.]  #015  expat                   2.6.4, 2.8.0 x2, 2.8.0-dev -> 2.6.4, 2.8.1 x2, 2.8.1-dev
[C.]  #016  ffmpeg                  4.4.7-data, 4.4.7-lib, 7.1.4-data, 7.1.4-lib, 8.1-data, 8.1-lib -> 4.4.8-data, 4.4.8-lib, 7.1.5-data, 7.1.5-lib, 8.1.1-data, 8.1.1-lib
[U.]  #017  ffmpeg-headless         8.1-data x2, 8.1-lib x2 -> 8.1.1-data x2, 8.1.1-lib x2
[U.]  #018  fftw-double             3.3.10 x2 -> 3.3.11 x2
[U.]  #019  fftw-single             3.3.10 x2 -> 3.3.11 x2
[U*]  #020  fish                    4.7.1, 4.7.1-doc, 4.7.1_fish-completions x2 -> 4.8.0, 4.8.0-doc, 4.8.0_fish-completions x2
[U.]  #021  flatpak                 1.16.6 -> 1.18.0
[U.]  #022  freerdp                 3.26.0 -> 3.27.1
[U.]  #023  freetype                2.14.2 x2, 2.14.2-dev -> 2.14.3 x2, 2.14.3-dev
[C*]  #024  gdm                     <none>, 50.0 -> <none>, 50.1
[U*]  #025  getent-glibc            2.42-61 -> 2.42-67
[U.]  #026  gh                      2.94.0, 2.94.0-fish-completions -> 2.95.0, 2.95.0-fish-completions
[U.]  #027  ghostscript-with-X      10.07.0, 10.07.0-fonts -> 10.07.1, 10.07.1-fonts
[C*]  #028  glibc                   2.40-66, 2.42-61 x2, 2.42-61-bin x2, 2.42-61-dev, 2.42-61-getent -> 2.40-66, 2.42-67 x2, 2.42-67-bin x2, 2.42-67-dev, 2.42-67-getent
[U*]  #029  glibc-locales           2.42-61 x2 -> 2.42-67 x2
[U.]  #030  glibc-multi             2.42-61, 2.42-61-bin -> 2.42-67, 2.42-67-bin
[U*]  #031  gnome-control-center    50.1 -> 50.2
[U*]  #032  gnome-session           50.0, 50.0_fish-completions, 50.0-sessions -> 50.1, 50.1_fish-completions, 50.1-sessions
[U*]  #033  gnome-shell             50.1, 50.1_fish-completions -> 50.2, 50.2_fish-completions
[U*]  #034  gnome-text-editor       50.0 -> 50.1
[U*]  #035  gnome-user-docs         50.0 -> 50.2
[U*]  #036  gnome-user-share        48.2 -> 48.3
[U.]  #037  gupnp-av                0.14.4 -> 0.14.5
[U.]  #038  ijs                     10.07.0 -> 10.07.1
[U.]  #039  imagemagick             7.1.2-23, 7.1.2-23-fish-completions -> 7.1.2-24, 7.1.2-24-fish-completions
[U.]  #040  initrd-linux            6.18.35 -> 6.18.36
[U.]  #041  kdecoration             6.6.5 -> 6.7.1
[C.]  #042  krb5                    1.21.3-lib, 1.22.1, 1.22.1-lib x2 -> 1.21.3-lib, 1.22.2, 1.22.2-lib x2
[U.]  #043  lhasa                   0.5.0 -> 0.6.0
[C.]  #044  libXNVCtrl              390.157, 595.80 -> 390.157, 595.84
[U.]  #045  libadwaita              1.9.0 -> 1.9.1
[U.]  #046  libde265                1.0.18 -> 1.1.1
[U.]  #047  libgcrypt               1.11.2-bin, 1.11.2-lib x2 -> 1.12.2-bin, 1.12.2-lib x2
[U.]  #048  libheif                 1.21.2-lib -> 1.23.0-lib
[U.]  #049  libkrun                 1.18.1 -> 1.19.0
[U.]  #050  libphonenumber          9.0.32 -> 9.0.33
[U.]  #051  libpng-apng             1.6.56 x2, 1.6.56-dev -> 1.6.58 x2, 1.6.58-dev
[U.]  #052  libwmf                  0.2.13 -> 0.2.15
[U.]  #053  libxml2                 2.15.2 x2, 2.15.2-bin, 2.15.2-dev -> 2.15.3 x2, 2.15.3-bin, 2.15.3-dev
[U.]  #054  linux                   6.18.35, 6.18.35-modules x2 -> 6.18.36, 6.18.36-modules x2
[U.]  #055  linux-firmware          20260519-zstd -> 20260622-zstd
[U.]  #056  lsp-plugins             1.2.31 -> 1.2.33
[U.]  #057  lynx                    2.9.2 -> 2.9.3
[U.]  #058  mdadm                   4.4 -> 4.6
[U.]  #059  mesa                    26.1.2 x2 -> 26.1.3 x2
[U.]  #060  moby                    29.5.3 -> 29.6.0
[U.]  #061  mutter                  50.1 -> 50.2
[U*]  #062  nautilus                50.1, 50.1_fish-completions -> 50.2.2, 50.2.2_fish-completions
[U.]  #063  netavark                1.17.2 -> 2.0.0
[U.]  #064  nixos-system-rhuidean   26.11.20260616.567a49d -> 26.11.20260626.e73de5b
[U.]  #065  openapv                 0.2.1.2 x2 -> 0.2.1.3 x2
[U.]  #066  openblas                0.3.32 -> 0.3.33
[U.]  #067  openexr                 3.4.10 -> 3.4.11
[U*]  #068  orca                    50.1.2, 50.1.2_fish-completions -> 50.2, 50.2_fish-completions
[U*]  #069  papers                  50.0, 50.0_fish-completions -> 50.2, 50.2_fish-completions
[U.]  #070  perl5.42.0-HTTP-Daemon  6.16 x2 -> 6.17 x2
[U*]  #071  podman                  5.8.2, 5.8.2-man -> 5.8.3, 5.8.3-man
[C.]  #072  publicsuffix-list       0-unstable-2025-02-12, 0-unstable-2026-03-26 x2 -> 0-unstable-2025-02-12, 0-unstable-2026-05-13 x2
[U.]  #073  pv                      1.10.5 -> 1.11.0
[U.]  #074  qt5compat               6.11.0 -> 6.11.1
[U.]  #075  qtbase                  6.11.0, 6.11.0-dev, 6.11.0-only-plugins-qml -> 6.11.1, 6.11.1-dev, 6.11.1-only-plugins-qml
[U.]  #076  qtcharts                6.11.0 -> 6.11.1
[U.]  #077  qtdeclarative           6.11.0 -> 6.11.1
[U.]  #078  qtgraphs                6.11.0 -> 6.11.1
[U.]  #079  qtmultimedia            6.11.0 -> 6.11.1
[U.]  #080  qtquick3d               6.11.0 -> 6.11.1
[U.]  #081  qtquicktimeline         6.11.0 -> 6.11.1
[U.]  #082  qtshadertools           6.11.0 -> 6.11.1
[U.]  #083  qtspeech                6.11.0 -> 6.11.1
[U.]  #084  qtsvg                   6.11.0, 6.11.0-dev -> 6.11.1, 6.11.1-dev
[U.]  #085  qttools                 6.11.0 -> 6.11.1
[U.]  #086  qttranslations          6.11.0 -> 6.11.1
[U.]  #087  qtwayland               6.11.0 -> 6.11.1
[U*]  #088  rsync                   3.4.1, 3.4.1_fish-completions -> 3.4.4, 3.4.4_fish-completions
[U.]  #089  runc                    1.4.2 -> 1.4.3
[U*]  #090  rygel                   45.1, 45.1_fish-completions -> 45.2, 45.2_fish-completions
[U.]  #091  sd-switch               0.6.3 -> 0.6.4
[U.]  #092  sdl3                    3.4.8-lib x2 -> 3.4.10-lib x2
[U.]  #093  spotify                 1.2.86.502.g8cd7fb22, 1.2.86.502.g8cd7fb22-fish-completions -> 1.2.90.451.gb094aab0, 1.2.90.451.gb094aab0-fish-completions
[U*]  #094  strace                  7.0, 7.0-man -> 7.1, 7.1-man
[U*]  #095  sushi                   50.rc.1 -> 50.0
[C*]  #096  systemd                 <none>, 260.1 x2, 260.1-dev, 260.1-man -> <none>, 260.2 x2, 260.2-dev, 260.2-man
[U.]  #097  systemd-minimal         260.1 x2 -> 260.2 x2
[U.]  #098  systemd-minimal-libs    260.1 x2, 260.1-dev -> 260.2 x2, 260.2-dev
[U.]  #099  unbound                 1.25.0-lib x2 -> 1.25.1-lib x2
[U*]  #100  wireplumber             0.5.14, 0.5.14-doc, 0.5.14_fish-completions -> 0.5.15, 0.5.15-doc, 0.5.15_fish-completions
[U*]  #101  xdg-desktop-portal-wlr  0.8.2 -> 0.8.3
[U.]  #102  zen-browser             1.21.3b -> 1.21.4b
[U.]  #103  zen-browser-unwrapped   1.21.3b -> 1.21.4b
Added packages:
[A.]  #1  polkitd.conf  <none>
Closure size: 2670 -> 2671 (2584 paths added, 2583 paths removed, delta +1, disk usage +40.9MiB).
```

</details>

<details><summary><b>tanchico</b></summary>

```
<<< result-old
>>> result-new
Version changes:
[U.]  #001  aardvark-dns            1.17.1 -> 2.0.0
[U*]  #002  at-spi2-core            2.60.1 x2, 2.60.1-dev -> 2.60.4 x2, 2.60.4-dev
[U.]  #003  audit                   4.1.2-unstable-2025-09-06-lib x2 -> 4.1.4-lib x2
[U*]  #004  bind                    9.20.23-host, 9.20.23-lib, 9.20.23-man -> 9.20.24-host, 9.20.24-lib, 9.20.24-man
[U.]  #005  breeze                  6.6.5 -> 6.7.1
[U*]  #006  cpupower                6.18.35, 6.18.35_fish-completions -> 6.18.36, 6.18.36_fish-completions
[U.]  #007  discord                 1.0.141, 1.0.141-fish-completions -> 1.0.143, 1.0.143-fish-completions
[U*]  #008  docker                  29.5.3 -> 29.6.0
[U*]  #009  docker-compose          5.1.4 -> 5.2.0
[U.]  #010  docker-containerd       29.5.3 -> 29.6.0
[U.]  #011  docker-runc             29.5.3 -> 29.6.0
[U.]  #012  docker-tini             29.5.3 -> 29.6.0
[U.]  #013  e2fsprogs               1.47.3, 1.47.3-bin, 1.47.3-man -> 1.47.4, 1.47.4-bin, 1.47.4-man
[U.]  #014  evolution-data-server   3.60.1 x2 -> 3.60.2 x2
[C.]  #015  expat                   2.6.4, 2.8.0 x2, 2.8.0-dev -> 2.6.4, 2.8.1 x2, 2.8.1-dev
[C.]  #016  ffmpeg                  4.4.7-data, 4.4.7-lib, 7.1.4-data, 7.1.4-lib, 8.1-data, 8.1-lib -> 4.4.8-data, 4.4.8-lib, 7.1.5-data, 7.1.5-lib, 8.1.1-data, 8.1.1-lib
[U.]  #017  ffmpeg-headless         8.1-data x2, 8.1-lib x2 -> 8.1.1-data x2, 8.1.1-lib x2
[U.]  #018  fftw-double             3.3.10 x2 -> 3.3.11 x2
[U.]  #019  fftw-single             3.3.10 x2 -> 3.3.11 x2
[U*]  #020  fish                    4.7.1, 4.7.1-doc, 4.7.1_fish-completions x2 -> 4.8.0, 4.8.0-doc, 4.8.0_fish-completions x2
[U.]  #021  flatpak                 1.16.6 -> 1.18.0
[U.]  #022  freerdp                 3.26.0 -> 3.27.1
[U.]  #023  freetype                2.14.2 x2, 2.14.2-dev -> 2.14.3 x2, 2.14.3-dev
[C*]  #024  gdm                     <none>, 50.0 -> <none>, 50.1
[U*]  #025  getent-glibc            2.42-61 -> 2.42-67
[U.]  #026  gh                      2.94.0, 2.94.0-fish-completions -> 2.95.0, 2.95.0-fish-completions
[U.]  #027  ghostscript-with-X      10.07.0, 10.07.0-fonts -> 10.07.1, 10.07.1-fonts
[C*]  #028  glibc                   2.40-66, 2.42-61 x2, 2.42-61-bin x2, 2.42-61-dev, 2.42-61-getent -> 2.40-66, 2.42-67 x2, 2.42-67-bin x2, 2.42-67-dev, 2.42-67-getent
[U*]  #029  glibc-locales           2.42-61 x2 -> 2.42-67 x2
[U.]  #030  glibc-multi             2.42-61, 2.42-61-bin -> 2.42-67, 2.42-67-bin
[U*]  #031  gnome-control-center    50.1 -> 50.2
[U*]  #032  gnome-session           50.0, 50.0_fish-completions, 50.0-sessions -> 50.1, 50.1_fish-completions, 50.1-sessions
[U*]  #033  gnome-shell             50.1, 50.1_fish-completions -> 50.2, 50.2_fish-completions
[U*]  #034  gnome-text-editor       50.0 -> 50.1
[U*]  #035  gnome-user-docs         50.0 -> 50.2
[U*]  #036  gnome-user-share        48.2 -> 48.3
[U.]  #037  gupnp-av                0.14.4 -> 0.14.5
[U.]  #038  ijs                     10.07.0 -> 10.07.1
[U.]  #039  imagemagick             7.1.2-23, 7.1.2-23-fish-completions -> 7.1.2-24, 7.1.2-24-fish-completions
[U.]  #040  initrd-linux            6.18.35 -> 6.18.36
[U.]  #041  kdecoration             6.6.5 -> 6.7.1
[C.]  #042  krb5                    1.21.3-lib, 1.22.1, 1.22.1-lib x2 -> 1.21.3-lib, 1.22.2, 1.22.2-lib x2
[U.]  #043  lhasa                   0.5.0 -> 0.6.0
[C.]  #044  libXNVCtrl              390.157, 595.80 -> 390.157, 595.84
[U.]  #045  libadwaita              1.9.0 -> 1.9.1
[U.]  #046  libde265                1.0.18 -> 1.1.1
[U.]  #047  libgcrypt               1.11.2-bin, 1.11.2-lib x2 -> 1.12.2-bin, 1.12.2-lib x2
[U.]  #048  libheif                 1.21.2-lib -> 1.23.0-lib
[U.]  #049  libkrun                 1.18.1 -> 1.19.0
[U.]  #050  libphonenumber          9.0.32 -> 9.0.33
[U.]  #051  libpng-apng             1.6.56 x2, 1.6.56-dev -> 1.6.58 x2, 1.6.58-dev
[U.]  #052  libwmf                  0.2.13 -> 0.2.15
[U.]  #053  libxml2                 2.15.2 x2, 2.15.2-bin, 2.15.2-dev -> 2.15.3 x2, 2.15.3-bin, 2.15.3-dev
[U.]  #054  linux                   6.18.35, 6.18.35-modules x2 -> 6.18.36, 6.18.36-modules x2
[U.]  #055  linux-firmware          20260519-zstd -> 20260622-zstd
[U.]  #056  lsp-plugins             1.2.31 -> 1.2.33
[U.]  #057  lynx                    2.9.2 -> 2.9.3
[U.]  #058  mdadm                   4.4 -> 4.6
[U.]  #059  mesa                    26.1.2 x2 -> 26.1.3 x2
[U.]  #060  moby                    29.5.3 -> 29.6.0
[U.]  #061  mutter                  50.1 -> 50.2
[U*]  #062  nautilus                50.1, 50.1_fish-completions -> 50.2.2, 50.2.2_fish-completions
[U.]  #063  netavark                1.17.2 -> 2.0.0
[U.]  #064  nixos-system-tanchico   26.11.20260616.567a49d -> 26.11.20260626.e73de5b
[U.]  #065  openapv                 0.2.1.2 x2 -> 0.2.1.3 x2
[U.]  #066  openblas                0.3.32 -> 0.3.33
[U.]  #067  openexr                 3.4.10 -> 3.4.11
[U*]  #068  orca                    50.1.2, 50.1.2_fish-completions -> 50.2, 50.2_fish-completions
[U*]  #069  papers                  50.0, 50.0_fish-completions -> 50.2, 50.2_fish-completions
[U.]  #070  perl5.42.0-HTTP-Daemon  6.16 x2 -> 6.17 x2
[U*]  #071  podman                  5.8.2, 5.8.2-man -> 5.8.3, 5.8.3-man
[C.]  #072  publicsuffix-list       0-unstable-2025-02-12, 0-unstable-2026-03-26 x2 -> 0-unstable-2025-02-12, 0-unstable-2026-05-13 x2
[U.]  #073  pv                      1.10.5 -> 1.11.0
[U.]  #074  qt5compat               6.11.0 -> 6.11.1
[U.]  #075  qtbase                  6.11.0, 6.11.0-dev, 6.11.0-only-plugins-qml -> 6.11.1, 6.11.1-dev, 6.11.1-only-plugins-qml
[U.]  #076  qtcharts                6.11.0 -> 6.11.1
[U.]  #077  qtdeclarative           6.11.0 -> 6.11.1
[U.]  #078  qtgraphs                6.11.0 -> 6.11.1
[U.]  #079  qtmultimedia            6.11.0 -> 6.11.1
[U.]  #080  qtquick3d               6.11.0 -> 6.11.1
[U.]  #081  qtquicktimeline         6.11.0 -> 6.11.1
[U.]  #082  qtshadertools           6.11.0 -> 6.11.1
[U.]  #083  qtspeech                6.11.0 -> 6.11.1
[U.]  #084  qtsvg                   6.11.0, 6.11.0-dev -> 6.11.1, 6.11.1-dev
[U.]  #085  qttools                 6.11.0 -> 6.11.1
[U.]  #086  qttranslations          6.11.0 -> 6.11.1
[U.]  #087  qtwayland               6.11.0 -> 6.11.1
[U*]  #088  rsync                   3.4.1, 3.4.1_fish-completions -> 3.4.4, 3.4.4_fish-completions
[U.]  #089  runc                    1.4.2 -> 1.4.3
[U*]  #090  rygel                   45.1, 45.1_fish-completions -> 45.2, 45.2_fish-completions
[U.]  #091  sd-switch               0.6.3 -> 0.6.4
[U.]  #092  sdl3                    3.4.8-lib x2 -> 3.4.10-lib x2
[U.]  #093  spotify                 1.2.86.502.g8cd7fb22, 1.2.86.502.g8cd7fb22-fish-completions -> 1.2.90.451.gb094aab0, 1.2.90.451.gb094aab0-fish-completions
[U*]  #094  strace                  7.0, 7.0-man -> 7.1, 7.1-man
[U*]  #095  sushi                   50.rc.1 -> 50.0
[C*]  #096  systemd                 <none>, 260.1 x2, 260.1-dev, 260.1-man -> <none>, 260.2 x2, 260.2-dev, 260.2-man
[U.]  #097  systemd-minimal         260.1 x2 -> 260.2 x2
[U.]  #098  systemd-minimal-libs    260.1 x2, 260.1-dev -> 260.2 x2, 260.2-dev
[U.]  #099  unbound                 1.25.0-lib x2 -> 1.25.1-lib x2
[U*]  #100  wireplumber             0.5.14, 0.5.14-doc, 0.5.14_fish-completions -> 0.5.15, 0.5.15-doc, 0.5.15_fish-completions
[U*]  #101  xdg-desktop-portal-wlr  0.8.2 -> 0.8.3
[U.]  #102  zen-browser             1.21.3b -> 1.21.4b
[U.]  #103  zen-browser-unwrapped   1.21.3b -> 1.21.4b
Added packages:
[A.]  #1  polkitd.conf  <none>
Closure size: 2667 -> 2668 (2581 paths added, 2580 paths removed, delta +1, disk usage +41.4MiB).
```

</details>

<details><summary><b>terangreal</b></summary>

```
<<< result-old
>>> result-new
Version changes:
[U.]  #001  OVMF-xen                     202602-fd -> 202605-fd
[U.]  #002  aardvark-dns                 1.17.1 -> 2.0.0
[C.]  #003  aquamarine                   0.12.0+date=2026-06-06_6ecde03, 0.12.1 -> 0.12.1, 0.12.1+date=2026-06-21_6d6e238
[U.]  #004  at-spi2-core                 2.60.1, 2.60.1-dev -> 2.60.4, 2.60.4-dev
[U.]  #005  audit                        4.1.2-unstable-2025-09-06-lib x2 -> 4.1.4-lib x2
[U*]  #006  bind                         9.20.23-host, 9.20.23-lib, 9.20.23-man -> 9.20.24-host, 9.20.24-lib, 9.20.24-man
[U.]  #007  bottom                       0.12.3, 0.12.3-fish-completions -> 0.13.0, 0.13.0-fish-completions
[U.]  #008  breeze                       6.6.5 -> 6.7.1
[U*]  #009  cpupower                     6.18.35, 6.18.35_fish-completions -> 6.18.36, 6.18.36_fish-completions
[U.]  #010  discord                      1.0.141, 1.0.141-fish-completions -> 1.0.143, 1.0.143-fish-completions
[U*]  #011  docker                       29.5.3 -> 29.6.0
[U*]  #012  docker-compose               5.1.4 -> 5.2.0
[U.]  #013  docker-containerd            29.5.3 -> 29.6.0
[U.]  #014  docker-runc                  29.5.3 -> 29.6.0
[U.]  #015  docker-tini                  29.5.3 -> 29.6.0
[U.]  #016  e2fsprogs                    1.47.3, 1.47.3-bin -> 1.47.4, 1.47.4-bin
[U.]  #017  emacs-ghostel                0.34.0-unstable-2026-06-08 -> 0.35.4-unstable-2026-06-19
[U.]  #018  emacs-mu4e                   1.14.1 -> 1.14.2
[U.]  #019  evolution-data-server        3.60.1 -> 3.60.2
[C.]  #020  expat                        2.6.4, 2.8.0 x2, 2.8.0-dev -> 2.6.4, 2.8.1 x2, 2.8.1-dev
[C.]  #021  ffmpeg                       7.1.4-data, 7.1.4-lib, 8.1-data, 8.1-lib -> 7.1.5-data, 7.1.5-lib, 8.1.1-data, 8.1.1-lib
[U.]  #022  ffmpeg-headless              8.1-data x2, 8.1-lib x2 -> 8.1.1-data x2, 8.1.1-lib x2
[U.]  #023  fftw-double                  3.3.10 x2 -> 3.3.11 x2
[U.]  #024  fftw-single                  3.3.10 x2 -> 3.3.11 x2
[U*]  #025  fish                         4.7.1, 4.7.1-doc, 4.7.1_fish-completions x2 -> 4.8.0, 4.8.0-doc, 4.8.0-fish-completions x2
[U.]  #026  flatpak                      1.16.6 -> 1.18.0
[U.]  #027  freetype                     2.14.2 x2, 2.14.2-dev -> 2.14.3 x2, 2.14.3-dev
[C.]  #028  gcc                          14-20241116-lib, 14-20241116-libgcc, 15.2.0 x2, 15.2.0-lib x3, 15.2.0-libgcc x3 -> 14-20241116-lib, 14-20241116-libgcc, 15.2.0 x2, 15.2.0-lib x3, 15.2.0-libgcc x3, 16.1.0-lib, 16.1.0-libgcc
[U.]  #029  gemini-cli                   0.44.1 -> 0.47.0
[U*]  #030  getent-glibc                 2.42-61 -> 2.42-67
[U.]  #031  gh                           2.94.0, 2.94.0-fish-completions -> 2.95.0, 2.95.0-fish-completions
[U.]  #032  ghostscript-with-X           10.07.0, 10.07.0-fonts -> 10.07.1, 10.07.1-fonts
[C*]  #033  glibc                        2.40-66, 2.42-61 x2, 2.42-61-bin, 2.42-61-dev, 2.42-61-getent -> 2.40-66, 2.42-67 x2, 2.42-67-bin, 2.42-67-dev, 2.42-67-getent
[U*]  #034  glibc-locales                2.42-61 -> 2.42-67
[C.]  #035  hyprgraphics                 0.5.1, 0.5.1+date=2026-04-17_68d0644 -> 0.5.1, 0.5.1+date=2026-06-27_c6e7b9f
[C*]  #036  hyprland                     0.55.0+date=2026-06-19_d486a5f, 0.55.0+date=2026-06-19_d486a5f-man, 0.55.4 -> 0.55.0+date=2026-06-28_b8d910d, 0.55.0+date=2026-06-28_b8d910d-man, 0.55.4
[U.]  #037  hyprland-guiutils            0.2.1+date=2026-04-17_a968d21 -> 0.2.1+date=2026-06-27_5ba080e
[C.]  #038  hyprutils                    0.13.1, 0.13.1+date=2026-05-31_40ede2e, 0.13.1+date=2026-05-31_40ede2e-dev -> 0.13.1, 0.13.1+date=2026-06-21_9d8bf6e, 0.13.1+date=2026-06-21_9d8bf6e-dev
[C.]  #039  icu4c                        76.1 x2, 76.1-dev, 77.1 -> 76.1 x2, 76.1-dev, 77.1, 78.3, 78.3-dev
[U.]  #040  ijs                          10.07.0 -> 10.07.1
[U.]  #041  imagemagick                  7.1.2-23, 7.1.2-23-fish-completions -> 7.1.2-24, 7.1.2-24-fish-completions
[U.]  #042  initrd-linux                 6.18.35 -> 6.18.36
[U.]  #043  kdecoration                  6.6.5 -> 6.7.1
[C.]  #044  krb5                         1.21.3-lib, 1.22.1, 1.22.1-dev, 1.22.1-lib x2 -> 1.21.3-lib, 1.22.2, 1.22.2-dev, 1.22.2-lib x2
[U.]  #045  lhasa                        0.5.0 -> 0.6.0
[U.]  #046  libadwaita                   1.9.0 -> 1.9.1
[U.]  #047  libde265                     1.0.18 -> 1.1.1
[U.]  #048  libgcrypt                    1.11.2-lib x2 -> 1.12.2-lib x2
[U.]  #049  libheif                      1.21.2-lib -> 1.23.0-lib
[U.]  #050  libkrun                      1.18.1 -> 1.19.0
[U.]  #051  libphonenumber               9.0.32 -> 9.0.33
[U.]  #052  libpng-apng                  1.6.56 x2, 1.6.56-dev -> 1.6.58 x2, 1.6.58-dev
[U.]  #053  libwmf                       0.2.13 -> 0.2.15
[U.]  #054  libxml2                      2.15.2 x3, 2.15.2-bin x2, 2.15.2-dev x2, 2.15.2-py -> 2.15.3 x3, 2.15.3-bin x2, 2.15.3-dev x2, 2.15.3-py
[U.]  #055  linux                        6.18.35, 6.18.35-modules x2 -> 6.18.36, 6.18.36-modules x2
[U.]  #056  linux-firmware               20260519-zstd -> 20260622-zstd
[U.]  #057  lsp-plugins                  1.2.31 -> 1.2.33
[U.]  #058  mdadm                        4.4 -> 4.6
[U.]  #059  mesa                         26.1.2 x2 -> 26.1.3 x2
[U.]  #060  moby                         29.5.3 -> 29.6.0
[U.]  #061  mu                           1.14.1, 1.14.1-fish-completions -> 1.14.2, 1.14.2-fish-completions
[U.]  #062  netavark                     1.17.2 -> 2.0.0
[U.]  #063  nixos-system-terangreal      26.11.20260616.567a49d -> 26.11.20260626.e73de5b
[C.]  #064  nodejs                       22.22.3, 24.15.0 -> 22.23.1, 24.16.0
[C.]  #065  nodejs-slim                  22.22.3, 22.22.3-corepack, 22.22.3-npm, 24.15.0, 24.15.0-corepack, 24.15.0-npm -> 22.23.1, 22.23.1-corepack, 22.23.1-npm, 24.16.0, 24.16.0-corepack, 24.16.0-npm
[U.]  #066  openapv                      0.2.1.2 x2 -> 0.2.1.3 x2
[U.]  #067  openblas                     0.3.32 -> 0.3.33
[U.]  #068  openexr                      3.4.10 -> 3.4.11
[U.]  #069  perl5.42.0-HTTP-Daemon       6.16 -> 6.17
[U*]  #070  podman                       5.8.2, 5.8.2-man -> 5.8.3, 5.8.3-man
[U.]  #071  protonmail-bridge            3.24.2, 3.24.2-fish-completions -> 3.25.0, 3.25.0-fish-completions
[C.]  #072  publicsuffix-list            0-unstable-2025-02-12, 0-unstable-2026-03-26 x2 -> 0-unstable-2025-02-12, 0-unstable-2026-05-13 x2
[U.]  #073  python3.13-aiodns            4.0.0 -> 4.0.4
[U.]  #074  python3.13-pyjwt             2.12.1 -> 2.13.0
[U.]  #075  python3.13-python-engineio   4.13.2 -> 4.13.3
[U.]  #076  python3.13-python-socketio   5.16.2 -> 5.16.3
[U.]  #077  qt5compat                    6.11.0 -> 6.11.1
[C.]  #078  qtbase                       5.15.18, 5.15.18-bin, 6.11.0, 6.11.0-dev, 6.11.0-only-plugins-qml -> 5.15.19, 5.15.19-bin, 6.11.1, 6.11.1-dev, 6.11.1-only-plugins-qml
[C.]  #079  qtdeclarative                5.15.18, 5.15.18-bin, 6.11.0 -> 5.15.19, 5.15.19-bin, 6.11.1
[U.]  #080  qtgraphs                     6.11.0 -> 6.11.1
[U.]  #081  qtmultimedia                 6.11.0 -> 6.11.1
[U.]  #082  qtquick3d                    6.11.0 -> 6.11.1
[U.]  #083  qtquickcontrols              5.15.18 -> 5.15.19
[U.]  #084  qtquicktimeline              6.11.0 -> 6.11.1
[U.]  #085  qtshadertools                6.11.0 -> 6.11.1
[U.]  #086  qtspeech                     6.11.0 -> 6.11.1
[C.]  #087  qtsvg                        5.15.18, 5.15.18-bin, 6.11.0, 6.11.0-dev -> 5.15.19, 5.15.19-bin, 6.11.1, 6.11.1-dev
[C.]  #088  qttools                      5.15.18, 5.15.18-bin, 6.11.0 -> 5.15.19, 5.15.19-bin, 6.11.1
[C.]  #089  qttranslations               5.15.18, 6.11.0 -> 5.15.19, 6.11.1
[C.]  #090  qtwayland                    5.15.18, 5.15.18-bin, 6.11.0 -> 5.15.19, 5.15.19-bin, 6.11.1
[U.]  #091  qtx11extras                  5.15.18 -> 5.15.19
[U*]  #092  rsync                        3.4.1, 3.4.1_fish-completions -> 3.4.4, 3.4.4_fish-completions
[U.]  #093  runc                         1.4.2 -> 1.4.3
[U.]  #094  sd-switch                    0.6.3 -> 0.6.4
[U.]  #095  sdl3                         3.4.8-lib -> 3.4.10-lib
[U.]  #096  simdjson                     4.6.0 -> 4.6.4
[U*]  #097  strace                       7.0, 7.0-man -> 7.1, 7.1-man
[C*]  #098  systemd                      <none>, 260.1 x2, 260.1-dev, 260.1-man -> <none>, 260.2 x2, 260.2-dev, 260.2-man
[U.]  #099  systemd-minimal              260.1 x2 -> 260.2 x2
[U.]  #100  systemd-minimal-libs         260.1 x2, 260.1-dev -> 260.2 x2, 260.2-dev
[U.]  #101  tailwindcss-language-server  0.14.28 -> 0.14.29
[U.]  #102  unbound                      1.25.0-lib x2 -> 1.25.1-lib x2
[U*]  #103  wireplumber                  0.5.14, 0.5.14-doc, 0.5.14_fish-completions -> 0.5.15, 0.5.15-doc, 0.5.15_fish-completions
[U*]  #104  xdg-desktop-portal-hyprland  1.3.12+date=2026-05-30_4a170c0 -> 1.3.12+date=2026-06-24_882ad01
[U.]  #105  zen-browser                  1.21.3b -> 1.21.4b
[U.]  #106  zen-browser-unwrapped        1.21.3b -> 1.21.4b
Added packages:
[A.]  #1  polkitd.conf                           <none>
[A.]  #2  python3.13-invoke                      2.2.1
[A.]  #3  unit-wayland-session-bindpid-.service  <none>
[A.]  #4  unit-wayland-wm-.service               <none>
Closure size: 2863 -> 2871 (2782 paths added, 2774 paths removed, delta +8, disk usage +84.1MiB).
```

</details>

<details><summary><b>tuathaan</b></summary>

```
<<< result-old
>>> result-new
Version changes:
[U.]  #001  aardvark-dns                 1.17.1 -> 2.0.0
[C.]  #002  aquamarine                   0.12.0+date=2026-06-06_6ecde03, 0.12.1 -> 0.12.1, 0.12.1+date=2026-06-21_6d6e238
[U.]  #003  at-spi2-core                 2.60.1, 2.60.1-dev -> 2.60.4, 2.60.4-dev
[U.]  #004  audit                        4.1.2-unstable-2025-09-06-lib x2 -> 4.1.4-lib x2
[U*]  #005  bind                         9.20.23-host, 9.20.23-lib, 9.20.23-man -> 9.20.24-host, 9.20.24-lib, 9.20.24-man
[U.]  #006  bottom                       0.12.3, 0.12.3-fish-completions -> 0.13.0, 0.13.0-fish-completions
[U.]  #007  breeze                       6.6.5 -> 6.7.1
[U*]  #008  cpupower                     6.18.35, 6.18.35_fish-completions -> 6.18.36, 6.18.36_fish-completions
[U.]  #009  discord                      1.0.141, 1.0.141-fish-completions -> 1.0.143, 1.0.143-fish-completions
[U*]  #010  docker                       29.5.3 -> 29.6.0
[U*]  #011  docker-compose               5.1.4 -> 5.2.0
[U.]  #012  docker-containerd            29.5.3 -> 29.6.0
[U.]  #013  docker-runc                  29.5.3 -> 29.6.0
[U.]  #014  docker-tini                  29.5.3 -> 29.6.0
[U.]  #015  e2fsprogs                    1.47.3, 1.47.3-bin -> 1.47.4, 1.47.4-bin
[U.]  #016  emacs-ghostel                0.34.0-unstable-2026-06-08 -> 0.35.4-unstable-2026-06-19
[U.]  #017  emacs-mu4e                   1.14.1 -> 1.14.2
[U.]  #018  evolution-data-server        3.60.1 -> 3.60.2
[C.]  #019  expat                        2.6.4, 2.8.0 x2, 2.8.0-dev -> 2.6.4, 2.8.1 x2, 2.8.1-dev
[C.]  #020  ffmpeg                       7.1.4-data, 7.1.4-lib, 8.1-data, 8.1-lib -> 7.1.5-data, 7.1.5-lib, 8.1.1-data, 8.1.1-lib
[U.]  #021  ffmpeg-headless              8.1-data x2, 8.1-lib x2 -> 8.1.1-data x2, 8.1.1-lib x2
[U.]  #022  fftw-double                  3.3.10 x2 -> 3.3.11 x2
[U.]  #023  fftw-single                  3.3.10 x2 -> 3.3.11 x2
[U*]  #024  fish                         4.7.1, 4.7.1-doc, 4.7.1_fish-completions x2 -> 4.8.0, 4.8.0-doc, 4.8.0_fish-completions x2
[U.]  #025  flatpak                      1.16.6 -> 1.18.0
[U.]  #026  freetype                     2.14.2 x2, 2.14.2-dev -> 2.14.3 x2, 2.14.3-dev
[C.]  #027  gcc                          14-20241116-lib, 14-20241116-libgcc, 15.2.0 x2, 15.2.0-lib x3, 15.2.0-libgcc x3 -> 14-20241116-lib, 14-20241116-libgcc, 15.2.0 x2, 15.2.0-lib x3, 15.2.0-libgcc x3, 16.1.0-lib, 16.1.0-libgcc
[U.]  #028  gemini-cli                   0.44.1 -> 0.47.0
[U*]  #029  getent-glibc                 2.42-61 -> 2.42-67
[U.]  #030  gh                           2.94.0, 2.94.0-fish-completions -> 2.95.0, 2.95.0-fish-completions
[U.]  #031  ghostscript-with-X           10.07.0, 10.07.0-fonts -> 10.07.1, 10.07.1-fonts
[C*]  #032  glibc                        2.40-66, 2.42-61 x2, 2.42-61-bin, 2.42-61-dev, 2.42-61-getent -> 2.40-66, 2.42-67 x2, 2.42-67-bin, 2.42-67-dev, 2.42-67-getent
[U*]  #033  glibc-locales                2.42-61 -> 2.42-67
[C.]  #034  hyprgraphics                 0.5.1, 0.5.1+date=2026-04-17_68d0644 -> 0.5.1, 0.5.1+date=2026-06-27_c6e7b9f
[C*]  #035  hyprland                     0.55.0+date=2026-06-19_d486a5f, 0.55.0+date=2026-06-19_d486a5f-man, 0.55.4 -> 0.55.0+date=2026-06-28_b8d910d, 0.55.0+date=2026-06-28_b8d910d-man, 0.55.4
[U.]  #036  hyprland-guiutils            0.2.1+date=2026-04-17_a968d21 -> 0.2.1+date=2026-06-27_5ba080e
[C.]  #037  hyprutils                    0.13.1, 0.13.1+date=2026-05-31_40ede2e, 0.13.1+date=2026-05-31_40ede2e-dev -> 0.13.1, 0.13.1+date=2026-06-21_9d8bf6e, 0.13.1+date=2026-06-21_9d8bf6e-dev
[C.]  #038  icu4c                        76.1 x2, 76.1-dev, 77.1 -> 76.1 x2, 76.1-dev, 77.1, 78.3, 78.3-dev
[U.]  #039  ijs                          10.07.0 -> 10.07.1
[U.]  #040  imagemagick                  7.1.2-23, 7.1.2-23-fish-completions -> 7.1.2-24, 7.1.2-24-fish-completions
[U.]  #041  initrd-linux                 6.18.35 -> 6.18.36
[U.]  #042  kdecoration                  6.6.5 -> 6.7.1
[C.]  #043  krb5                         1.21.3-lib, 1.22.1, 1.22.1-dev, 1.22.1-lib x2 -> 1.21.3-lib, 1.22.2, 1.22.2-dev, 1.22.2-lib x2
[U.]  #044  lhasa                        0.5.0 -> 0.6.0
[U.]  #045  libadwaita                   1.9.0 -> 1.9.1
[U.]  #046  libde265                     1.0.18 -> 1.1.1
[U.]  #047  libgcrypt                    1.11.2-lib x2 -> 1.12.2-lib x2
[U.]  #048  libheif                      1.21.2-lib -> 1.23.0-lib
[U.]  #049  libkrun                      1.18.1 -> 1.19.0
[U.]  #050  libphonenumber               9.0.32 -> 9.0.33
[U.]  #051  libpng-apng                  1.6.56 x2, 1.6.56-dev -> 1.6.58 x2, 1.6.58-dev
[U.]  #052  libwmf                       0.2.13 -> 0.2.15
[U.]  #053  libxml2                      2.15.2 x2, 2.15.2-bin, 2.15.2-dev -> 2.15.3 x2, 2.15.3-bin, 2.15.3-dev
[U.]  #054  linux                        6.18.35, 6.18.35-modules x2 -> 6.18.36, 6.18.36-modules x2
[U.]  #055  linux-firmware               20260519-zstd -> 20260622-zstd
[U.]  #056  lsp-plugins                  1.2.31 -> 1.2.33
[U.]  #057  mdadm                        4.4 -> 4.6
[U.]  #058  mesa                         26.1.2 x2 -> 26.1.3 x2
[U.]  #059  moby                         29.5.3 -> 29.6.0
[U.]  #060  mu                           1.14.1, 1.14.1-fish-completions -> 1.14.2, 1.14.2-fish-completions
[U.]  #061  netavark                     1.17.2 -> 2.0.0
[U.]  #062  nixos-system-tuathaan        26.11.20260616.567a49d -> 26.11.20260626.e73de5b
[C.]  #063  nodejs                       22.22.3, 24.15.0 -> 22.23.1, 24.16.0
[C.]  #064  nodejs-slim                  22.22.3, 22.22.3-corepack, 22.22.3-npm, 24.15.0, 24.15.0-corepack, 24.15.0-npm -> 22.23.1, 22.23.1-corepack, 22.23.1-npm, 24.16.0, 24.16.0-corepack, 24.16.0-npm
[U.]  #065  openapv                      0.2.1.2 x2 -> 0.2.1.3 x2
[U.]  #066  openblas                     0.3.32 -> 0.3.33
[U.]  #067  openexr                      3.4.10 -> 3.4.11
[U.]  #068  perl5.42.0-HTTP-Daemon       6.16 -> 6.17
[U*]  #069  podman                       5.8.2, 5.8.2-man -> 5.8.3, 5.8.3-man
[U.]  #070  protonmail-bridge            3.24.2, 3.24.2-fish-completions -> 3.25.0, 3.25.0-fish-completions
[C.]  #071  publicsuffix-list            0-unstable-2025-02-12, 0-unstable-2026-03-26 x2 -> 0-unstable-2025-02-12, 0-unstable-2026-05-13 x2
[U.]  #072  python3.13-aiodns            4.0.0 -> 4.0.4
[U.]  #073  python3.13-pyjwt             2.12.1 -> 2.13.0
[U.]  #074  python3.13-python-engineio   4.13.2 -> 4.13.3
[U.]  #075  python3.13-python-socketio   5.16.2 -> 5.16.3
[U.]  #076  qt5compat                    6.11.0 -> 6.11.1
[C.]  #077  qtbase                       5.15.18, 5.15.18-bin, 6.11.0, 6.11.0-dev, 6.11.0-only-plugins-qml -> 5.15.19, 5.15.19-bin, 6.11.1, 6.11.1-dev, 6.11.1-only-plugins-qml
[C.]  #078  qtdeclarative                5.15.18, 5.15.18-bin, 6.11.0 -> 5.15.19, 5.15.19-bin, 6.11.1
[U.]  #079  qtgraphs                     6.11.0 -> 6.11.1
[U.]  #080  qtmultimedia                 6.11.0 -> 6.11.1
[U.]  #081  qtquick3d                    6.11.0 -> 6.11.1
[U.]  #082  qtquickcontrols              5.15.18 -> 5.15.19
[U.]  #083  qtquicktimeline              6.11.0 -> 6.11.1
[U.]  #084  qtshadertools                6.11.0 -> 6.11.1
[U.]  #085  qtspeech                     6.11.0 -> 6.11.1
[C.]  #086  qtsvg                        5.15.18, 5.15.18-bin, 6.11.0, 6.11.0-dev -> 5.15.19, 5.15.19-bin, 6.11.1, 6.11.1-dev
[C.]  #087  qttools                      5.15.18, 5.15.18-bin, 6.11.0 -> 5.15.19, 5.15.19-bin, 6.11.1
[C.]  #088  qttranslations               5.15.18, 6.11.0 -> 5.15.19, 6.11.1
[C.]  #089  qtwayland                    5.15.18, 5.15.18-bin, 6.11.0 -> 5.15.19, 5.15.19-bin, 6.11.1
[U.]  #090  qtx11extras                  5.15.18 -> 5.15.19
[U*]  #091  rsync                        3.4.1, 3.4.1_fish-completions -> 3.4.4, 3.4.4_fish-completions
[U.]  #092  runc                         1.4.2 -> 1.4.3
[U.]  #093  sd-switch                    0.6.3 -> 0.6.4
[U.]  #094  sdl3                         3.4.8-lib -> 3.4.10-lib
[U.]  #095  simdjson                     4.6.0 -> 4.6.4
[U*]  #096  strace                       7.0, 7.0-man -> 7.1, 7.1-man
[C*]  #097  systemd                      <none>, 260.1 x2, 260.1-dev, 260.1-man -> <none>, 260.2 x2, 260.2-dev, 260.2-man
[U.]  #098  systemd-minimal              260.1 x2 -> 260.2 x2
[U.]  #099  systemd-minimal-libs         260.1 x2, 260.1-dev -> 260.2 x2, 260.2-dev
[U.]  #100  tailwindcss-language-server  0.14.28 -> 0.14.29
[U.]  #101  unbound                      1.25.0-lib x2 -> 1.25.1-lib x2
[U*]  #102  wireplumber                  0.5.14, 0.5.14-doc, 0.5.14_fish-completions -> 0.5.15, 0.5.15-doc, 0.5.15_fish-completions
[U.]  #103  x86_energy_perf_policy       6.18.35 -> 6.18.36
[U*]  #104  xdg-desktop-portal-hyprland  1.3.12+date=2026-05-30_4a170c0 -> 1.3.12+date=2026-06-24_882ad01
[U.]  #105  zen-browser                  1.21.3b -> 1.21.4b
[U.]  #106  zen-browser-unwrapped        1.21.3b -> 1.21.4b
Added packages:
[A.]  #1  polkitd.conf                           <none>
[A.]  #2  python3.13-invoke                      2.2.1
[A.]  #3  unit-wayland-session-bindpid-.service  <none>
[A.]  #4  unit-wayland-wm-.service               <none>
Closure size: 2797 -> 2805 (2716 paths added, 2708 paths removed, delta +8, disk usage +83.6MiB).
```

</details>

