### PR TITLE
Auto update 2026-07-05

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,11 +129,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782540557,
-        "narHash": "sha256-9A46MkRhAk9pKjLWELOvMwZmyquwDEmuE6khwvc7whY=",
+        "lastModified": 1783168145,
+        "narHash": "sha256-yFyu8nsCcKvZdmIHArd8F43sL1B1DtWSxHf22DKanhs=",
         "owner": "Gako358",
         "repo": "emacs-flake",
-        "rev": "4458731477e674be552ff6ae3db8b579fb4b5e33",
+        "rev": "29d0164cd379a176035a2ef263ef05ad3fc04c53",
         "type": "github"
       },
       "original": {
@@ -211,11 +211,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1778716662,
-        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
+        "lastModified": 1782949081,
+        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
+        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
         "type": "github"
       },
       "original": {
@@ -229,11 +229,11 @@
         "nixpkgs-lib": "nixpkgs-lib_2"
       },
       "locked": {
-        "lastModified": 1778716662,
-        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
+        "lastModified": 1782949081,
+        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
+        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
         "type": "github"
       },
       "original": {
@@ -401,27 +401,6 @@
         "type": "github"
       }
     },
-    "gitignore_4": {
-      "inputs": {
-        "nixpkgs": [
-          "pre-commit-hooks-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1709087332,
-        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "type": "github"
-      }
-    },
     "hardware": {
       "inputs": {
         "nixpkgs": "nixpkgs"
@@ -447,11 +426,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782522538,
-        "narHash": "sha256-CvOaUvJ+mXlxU3m2cPWKcOAhtKETsPUYhq+Xa5ewBp4=",
+        "lastModified": 1783222121,
+        "narHash": "sha256-E/ElL373TO8lQ2aMvYyzN+k4xkVaUGoRqoa8AtM71tI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8d8a6cc50ddc60748791a14ee1163c865ec57635",
+        "rev": "a1645f40777620c4bd2b6d854b290c2fc354a266",
         "type": "github"
       },
       "original": {
@@ -561,11 +540,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776426467,
-        "narHash": "sha256-iI1orcQNEQAwAyRHHRogC68E3nls710wwbaD1X6RRKI=",
+        "lastModified": 1782748876,
+        "narHash": "sha256-ODZh4jYjGieX2W15VAv/yIUnio74CnaDOe18X77tEwM=",
         "owner": "hyprwm",
         "repo": "hypridle",
-        "rev": "ff41dd6d94734d6e68649e95dffc788b16ecd6b5",
+        "rev": "128dcfa96dfc9c90136c9a80c6e2443f8b54928c",
         "type": "github"
       },
       "original": {
@@ -591,11 +570,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1782635098,
-        "narHash": "sha256-0/PdEhnLw2KAbCYoyYjFh1Orwf8Tlmg7rxYA8k0AX9w=",
+        "lastModified": 1783198893,
+        "narHash": "sha256-UgdXpHgsg700hROak8RspFTfa/PDClxfyCEKs12nhxU=",
         "owner": "hyprwm",
         "repo": "hyprland",
-        "rev": "b8d910d874d07548bf20529b7ad1f02e9b3c8e35",
+        "rev": "7a5214614b2f5bec4dbe1d0bddbc128c79cd2dfb",
         "type": "github"
       },
       "original": {
@@ -612,11 +591,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780083791,
-        "narHash": "sha256-epTJKmTCNL1Hm6/YdEWAgiOMVBSzC9/v/rjyOieP3yA=",
+        "lastModified": 1782811467,
+        "narHash": "sha256-JP0D8r8o9+jnYk0/B5O722La+oZeC5iNQ3lonKFTmbQ=",
         "owner": "hyprwm",
         "repo": "contrib",
-        "rev": "bf1a7cdb086587e6bed6e8ecd285a81c01a11c54",
+        "rev": "3dcbce715ae8b93107fa8632db15bf976862a573",
         "type": "github"
       },
       "original": {
@@ -688,11 +667,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781442805,
-        "narHash": "sha256-Kt56e6Bq2sfqN8yq1RHsS6z+8QKCZelmhaeQQRtZyqU=",
+        "lastModified": 1782769258,
+        "narHash": "sha256-HAhqQOoz4S0gzIOMnClL49B+rMT7zdp3UDWeqxtMs/k=",
         "owner": "hyprwm",
         "repo": "hyprland-plugins",
-        "rev": "1f90c674d51a1ef83c725cd6d02280b4c969fdf7",
+        "rev": "71b8953d7d92dbebe87a6ff9895bdd30e7495873",
         "type": "github"
       },
       "original": {
@@ -939,11 +918,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782035033,
-        "narHash": "sha256-pUtCphVzH1iNUTMGdJr4+e/yzUXA6/DZwsn+cyfIVJU=",
+        "lastModified": 1783002634,
+        "narHash": "sha256-xGqHIUK0wIZoW7SiMalwvO6uGOO/VrlQwoRobpE7dDI=",
         "owner": "hyprwm",
         "repo": "hyprutils",
-        "rev": "9d8bf6e810597152eef8906c670b96679af2faec",
+        "rev": "41fb809557abd29a57151b6e1aaeabd05f9437e1",
         "type": "github"
       },
       "original": {
@@ -1094,11 +1073,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1782160136,
-        "narHash": "sha256-APwmLI4UuSTim0JO/kZ6FXDPiZVp3zIj0uGDF2UZ5kU=",
+        "lastModified": 1783187991,
+        "narHash": "sha256-qGYEthfxqPeGfEkcJzZv98cX3+8Mg29PZDfZEhZ+Byg=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "6650fb7c6b48177c8200e21ffac99a4adc72b08d",
+        "rev": "0368b35d4677854d897951d35b0bfd3649664383",
         "type": "github"
       },
       "original": {
@@ -1163,11 +1142,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1777168982,
-        "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
+        "lastModified": 1782614948,
+        "narHash": "sha256-ePjCwr1sNm9NYUqywL7QfK3JnlS015msC+eBu2zKlp8=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
+        "rev": "db3f255737b94216eb71cce308e2912cf6bc2d7c",
         "type": "github"
       },
       "original": {
@@ -1178,11 +1157,11 @@
     },
     "nixpkgs-lib_2": {
       "locked": {
-        "lastModified": 1777168982,
-        "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
+        "lastModified": 1782614948,
+        "narHash": "sha256-ePjCwr1sNm9NYUqywL7QfK3JnlS015msC+eBu2zKlp8=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
+        "rev": "db3f255737b94216eb71cce308e2912cf6bc2d7c",
         "type": "github"
       },
       "original": {
@@ -1335,11 +1314,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1782467914,
-        "narHash": "sha256-pGvFkM8N0xEkIIXDe5YYfbEAvHrk4IxBrjB/x8OomhE=",
+        "lastModified": 1782959384,
+        "narHash": "sha256-xnJJk+ct+D2+wdRxj1wk36w5zV9RVESwRqcklPdt3fM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e73de5be04e0eff4190a1432b946d469c794e7b4",
+        "rev": "65179426c83bb3f6bc14898b42ea1c6f01d374b0",
         "type": "github"
       },
       "original": {
@@ -1351,11 +1330,11 @@
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1782467914,
-        "narHash": "sha256-pGvFkM8N0xEkIIXDe5YYfbEAvHrk4IxBrjB/x8OomhE=",
+        "lastModified": 1782959384,
+        "narHash": "sha256-xnJJk+ct+D2+wdRxj1wk36w5zV9RVESwRqcklPdt3fM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e73de5be04e0eff4190a1432b946d469c794e7b4",
+        "rev": "65179426c83bb3f6bc14898b42ea1c6f01d374b0",
         "type": "github"
       },
       "original": {
@@ -1371,11 +1350,11 @@
         "nixpkgs": "nixpkgs_9"
       },
       "locked": {
-        "lastModified": 1782637429,
-        "narHash": "sha256-6LlAl8QH0SQ2VpmlxsKr23i6DTN9ma4ltSqlu8sNWOs=",
+        "lastModified": 1783243336,
+        "narHash": "sha256-jNyJzZIv3gNJSiR/Wye9Si1R5zYnPyRAR0fNoxMqrbQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4ad71fa230d0686b4a0d4818c9b201b05fd4a0e2",
+        "rev": "98d2d02aa2189226050c1cc211dd3983ca4d18d2",
         "type": "github"
       },
       "original": {
@@ -1476,17 +1455,16 @@
     "pre-commit-hooks-nix_2": {
       "inputs": {
         "flake-compat": "flake-compat_4",
-        "gitignore": "gitignore_4",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1781733627,
-        "narHash": "sha256-U3yTuGBnmXvXoQI3qkpfEDsn9RovQPAjN7ndRco+3u0=",
+        "lastModified": 1783008725,
+        "narHash": "sha256-jGiy6+sxjNWXSjp25uoJuNfyH9zBK1PEDY0lVoL4ibQ=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "3bbec39bc90eadfa031e6f3b77272f3f60803e39",
+        "rev": "bca82caa46d5ec0f5d422c61fb1e30bc51313cbe",
         "type": "github"
       },
       "original": {
@@ -1529,11 +1507,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782012058,
-        "narHash": "sha256-9mWUnReOUXfKjZuJAL/bAFH3LUyECTRtXgSNVjRw3UY=",
+        "lastModified": 1783144302,
+        "narHash": "sha256-NQnzmXwpEAd5tjMBh2+P/y9NknF+WHv5+6yoXoN4h/Y=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "8534567325bd8a8d2928e6afd81e0a87d19efd3c",
+        "rev": "fe5aee0952e8e1525533d61defd9e36513db811b",
         "type": "github"
       },
       "original": {
@@ -1568,11 +1546,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782165805,
-        "narHash": "sha256-478kKQBvK6SYTOdN2h9jhKJv94nbXRbFMfuL1WshErg=",
+        "lastModified": 1783174389,
+        "narHash": "sha256-aCWC8ngycU7OdJrU2+Je3qf+1a2ykuBvpPhZT/9tXMc=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "56b24064fdcaedca53553b1a6d607fd23b613a24",
+        "rev": "f1406619a3884cd5c47992a70b8b35c9c0fcb4c9",
         "type": "github"
       },
       "original": {
@@ -1689,11 +1667,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782624757,
-        "narHash": "sha256-pqFaCAV+g8H+p0kE4vYn9ZgcEFvt644zGy7SyCdf9c8=",
+        "lastModified": 1783063092,
+        "narHash": "sha256-H6lM+h8+ZT25uWJwmYkER5yj5RJ9DP2++n5um/XH3J0=",
         "owner": "youwen5",
         "repo": "zen-browser-flake",
-        "rev": "907465791e7064d86d37964dd95e23280dfb68da",
+        "rev": "36b24209358c82e0ea5404ba003ae8dc37334c86",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automatic flake update on 2026-07-05.

Review the per-host package changes below before merging.

## Input changes

```
unpacking 'github:nix-community/disko/de5708739256238fb912c62f03988815db89ec9a' into the Git cache...
unpacking 'github:Gako358/emacs-flake/29d0164cd379a176035a2ef263ef05ad3fc04c53' into the Git cache...
unpacking 'github:hercules-ci/flake-parts/17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e' into the Git cache...
unpacking 'github:nixos/nixos-hardware/a9cf7546a938c737b079e738de73934a13de9784' into the Git cache...
unpacking 'github:nix-community/home-manager/a1645f40777620c4bd2b6d854b290c2fc354a266' into the Git cache...
unpacking 'github:hyprwm/hypridle/128dcfa96dfc9c90136c9a80c6e2443f8b54928c' into the Git cache...
unpacking 'github:hyprwm/hyprland/7a5214614b2f5bec4dbe1d0bddbc128c79cd2dfb' into the Git cache...
unpacking 'github:hyprwm/contrib/3dcbce715ae8b93107fa8632db15bf976862a573' into the Git cache...
unpacking 'github:hyprwm/hyprland-plugins/71b8953d7d92dbebe87a6ff9895bdd30e7495873' into the Git cache...
unpacking 'github:hyprwm/hyprpaper/c011bd20886ea3301474e77d7fa4d22ab013ece0' into the Git cache...
unpacking 'github:nix-community/impermanence/7b1d382faf603b6d264f58627330f9faa5cba149' into the Git cache...
unpacking 'github:vic/import-tree/d321337efd0f23a9eb14a42adb7b2c29313ab274' into the Git cache...
unpacking 'github:nix-community/lanzaboote/0368b35d4677854d897951d35b0bfd3649664383' into the Git cache...
unpacking 'github:misterio77/nix-colors/b01f024090d2c4fc3152cd0cf12027a7b8453ba1' into the Git cache...
unpacking 'github:nixos/nixpkgs/65179426c83bb3f6bc14898b42ea1c6f01d374b0' into the Git cache...
unpacking 'github:nix-community/NUR/98d2d02aa2189226050c1cc211dd3983ca4d18d2' into the Git cache...
unpacking 'github:nix-community/plasma-manager/a524a6160e6df89f7673ba293cf7d78b559eb1a5' into the Git cache...
unpacking 'github:cachix/pre-commit-hooks.nix/bca82caa46d5ec0f5d422c61fb1e30bc51313cbe' into the Git cache...
unpacking 'github:gako358/scram/cd8a014d65ce34d28f318ca27040db8d0779f55a' into the Git cache...
unpacking 'github:Mic92/sops-nix/f1406619a3884cd5c47992a70b8b35c9c0fcb4c9' into the Git cache...
unpacking 'github:youwen5/zen-browser-flake/36b24209358c82e0ea5404ba003ae8dc37334c86' into the Git cache...
warning: updating lock file "/home/runner/work/dotfiles/dotfiles/flake.lock":
• Updated input 'emacs-flake':
    'github:Gako358/emacs-flake/4458731477e674be552ff6ae3db8b579fb4b5e33?narHash=sha256-9A46MkRhAk9pKjLWELOvMwZmyquwDEmuE6khwvc7whY%3D' (2026-06-27)
  → 'github:Gako358/emacs-flake/29d0164cd379a176035a2ef263ef05ad3fc04c53?narHash=sha256-yFyu8nsCcKvZdmIHArd8F43sL1B1DtWSxHf22DKanhs%3D' (2026-07-04)
• Updated input 'emacs-flake/flake-parts':
    'github:hercules-ci/flake-parts/f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb?narHash=sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4%3D' (2026-05-13)
  → 'github:hercules-ci/flake-parts/17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e?narHash=sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w%2B6NWK9yA%3D' (2026-07-01)
• Updated input 'emacs-flake/flake-parts/nixpkgs-lib':
    'github:nix-community/nixpkgs.lib/f5901329dade4a6ea039af1433fb087bd9c1fe14?narHash=sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ%3D' (2026-04-26)
  → 'github:nix-community/nixpkgs.lib/db3f255737b94216eb71cce308e2912cf6bc2d7c?narHash=sha256-ePjCwr1sNm9NYUqywL7QfK3JnlS015msC%2BeBu2zKlp8%3D' (2026-06-28)
• Updated input 'flake-parts':
    'github:hercules-ci/flake-parts/f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb?narHash=sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4%3D' (2026-05-13)
  → 'github:hercules-ci/flake-parts/17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e?narHash=sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w%2B6NWK9yA%3D' (2026-07-01)
• Updated input 'flake-parts/nixpkgs-lib':
    'github:nix-community/nixpkgs.lib/f5901329dade4a6ea039af1433fb087bd9c1fe14?narHash=sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ%3D' (2026-04-26)
  → 'github:nix-community/nixpkgs.lib/db3f255737b94216eb71cce308e2912cf6bc2d7c?narHash=sha256-ePjCwr1sNm9NYUqywL7QfK3JnlS015msC%2BeBu2zKlp8%3D' (2026-06-28)
• Updated input 'home-manager':
    'github:nix-community/home-manager/8d8a6cc50ddc60748791a14ee1163c865ec57635?narHash=sha256-CvOaUvJ%2BmXlxU3m2cPWKcOAhtKETsPUYhq%2BXa5ewBp4%3D' (2026-06-27)
  → 'github:nix-community/home-manager/a1645f40777620c4bd2b6d854b290c2fc354a266?narHash=sha256-E/ElL373TO8lQ2aMvYyzN%2Bk4xkVaUGoRqoa8AtM71tI%3D' (2026-07-05)
• Updated input 'hypridle':
    'github:hyprwm/hypridle/ff41dd6d94734d6e68649e95dffc788b16ecd6b5?narHash=sha256-iI1orcQNEQAwAyRHHRogC68E3nls710wwbaD1X6RRKI%3D' (2026-04-17)
  → 'github:hyprwm/hypridle/128dcfa96dfc9c90136c9a80c6e2443f8b54928c?narHash=sha256-ODZh4jYjGieX2W15VAv/yIUnio74CnaDOe18X77tEwM%3D' (2026-06-29)
• Updated input 'hyprland':
    'github:hyprwm/hyprland/b8d910d874d07548bf20529b7ad1f02e9b3c8e35?narHash=sha256-0/PdEhnLw2KAbCYoyYjFh1Orwf8Tlmg7rxYA8k0AX9w%3D' (2026-06-28)
  → 'github:hyprwm/hyprland/7a5214614b2f5bec4dbe1d0bddbc128c79cd2dfb?narHash=sha256-UgdXpHgsg700hROak8RspFTfa/PDClxfyCEKs12nhxU%3D' (2026-07-04)
• Updated input 'hyprland/hyprutils':
    'github:hyprwm/hyprutils/9d8bf6e810597152eef8906c670b96679af2faec?narHash=sha256-pUtCphVzH1iNUTMGdJr4%2Be/yzUXA6/DZwsn%2BcyfIVJU%3D' (2026-06-21)
  → 'github:hyprwm/hyprutils/41fb809557abd29a57151b6e1aaeabd05f9437e1?narHash=sha256-xGqHIUK0wIZoW7SiMalwvO6uGOO/VrlQwoRobpE7dDI%3D' (2026-07-02)
• Updated input 'hyprland-contrib':
    'github:hyprwm/contrib/bf1a7cdb086587e6bed6e8ecd285a81c01a11c54?narHash=sha256-epTJKmTCNL1Hm6/YdEWAgiOMVBSzC9/v/rjyOieP3yA%3D' (2026-05-29)
  → 'github:hyprwm/contrib/3dcbce715ae8b93107fa8632db15bf976862a573?narHash=sha256-JP0D8r8o9%2BjnYk0/B5O722La%2BoZeC5iNQ3lonKFTmbQ%3D' (2026-06-30)
• Updated input 'hyprland-plugins':
    'github:hyprwm/hyprland-plugins/1f90c674d51a1ef83c725cd6d02280b4c969fdf7?narHash=sha256-Kt56e6Bq2sfqN8yq1RHsS6z%2B8QKCZelmhaeQQRtZyqU%3D' (2026-06-14)
  → 'github:hyprwm/hyprland-plugins/71b8953d7d92dbebe87a6ff9895bdd30e7495873?narHash=sha256-HAhqQOoz4S0gzIOMnClL49B%2BrMT7zdp3UDWeqxtMs/k%3D' (2026-06-29)
• Updated input 'lanzaboote':
    'github:nix-community/lanzaboote/6650fb7c6b48177c8200e21ffac99a4adc72b08d?narHash=sha256-APwmLI4UuSTim0JO/kZ6FXDPiZVp3zIj0uGDF2UZ5kU%3D' (2026-06-22)
  → 'github:nix-community/lanzaboote/0368b35d4677854d897951d35b0bfd3649664383?narHash=sha256-qGYEthfxqPeGfEkcJzZv98cX3%2B8Mg29PZDfZEhZ%2BByg%3D' (2026-07-04)
• Updated input 'lanzaboote/rust-overlay':
    'github:oxalica/rust-overlay/8534567325bd8a8d2928e6afd81e0a87d19efd3c?narHash=sha256-9mWUnReOUXfKjZuJAL/bAFH3LUyECTRtXgSNVjRw3UY%3D' (2026-06-21)
  → 'github:oxalica/rust-overlay/fe5aee0952e8e1525533d61defd9e36513db811b?narHash=sha256-NQnzmXwpEAd5tjMBh2%2BP/y9NknF%2BWHv5%2B6yoXoN4h/Y%3D' (2026-07-04)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/e73de5be04e0eff4190a1432b946d469c794e7b4?narHash=sha256-pGvFkM8N0xEkIIXDe5YYfbEAvHrk4IxBrjB/x8OomhE%3D' (2026-06-26)
  → 'github:nixos/nixpkgs/65179426c83bb3f6bc14898b42ea1c6f01d374b0?narHash=sha256-xnJJk%2Bct%2BD2%2BwdRxj1wk36w5zV9RVESwRqcklPdt3fM%3D' (2026-07-02)
• Updated input 'nur':
    'github:nix-community/NUR/4ad71fa230d0686b4a0d4818c9b201b05fd4a0e2?narHash=sha256-6LlAl8QH0SQ2VpmlxsKr23i6DTN9ma4ltSqlu8sNWOs%3D' (2026-06-28)
  → 'github:nix-community/NUR/98d2d02aa2189226050c1cc211dd3983ca4d18d2?narHash=sha256-jNyJzZIv3gNJSiR/Wye9Si1R5zYnPyRAR0fNoxMqrbQ%3D' (2026-07-05)
• Updated input 'nur/nixpkgs':
    'github:nixos/nixpkgs/e73de5be04e0eff4190a1432b946d469c794e7b4?narHash=sha256-pGvFkM8N0xEkIIXDe5YYfbEAvHrk4IxBrjB/x8OomhE%3D' (2026-06-26)
  → 'github:nixos/nixpkgs/65179426c83bb3f6bc14898b42ea1c6f01d374b0?narHash=sha256-xnJJk%2Bct%2BD2%2BwdRxj1wk36w5zV9RVESwRqcklPdt3fM%3D' (2026-07-02)
• Updated input 'pre-commit-hooks-nix':
    'github:cachix/pre-commit-hooks.nix/3bbec39bc90eadfa031e6f3b77272f3f60803e39?narHash=sha256-U3yTuGBnmXvXoQI3qkpfEDsn9RovQPAjN7ndRco%2B3u0%3D' (2026-06-17)
  → 'github:cachix/pre-commit-hooks.nix/bca82caa46d5ec0f5d422c61fb1e30bc51313cbe?narHash=sha256-jGiy6%2BsxjNWXSjp25uoJuNfyH9zBK1PEDY0lVoL4ibQ%3D' (2026-07-02)
• Removed input 'pre-commit-hooks-nix/gitignore'
• Removed input 'pre-commit-hooks-nix/gitignore/nixpkgs'
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/56b24064fdcaedca53553b1a6d607fd23b613a24?narHash=sha256-478kKQBvK6SYTOdN2h9jhKJv94nbXRbFMfuL1WshErg%3D' (2026-06-22)
  → 'github:Mic92/sops-nix/f1406619a3884cd5c47992a70b8b35c9c0fcb4c9?narHash=sha256-aCWC8ngycU7OdJrU2%2BJe3qf%2B1a2ykuBvpPhZT/9tXMc%3D' (2026-07-04)
• Updated input 'zen-browser':
    'github:youwen5/zen-browser-flake/907465791e7064d86d37964dd95e23280dfb68da?narHash=sha256-pqFaCAV%2Bg8H%2Bp0kE4vYn9ZgcEFvt644zGy7SyCdf9c8%3D' (2026-06-28)
  → 'github:youwen5/zen-browser-flake/36b24209358c82e0ea5404ba003ae8dc37334c86?narHash=sha256-H6lM%2Bh8%2BZT25uWJwmYkER5yj5RJ9DP2%2B%2Bn5um/XH3J0%3D' (2026-07-03)
```

## Per-host package diff

<details><summary><b>aanallein</b></summary>

```
<<< result-old
>>> result-new
Version changes:
[U*]  #1  cpupower                6.18.36, 6.18.36_fish-completions -> 6.18.37, 6.18.37_fish-completions
[U.]  #2  initrd-linux            6.18.36 -> 6.18.37
[U.]  #3  linux                   6.18.36, 6.18.36-modules x2 -> 6.18.37, 6.18.37-modules x2
[D.]  #4  netavark                2.0.0 -> 1.17.2
[U.]  #5  nixos-system-aanallein  26.11.20260626.e73de5b -> 26.11.20260702.6517942
[U*]  #6  podman                  5.8.3, 5.8.3-man -> 5.8.4, 5.8.4-man
[U.]  #7  starship                1.25.1, 1.25.1-fish-completions -> 1.26.0, 1.26.0-fish-completions
[U.]  #8  xarchiver               0.5.4.26, 0.5.4.26-fish-completions -> 0.5.4.27, 0.5.4.27-fish-completions
Closure size: 1837 -> 1837 (128 paths added, 128 paths removed, delta +0, disk usage +735.7KiB).
```

</details>

<details><summary><b>rhuidean</b></summary>

```
<<< result-old
>>> result-new
Version changes:
[U.]  #01  breeze                  6.7.1 -> 6.7.2
[U*]  #02  cpupower                6.18.36, 6.18.36_fish-completions -> 6.18.37, 6.18.37_fish-completions
[U.]  #03  discord                 1.0.143, 1.0.143-fish-completions -> 1.0.144, 1.0.144-fish-completions
[U.]  #04  easyeffects             8.2.4, 8.2.4-fish-completions -> 8.2.5, 8.2.5-fish-completions
[U.]  #05  electron                41.7.2 -> 41.9.1
[U.]  #06  electron-unwrapped      41.7.2 -> 41.9.1
[U*]  #07  gnome-control-center    50.2 -> 50.3
[U*]  #08  gnome-maps              50.1 -> 50.2
[U.]  #09  gnome-shell-extensions  50.1 -> 50.2
[U.]  #10  gspell                  1.14.3 -> 1.14.4
[U*]  #11  gvfs                    1.60.0 x2 -> 1.60.1 x2
[U.]  #12  initrd-linux            6.18.36 -> 6.18.37
[U.]  #13  kdecoration             6.7.1 -> 6.7.2
[U.]  #14  libnfs                  5.0.3 -> 6.0.2
[U.]  #15  libshumate              1.6.1 -> 1.6.2
[U.]  #16  linux                   6.18.36, 6.18.36-modules x2 -> 6.18.37, 6.18.37-modules x2
[D.]  #17  netavark                2.0.0 -> 1.17.2
[C.]  #18  ngtcp2                  1.22.1 x2, 1.23.0 -> 1.22.1 x2, 1.24.0
[U.]  #19  nixos-system-rhuidean   26.11.20260626.e73de5b -> 26.11.20260702.6517942
[U*]  #20  podman                  5.8.3, 5.8.3-man -> 5.8.4, 5.8.4-man
[U.]  #21  starship                1.25.1, 1.25.1-fish-completions -> 1.26.0, 1.26.0-fish-completions
[U.]  #22  xarchiver               0.5.4.26, 0.5.4.26-fish-completions -> 0.5.4.27, 0.5.4.27-fish-completions
[U.]  #23  zen-browser             1.21.4b -> 1.21.5b
[U.]  #24  zen-browser-unwrapped   1.21.4b -> 1.21.5b
Added packages:
[A.]  #1  proton-ge-bin-GE-Proton11  1-steamcompattool
Removed packages:
[R.]  #1  proton-ge-bin-GE-Proton10  34-steamcompattool
Closure size: 2672 -> 2672 (207 paths added, 207 paths removed, delta +0, disk usage +33.3MiB).
```

</details>

<details><summary><b>tanchico</b></summary>

```
<<< result-old
>>> result-new
Version changes:
[U.]  #01  breeze                  6.7.1 -> 6.7.2
[U*]  #02  cpupower                6.18.36, 6.18.36_fish-completions -> 6.18.37, 6.18.37_fish-completions
[U.]  #03  discord                 1.0.143, 1.0.143-fish-completions -> 1.0.144, 1.0.144-fish-completions
[U.]  #04  easyeffects             8.2.4, 8.2.4-fish-completions -> 8.2.5, 8.2.5-fish-completions
[U.]  #05  electron                41.7.2 -> 41.9.1
[U.]  #06  electron-unwrapped      41.7.2 -> 41.9.1
[U*]  #07  gnome-control-center    50.2 -> 50.3
[U*]  #08  gnome-maps              50.1 -> 50.2
[U.]  #09  gnome-shell-extensions  50.1 -> 50.2
[U.]  #10  gspell                  1.14.3 -> 1.14.4
[U*]  #11  gvfs                    1.60.0 x2 -> 1.60.1 x2
[U.]  #12  initrd-linux            6.18.36 -> 6.18.37
[U.]  #13  kdecoration             6.7.1 -> 6.7.2
[U.]  #14  libnfs                  5.0.3 -> 6.0.2
[U.]  #15  libshumate              1.6.1 -> 1.6.2
[U.]  #16  linux                   6.18.36, 6.18.36-modules x2 -> 6.18.37, 6.18.37-modules x2
[D.]  #17  netavark                2.0.0 -> 1.17.2
[C.]  #18  ngtcp2                  1.22.1 x2, 1.23.0 -> 1.22.1 x2, 1.24.0
[U.]  #19  nixos-system-tanchico   26.11.20260626.e73de5b -> 26.11.20260702.6517942
[U*]  #20  podman                  5.8.3, 5.8.3-man -> 5.8.4, 5.8.4-man
[U.]  #21  starship                1.25.1, 1.25.1-fish-completions -> 1.26.0, 1.26.0-fish-completions
[U.]  #22  xarchiver               0.5.4.26, 0.5.4.26-fish-completions -> 0.5.4.27, 0.5.4.27-fish-completions
[U.]  #23  zen-browser             1.21.4b -> 1.21.5b
[U.]  #24  zen-browser-unwrapped   1.21.4b -> 1.21.5b
Added packages:
[A.]  #1  proton-ge-bin-GE-Proton11  1-steamcompattool
Removed packages:
[R.]  #1  proton-ge-bin-GE-Proton10  34-steamcompattool
Closure size: 2669 -> 2669 (206 paths added, 206 paths removed, delta +0, disk usage +32.8MiB).
```

</details>

<details><summary><b>terangreal</b></summary>

```
<<< result-old
>>> result-new
Version changes:
[U.]  #01  bottom                   0.13.0, 0.13.0-fish-completions -> 0.14.2, 0.14.2-fish-completions
[U.]  #02  breeze                   6.7.1 -> 6.7.2
[U*]  #03  cpupower                 6.18.36, 6.18.36_fish-completions -> 6.18.37, 6.18.37_fish-completions
[U.]  #04  discord                  1.0.143, 1.0.143-fish-completions -> 1.0.144, 1.0.144-fish-completions
[U.]  #05  easyeffects              8.2.4, 8.2.4-fish-completions -> 8.2.5, 8.2.5-fish-completions
[U.]  #06  electron                 41.7.2 -> 41.9.1
[U.]  #07  electron-unwrapped       41.7.2 -> 41.9.1
[U.]  #08  emacs-apheleia           20260422.253 -> 20260619.1935
[U.]  #09  emacs-bui                20210108.1141 -> 20260502.730
[U.]  #10  emacs-cape               20260419.1847 -> 20260519.1021
[U.]  #11  emacs-closql             20260101.1828 -> 20260601.1540
[U.]  #12  emacs-compat             30.1.0.1 -> 31.0.0.1
[U.]  #13  emacs-cond-let           20260201.1500 -> 20260601.1457
[U.]  #14  emacs-consult            20260421.1105 -> 20260605.1907
[U.]  #15  emacs-consult-gh         20250915.2043 -> 20260625.257
[U.]  #16  emacs-consult-gh-embark  20250906.1805 -> 20260623.1820
[U.]  #17  emacs-consult-lsp        20251025.719 -> 20260619.643
[U.]  #18  emacs-corfu              20260419.1808 -> 20260519.1053
[U.]  #19  emacs-dap-mode           20260208.1403 -> 20260616.1526
[U.]  #20  emacs-diff-hl            20260328.1925 -> 20260624.444
[U.]  #21  emacs-dtrt-indent        20251102.857 -> 20260608.1055
[U.]  #22  emacs-dumb-jump          20260406.1824 -> 20260603.1700
[U.]  #23  emacs-eca                20260423.1754 -> 20260622.1430
[U.]  #24  emacs-eldoc-box          20260415.226 -> 20260620.158
[U.]  #25  emacs-emacsql            20260401.1220 -> 20260601.1722
[U.]  #26  emacs-embark             20260404.2302 -> 20260610.302
[U.]  #27  emacs-embark-consult     20260404.2302 -> 20260503.118
[U.]  #28  emacs-evil               20251108.138 -> 20260603.654
[U.]  #29  emacs-evil-collection    20260423.438 -> 20260624.327
[U.]  #30  emacs-flycheck           20260320.1715 -> 20260604.2002
[U.]  #31  emacs-forge              20260423.1757 -> 20260623.1325
[U.]  #32  emacs-ghostel            0.35.4-unstable-2026-06-19 -> 0.39.0-unstable-2026-06-26
[U.]  #33  emacs-ghub               20260423.1634 -> 20260603.1818
[U.]  #34  emacs-kotlin-ts-mode     20260326.930 -> 20260512.1409
[U.]  #35  emacs-llama              20260301.1253 -> 20260601.1455
[U.]  #36  emacs-lsp-docker         20250228.2210 -> 20260507.1750
[U.]  #37  emacs-lsp-haskell        20251121.1710 -> 20260507.1745
[U.]  #38  emacs-lsp-java           20260312.1356 -> 20260510.647
[U.]  #39  emacs-lsp-metals         20250228.2145 -> 20260529.1928
[U.]  #40  emacs-lsp-mode           20260423.1033 -> 20260616.510
[U.]  #41  emacs-lsp-treemacs       20251217.1621 -> 20260515.746
[U.]  #42  emacs-lsp-ui             20260104.1525 -> 20260512.1516
[U.]  #43  emacs-magit              20260422.2206 -> 20260621.1253
[U.]  #44  emacs-magit-section      20260422.2206 -> 20260514.937
[U.]  #45  emacs-marginalia         20260309.1545 -> 20260519.1044
[U.]  #46  emacs-markdown-mode      20260423.1508 -> 20260425.954
[U.]  #47  emacs-mcp                20260222.1058 -> 20260615.940
[U.]  #48  emacs-nerd-icons         20260325.346 -> 20260619.455
[U.]  #49  emacs-orderless          20260124.1000 -> 20260519.1029
[U.]  #50  emacs-org                9.8.3 -> 9.8.6
[U.]  #51  emacs-org-modern         20260325.721 -> 20260519.1046
[U.]  #52  emacs-org-msg            20260211.901 -> 20260507.725
[U.]  #53  emacs-org-roam           20260423.437 -> 20260425.1623
[U.]  #54  emacs-polymode           20260302.1043 -> 20260505.1803
[U.]  #55  emacs-posframe           20260423.213 -> 20260527.857
[U.]  #56  emacs-pr-review          20260423.953 -> 20260509.1433
[U.]  #57  emacs-projectile         20260310.858 -> 20260620.902
[U.]  #58  emacs-shell-maker        20260330.851 -> 20260609.1823
[U.]  #59  emacs-shift-number       20260103.831 -> 20260620.1211
[U.]  #60  emacs-tablist            20231019.1126 -> 20260623.1855
[U.]  #61  emacs-tramp              2.8.1.3 -> 2.8.1.5
[U.]  #62  emacs-transient          20260422.1646 -> 20260617.1137
[U.]  #63  emacs-treepy             20260313.916 -> 20260531.1144
[U.]  #64  emacs-vertico            20260419.1808 -> 20260605.1903
[U.]  #65  emacs-web-mode           20260331.1441 -> 20260623.932
[U.]  #66  emacs-with-editor        20260417.751 -> 20260623.1348
[U.]  #67  emacs-yaml               20260113.653 -> 20260605.834
[U*]  #68  gvfs                     1.60.0 x2 -> 1.60.1 x2
[U.]  #69  hypridle                 0.1.7+date=2026-04-17_ff41dd6 -> 0.1.7+date=2026-06-29_128dcfa
[C*]  #70  hyprland                 0.55.0+date=2026-06-28_b8d910d, 0.55.0+date=2026-06-28_b8d910d-man, 0.55.4 -> 0.55.0+date=2026-07-04_7a52146, 0.55.0+date=2026-07-04_7a52146-man, 0.55.4
[C.]  #71  hyprutils                0.13.1, 0.13.1+date=2026-06-21_9d8bf6e, 0.13.1+date=2026-06-21_9d8bf6e-dev -> 0.13.1, 0.13.1+date=2026-07-02_41fb809, 0.13.1+date=2026-07-02_41fb809-dev
[U.]  #72  initrd-linux             6.18.36 -> 6.18.37
[U.]  #73  kdecoration              6.7.1 -> 6.7.2
[U.]  #74  libnfs                   5.0.3 -> 6.0.2
[U.]  #75  linux                    6.18.36, 6.18.36-modules x2 -> 6.18.37, 6.18.37-modules x2
[D.]  #76  netavark                 2.0.0 -> 1.17.2
[U.]  #77  nixos-system-terangreal  26.11.20260626.e73de5b -> 26.11.20260702.6517942
[U*]  #78  podman                   5.8.3, 5.8.3-man -> 5.8.4, 5.8.4-man
[U.]  #79  starship                 1.25.1, 1.25.1-fish-completions -> 1.26.0, 1.26.0-fish-completions
[U.]  #80  tree-sitter-c            0.24.1 -> 0.24.2
[U.]  #81  tree-sitter-lua          0.0.19-unstable-2025-05-16 -> 0.0.19-unstable-2026-02-26
[U.]  #82  tree-sitter-scala        0.25.0 -> 0.26.0
[U.]  #83  xarchiver                0.5.4.26, 0.5.4.26-fish-completions -> 0.5.4.27, 0.5.4.27-fish-completions
[U.]  #84  zen-browser              1.21.4b -> 1.21.5b
[U.]  #85  zen-browser-unwrapped    1.21.4b -> 1.21.5b
Removed packages:
[R.]  #1  emacs-annalist         20240501.1201
[R.]  #2  emacs-lsp-tailwindcss  20251009.810
Closure size: 3139 -> 3137 (366 paths added, 368 paths removed, delta -2, disk usage +5.9MiB).
```

</details>

<details><summary><b>tuathaan</b></summary>

```
<<< result-old
>>> result-new
Version changes:
[U.]  #01  bottom                   0.13.0, 0.13.0-fish-completions -> 0.14.2, 0.14.2-fish-completions
[U.]  #02  breeze                   6.7.1 -> 6.7.2
[U*]  #03  cpupower                 6.18.36, 6.18.36_fish-completions -> 6.18.37, 6.18.37_fish-completions
[U.]  #04  discord                  1.0.143, 1.0.143-fish-completions -> 1.0.144, 1.0.144-fish-completions
[U.]  #05  easyeffects              8.2.4, 8.2.4-fish-completions -> 8.2.5, 8.2.5-fish-completions
[U.]  #06  electron                 41.7.2 -> 41.9.1
[U.]  #07  electron-unwrapped       41.7.2 -> 41.9.1
[U.]  #08  emacs-apheleia           20260422.253 -> 20260619.1935
[U.]  #09  emacs-bui                20210108.1141 -> 20260502.730
[U.]  #10  emacs-cape               20260419.1847 -> 20260519.1021
[U.]  #11  emacs-closql             20260101.1828 -> 20260601.1540
[U.]  #12  emacs-compat             30.1.0.1 -> 31.0.0.1
[U.]  #13  emacs-cond-let           20260201.1500 -> 20260601.1457
[U.]  #14  emacs-consult            20260421.1105 -> 20260605.1907
[U.]  #15  emacs-consult-gh         20250915.2043 -> 20260625.257
[U.]  #16  emacs-consult-gh-embark  20250906.1805 -> 20260623.1820
[U.]  #17  emacs-consult-lsp        20251025.719 -> 20260619.643
[U.]  #18  emacs-corfu              20260419.1808 -> 20260519.1053
[U.]  #19  emacs-dap-mode           20260208.1403 -> 20260616.1526
[U.]  #20  emacs-diff-hl            20260328.1925 -> 20260624.444
[U.]  #21  emacs-dtrt-indent        20251102.857 -> 20260608.1055
[U.]  #22  emacs-dumb-jump          20260406.1824 -> 20260603.1700
[U.]  #23  emacs-eca                20260423.1754 -> 20260622.1430
[U.]  #24  emacs-eldoc-box          20260415.226 -> 20260620.158
[U.]  #25  emacs-emacsql            20260401.1220 -> 20260601.1722
[U.]  #26  emacs-embark             20260404.2302 -> 20260610.302
[U.]  #27  emacs-embark-consult     20260404.2302 -> 20260503.118
[U.]  #28  emacs-evil               20251108.138 -> 20260603.654
[U.]  #29  emacs-evil-collection    20260423.438 -> 20260624.327
[U.]  #30  emacs-flycheck           20260320.1715 -> 20260604.2002
[U.]  #31  emacs-forge              20260423.1757 -> 20260623.1325
[U.]  #32  emacs-ghostel            0.35.4-unstable-2026-06-19 -> 0.39.0-unstable-2026-06-26
[U.]  #33  emacs-ghub               20260423.1634 -> 20260603.1818
[U.]  #34  emacs-kotlin-ts-mode     20260326.930 -> 20260512.1409
[U.]  #35  emacs-llama              20260301.1253 -> 20260601.1455
[U.]  #36  emacs-lsp-docker         20250228.2210 -> 20260507.1750
[U.]  #37  emacs-lsp-haskell        20251121.1710 -> 20260507.1745
[U.]  #38  emacs-lsp-java           20260312.1356 -> 20260510.647
[U.]  #39  emacs-lsp-metals         20250228.2145 -> 20260529.1928
[U.]  #40  emacs-lsp-mode           20260423.1033 -> 20260616.510
[U.]  #41  emacs-lsp-treemacs       20251217.1621 -> 20260515.746
[U.]  #42  emacs-lsp-ui             20260104.1525 -> 20260512.1516
[U.]  #43  emacs-magit              20260422.2206 -> 20260621.1253
[U.]  #44  emacs-magit-section      20260422.2206 -> 20260514.937
[U.]  #45  emacs-marginalia         20260309.1545 -> 20260519.1044
[U.]  #46  emacs-markdown-mode      20260423.1508 -> 20260425.954
[U.]  #47  emacs-mcp                20260222.1058 -> 20260615.940
[U.]  #48  emacs-nerd-icons         20260325.346 -> 20260619.455
[U.]  #49  emacs-orderless          20260124.1000 -> 20260519.1029
[U.]  #50  emacs-org                9.8.3 -> 9.8.6
[U.]  #51  emacs-org-modern         20260325.721 -> 20260519.1046
[U.]  #52  emacs-org-msg            20260211.901 -> 20260507.725
[U.]  #53  emacs-org-roam           20260423.437 -> 20260425.1623
[U.]  #54  emacs-polymode           20260302.1043 -> 20260505.1803
[U.]  #55  emacs-posframe           20260423.213 -> 20260527.857
[U.]  #56  emacs-pr-review          20260423.953 -> 20260509.1433
[U.]  #57  emacs-projectile         20260310.858 -> 20260620.902
[U.]  #58  emacs-shell-maker        20260330.851 -> 20260609.1823
[U.]  #59  emacs-shift-number       20260103.831 -> 20260620.1211
[U.]  #60  emacs-tablist            20231019.1126 -> 20260623.1855
[U.]  #61  emacs-tramp              2.8.1.3 -> 2.8.1.5
[U.]  #62  emacs-transient          20260422.1646 -> 20260617.1137
[U.]  #63  emacs-treepy             20260313.916 -> 20260531.1144
[U.]  #64  emacs-vertico            20260419.1808 -> 20260605.1903
[U.]  #65  emacs-web-mode           20260331.1441 -> 20260623.932
[U.]  #66  emacs-with-editor        20260417.751 -> 20260623.1348
[U.]  #67  emacs-yaml               20260113.653 -> 20260605.834
[U*]  #68  gvfs                     1.60.0 x2 -> 1.60.1 x2
[U.]  #69  hypridle                 0.1.7+date=2026-04-17_ff41dd6 -> 0.1.7+date=2026-06-29_128dcfa
[C*]  #70  hyprland                 0.55.0+date=2026-06-28_b8d910d, 0.55.0+date=2026-06-28_b8d910d-man, 0.55.4 -> 0.55.0+date=2026-07-04_7a52146, 0.55.0+date=2026-07-04_7a52146-man, 0.55.4
[C.]  #71  hyprutils                0.13.1, 0.13.1+date=2026-06-21_9d8bf6e, 0.13.1+date=2026-06-21_9d8bf6e-dev -> 0.13.1, 0.13.1+date=2026-07-02_41fb809, 0.13.1+date=2026-07-02_41fb809-dev
[U.]  #72  initrd-linux             6.18.36 -> 6.18.37
[U.]  #73  kdecoration              6.7.1 -> 6.7.2
[U.]  #74  libnfs                   5.0.3 -> 6.0.2
[U.]  #75  linux                    6.18.36, 6.18.36-modules x2 -> 6.18.37, 6.18.37-modules x2
[D.]  #76  netavark                 2.0.0 -> 1.17.2
[U.]  #77  nixos-system-tuathaan    26.11.20260626.e73de5b -> 26.11.20260702.6517942
[U*]  #78  podman                   5.8.3, 5.8.3-man -> 5.8.4, 5.8.4-man
[U.]  #79  starship                 1.25.1, 1.25.1-fish-completions -> 1.26.0, 1.26.0-fish-completions
[U.]  #80  tree-sitter-c            0.24.1 -> 0.24.2
[U.]  #81  tree-sitter-lua          0.0.19-unstable-2025-05-16 -> 0.0.19-unstable-2026-02-26
[U.]  #82  tree-sitter-scala        0.25.0 -> 0.26.0
[U.]  #83  x86_energy_perf_policy   6.18.36 -> 6.18.37
[U.]  #84  xarchiver                0.5.4.26, 0.5.4.26-fish-completions -> 0.5.4.27, 0.5.4.27-fish-completions
[U.]  #85  zen-browser              1.21.4b -> 1.21.5b
[U.]  #86  zen-browser-unwrapped    1.21.4b -> 1.21.5b
Removed packages:
[R.]  #1  emacs-annalist         20240501.1201
[R.]  #2  emacs-lsp-tailwindcss  20251009.810
Closure size: 3073 -> 3071 (348 paths added, 350 paths removed, delta -2, disk usage +6.5MiB).
```

</details>

