### PR TITLE
Auto update 2026-07-12

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -86,11 +86,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1781825982,
-        "narHash": "sha256-SlXKwIRIhrOSAcTjCB3ftPLzJWZStQIPS7J1FlZPnKk=",
+        "lastModified": 1783203018,
+        "narHash": "sha256-G6R9IT/xwFuu+CYBWDUAok6AdC4ERC4ZfPPFtEpxnZE=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "469fd08d0bcf6926321fa973c6777fbc87785dd7",
+        "rev": "80db5bdc391be8a1794f6d8a2d56e3a84ebcede2",
         "type": "github"
       },
       "original": {
@@ -129,11 +129,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783168145,
-        "narHash": "sha256-yFyu8nsCcKvZdmIHArd8F43sL1B1DtWSxHf22DKanhs=",
+        "lastModified": 1783747793,
+        "narHash": "sha256-qHOWmQE0ef3JBt/Gbb8+qfHE52ZyayLdMf3YuPAapjg=",
         "owner": "Gako358",
         "repo": "emacs-flake",
-        "rev": "29d0164cd379a176035a2ef263ef05ad3fc04c53",
+        "rev": "c64814e04b20742b38d846d665eaf13dbf90e9d7",
         "type": "github"
       },
       "original": {
@@ -338,50 +338,6 @@
     "gitignore": {
       "inputs": {
         "nixpkgs": [
-          "hyprland",
-          "pre-commit-hooks",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1709087332,
-        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "type": "github"
-      }
-    },
-    "gitignore_2": {
-      "inputs": {
-        "nixpkgs": [
-          "lanzaboote",
-          "pre-commit",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1709087332,
-        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "type": "github"
-      }
-    },
-    "gitignore_3": {
-      "inputs": {
-        "nixpkgs": [
           "mugge",
           "pre-commit-hooks-nix",
           "nixpkgs"
@@ -406,11 +362,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1782562157,
-        "narHash": "sha256-a7+T6QSeowynwZ1ZJJbP8T8ntAytvrui8kFGJmIZt2c=",
+        "lastModified": 1783792734,
+        "narHash": "sha256-50rvY9GdFvpYDcMLcD/4cWSi0hVxArT5wsGlVsHy8eY=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "a9cf7546a938c737b079e738de73934a13de9784",
+        "rev": "8efb4337e857949f4cfac86d12ef1066f417f31f",
         "type": "github"
       },
       "original": {
@@ -426,11 +382,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783222121,
-        "narHash": "sha256-E/ElL373TO8lQ2aMvYyzN+k4xkVaUGoRqoa8AtM71tI=",
+        "lastModified": 1783823409,
+        "narHash": "sha256-OI4IkRjRXa1e7hYmCGJDPDq5H/kPwhsyoS80cNUF9fI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a1645f40777620c4bd2b6d854b290c2fc354a266",
+        "rev": "7566825d4652a1b885bd4ce65bd9e8def432fec9",
         "type": "github"
       },
       "original": {
@@ -570,11 +526,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1783198893,
-        "narHash": "sha256-UgdXpHgsg700hROak8RspFTfa/PDClxfyCEKs12nhxU=",
+        "lastModified": 1783804259,
+        "narHash": "sha256-obiYHJlgNeugve/5CNHWdyHEvbyjEbHXWOeBZ3ZbqOI=",
         "owner": "hyprwm",
         "repo": "hyprland",
-        "rev": "7a5214614b2f5bec4dbe1d0bddbc128c79cd2dfb",
+        "rev": "824ed12c9d40a857bb5952b5b209d27d78e01d5b",
         "type": "github"
       },
       "original": {
@@ -667,11 +623,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782769258,
-        "narHash": "sha256-HAhqQOoz4S0gzIOMnClL49B+rMT7zdp3UDWeqxtMs/k=",
+        "lastModified": 1783772407,
+        "narHash": "sha256-7J/A/jatgo6jxtnALGbDgmJg1NEwDQmbojltzxtqsxE=",
         "owner": "hyprwm",
         "repo": "hyprland-plugins",
-        "rev": "71b8953d7d92dbebe87a6ff9895bdd30e7495873",
+        "rev": "a2c77641bc80b749a9b02ebe6ff8dd6d727baee9",
         "type": "github"
       },
       "original": {
@@ -1073,11 +1029,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1783187991,
-        "narHash": "sha256-qGYEthfxqPeGfEkcJzZv98cX3+8Mg29PZDfZEhZ+Byg=",
+        "lastModified": 1783496806,
+        "narHash": "sha256-6B6CQUk1dPc8l/+otaGiYbuX8qeX/0VmSUQ+qSn0/uA=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "0368b35d4677854d897951d35b0bfd3649664383",
+        "rev": "6183ac79eadb079a1e72fa2c60915601be669100",
         "type": "github"
       },
       "original": {
@@ -1218,11 +1174,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1782467914,
-        "narHash": "sha256-pGvFkM8N0xEkIIXDe5YYfbEAvHrk4IxBrjB/x8OomhE=",
+        "lastModified": 1783522502,
+        "narHash": "sha256-iffAls3iaNTyJC2faYcUXSI+Gp02cDjYl+MygxKl2GI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e73de5be04e0eff4190a1432b946d469c794e7b4",
+        "rev": "0bb7ec54c8483066ec9d7720e780a5caa71f8612",
         "type": "github"
       },
       "original": {
@@ -1314,11 +1270,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1782959384,
-        "narHash": "sha256-xnJJk+ct+D2+wdRxj1wk36w5zV9RVESwRqcklPdt3fM=",
+        "lastModified": 1783776592,
+        "narHash": "sha256-UgCQzxeWI75XM8G+hPrPh+MKzEPjG3SpAj7dtqSbksA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "65179426c83bb3f6bc14898b42ea1c6f01d374b0",
+        "rev": "e7a3ca8092b61ff85b6a45bf863ea2b2d6a661b3",
         "type": "github"
       },
       "original": {
@@ -1330,11 +1286,11 @@
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1782959384,
-        "narHash": "sha256-xnJJk+ct+D2+wdRxj1wk36w5zV9RVESwRqcklPdt3fM=",
+        "lastModified": 1783776592,
+        "narHash": "sha256-UgCQzxeWI75XM8G+hPrPh+MKzEPjG3SpAj7dtqSbksA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "65179426c83bb3f6bc14898b42ea1c6f01d374b0",
+        "rev": "e7a3ca8092b61ff85b6a45bf863ea2b2d6a661b3",
         "type": "github"
       },
       "original": {
@@ -1350,11 +1306,11 @@
         "nixpkgs": "nixpkgs_9"
       },
       "locked": {
-        "lastModified": 1783243336,
-        "narHash": "sha256-jNyJzZIv3gNJSiR/Wye9Si1R5zYnPyRAR0fNoxMqrbQ=",
+        "lastModified": 1783853070,
+        "narHash": "sha256-5U21SX1++/e9+sSmtvSs7Fmi7x2mU1eoW6hcCkr8kmk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "98d2d02aa2189226050c1cc211dd3983ca4d18d2",
+        "rev": "d5c692909b88dd5ff24676f5d7e29fb5ef5f200e",
         "type": "github"
       },
       "original": {
@@ -1373,11 +1329,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775856943,
-        "narHash": "sha256-b7Mp7P+q2Md5AGt4rjHfMcBykzMumFTen10ST++AuTU=",
+        "lastModified": 1783574839,
+        "narHash": "sha256-ICof1tV4/9XheBLBGf7dhMhfMq4dOs1zwTHrr7zGFlA=",
         "owner": "nix-community",
         "repo": "plasma-manager",
-        "rev": "a524a6160e6df89f7673ba293cf7d78b559eb1a5",
+        "rev": "c551f0687658e4bb699cfff6015436ad7ee57a0d",
         "type": "github"
       },
       "original": {
@@ -1389,41 +1345,39 @@
     "pre-commit": {
       "inputs": {
         "flake-compat": "flake-compat_2",
-        "gitignore": "gitignore_2",
         "nixpkgs": [
           "lanzaboote",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1781733627,
-        "narHash": "sha256-U3yTuGBnmXvXoQI3qkpfEDsn9RovQPAjN7ndRco+3u0=",
+        "lastModified": 1783008725,
+        "narHash": "sha256-jGiy6+sxjNWXSjp25uoJuNfyH9zBK1PEDY0lVoL4ibQ=",
         "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
-        "rev": "3bbec39bc90eadfa031e6f3b77272f3f60803e39",
+        "repo": "git-hooks.nix",
+        "rev": "bca82caa46d5ec0f5d422c61fb1e30bc51313cbe",
         "type": "github"
       },
       "original": {
         "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
+        "repo": "git-hooks.nix",
         "type": "github"
       }
     },
     "pre-commit-hooks": {
       "inputs": {
         "flake-compat": "flake-compat",
-        "gitignore": "gitignore",
         "nixpkgs": [
           "hyprland",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1781733627,
-        "narHash": "sha256-U3yTuGBnmXvXoQI3qkpfEDsn9RovQPAjN7ndRco+3u0=",
+        "lastModified": 1783008725,
+        "narHash": "sha256-jGiy6+sxjNWXSjp25uoJuNfyH9zBK1PEDY0lVoL4ibQ=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "3bbec39bc90eadfa031e6f3b77272f3f60803e39",
+        "rev": "bca82caa46d5ec0f5d422c61fb1e30bc51313cbe",
         "type": "github"
       },
       "original": {
@@ -1435,7 +1389,7 @@
     "pre-commit-hooks-nix": {
       "inputs": {
         "flake-compat": "flake-compat_3",
-        "gitignore": "gitignore_3",
+        "gitignore": "gitignore",
         "nixpkgs": "nixpkgs_7"
       },
       "locked": {
@@ -1507,11 +1461,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783144302,
-        "narHash": "sha256-NQnzmXwpEAd5tjMBh2+P/y9NknF+WHv5+6yoXoN4h/Y=",
+        "lastModified": 1783488441,
+        "narHash": "sha256-jmWf+H3iC/0z7/mmvTovaJx1E/LME1QyHkyk+AFfJPk=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "fe5aee0952e8e1525533d61defd9e36513db811b",
+        "rev": "7dc3a177a239ed879c5581a80f6dc246c7e102f1",
         "type": "github"
       },
       "original": {
@@ -1647,11 +1601,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782311043,
-        "narHash": "sha256-07zLc2M3/ax+JsjxGTft17/Joua41LHE9/9AC/F9zeU=",
+        "lastModified": 1782644412,
+        "narHash": "sha256-/iSa/bL1QQFLv+uJ9gI0N87J8gOeZXvca7EjoPGKE6w=",
         "owner": "hyprwm",
         "repo": "xdg-desktop-portal-hyprland",
-        "rev": "882ad01e195ce201b07c618bbee44a0cad8b9e5a",
+        "rev": "c01c99fc278ec68c82e9865923088f043c7c1621",
         "type": "github"
       },
       "original": {
@@ -1667,11 +1621,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783063092,
-        "narHash": "sha256-H6lM+h8+ZT25uWJwmYkER5yj5RJ9DP2++n5um/XH3J0=",
+        "lastModified": 1783668749,
+        "narHash": "sha256-EDJjJYGT5pQKTBqmz+OA2sqE20kjj6mP699JFGDzse4=",
         "owner": "youwen5",
         "repo": "zen-browser-flake",
-        "rev": "36b24209358c82e0ea5404ba003ae8dc37334c86",
+        "rev": "e8041a3571e8cadb57dc18a3d6362d753510b94a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automatic flake update on 2026-07-12.

Review the per-host package changes below before merging.

## Input changes

```
unpacking 'github:nix-community/disko/de5708739256238fb912c62f03988815db89ec9a' into the Git cache...
unpacking 'github:Gako358/emacs-flake/c64814e04b20742b38d846d665eaf13dbf90e9d7' into the Git cache...
unpacking 'github:hercules-ci/flake-parts/17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e' into the Git cache...
unpacking 'github:nixos/nixos-hardware/8efb4337e857949f4cfac86d12ef1066f417f31f' into the Git cache...
unpacking 'github:nix-community/home-manager/7566825d4652a1b885bd4ce65bd9e8def432fec9' into the Git cache...
unpacking 'github:hyprwm/hypridle/128dcfa96dfc9c90136c9a80c6e2443f8b54928c' into the Git cache...
unpacking 'github:hyprwm/hyprland/824ed12c9d40a857bb5952b5b209d27d78e01d5b' into the Git cache...
unpacking 'github:hyprwm/contrib/3dcbce715ae8b93107fa8632db15bf976862a573' into the Git cache...
unpacking 'github:hyprwm/hyprland-plugins/a2c77641bc80b749a9b02ebe6ff8dd6d727baee9' into the Git cache...
unpacking 'github:hyprwm/hyprpaper/c011bd20886ea3301474e77d7fa4d22ab013ece0' into the Git cache...
unpacking 'github:nix-community/impermanence/7b1d382faf603b6d264f58627330f9faa5cba149' into the Git cache...
unpacking 'github:vic/import-tree/d321337efd0f23a9eb14a42adb7b2c29313ab274' into the Git cache...
unpacking 'github:nix-community/lanzaboote/6183ac79eadb079a1e72fa2c60915601be669100' into the Git cache...
unpacking 'github:misterio77/nix-colors/b01f024090d2c4fc3152cd0cf12027a7b8453ba1' into the Git cache...
unpacking 'github:nixos/nixpkgs/e7a3ca8092b61ff85b6a45bf863ea2b2d6a661b3' into the Git cache...
unpacking 'github:nix-community/NUR/d5c692909b88dd5ff24676f5d7e29fb5ef5f200e' into the Git cache...
unpacking 'github:nix-community/plasma-manager/c551f0687658e4bb699cfff6015436ad7ee57a0d' into the Git cache...
unpacking 'github:cachix/pre-commit-hooks.nix/bca82caa46d5ec0f5d422c61fb1e30bc51313cbe' into the Git cache...
unpacking 'github:gako358/scram/cd8a014d65ce34d28f318ca27040db8d0779f55a' into the Git cache...
unpacking 'github:Mic92/sops-nix/f1406619a3884cd5c47992a70b8b35c9c0fcb4c9' into the Git cache...
unpacking 'github:youwen5/zen-browser-flake/e8041a3571e8cadb57dc18a3d6362d753510b94a' into the Git cache...
warning: updating lock file "/home/runner/work/dotfiles/dotfiles/flake.lock":
• Updated input 'emacs-flake':
    'github:Gako358/emacs-flake/29d0164cd379a176035a2ef263ef05ad3fc04c53?narHash=sha256-yFyu8nsCcKvZdmIHArd8F43sL1B1DtWSxHf22DKanhs%3D' (2026-07-04)
  → 'github:Gako358/emacs-flake/c64814e04b20742b38d846d665eaf13dbf90e9d7?narHash=sha256-qHOWmQE0ef3JBt/Gbb8%2BqfHE52ZyayLdMf3YuPAapjg%3D' (2026-07-11)
• Updated input 'hardware':
    'github:nixos/nixos-hardware/a9cf7546a938c737b079e738de73934a13de9784?narHash=sha256-a7%2BT6QSeowynwZ1ZJJbP8T8ntAytvrui8kFGJmIZt2c%3D' (2026-06-27)
  → 'github:nixos/nixos-hardware/8efb4337e857949f4cfac86d12ef1066f417f31f?narHash=sha256-50rvY9GdFvpYDcMLcD/4cWSi0hVxArT5wsGlVsHy8eY%3D' (2026-07-11)
• Updated input 'home-manager':
    'github:nix-community/home-manager/a1645f40777620c4bd2b6d854b290c2fc354a266?narHash=sha256-E/ElL373TO8lQ2aMvYyzN%2Bk4xkVaUGoRqoa8AtM71tI%3D' (2026-07-05)
  → 'github:nix-community/home-manager/7566825d4652a1b885bd4ce65bd9e8def432fec9?narHash=sha256-OI4IkRjRXa1e7hYmCGJDPDq5H/kPwhsyoS80cNUF9fI%3D' (2026-07-12)
• Updated input 'hyprland':
    'github:hyprwm/hyprland/7a5214614b2f5bec4dbe1d0bddbc128c79cd2dfb?narHash=sha256-UgdXpHgsg700hROak8RspFTfa/PDClxfyCEKs12nhxU%3D' (2026-07-04)
  → 'github:hyprwm/hyprland/824ed12c9d40a857bb5952b5b209d27d78e01d5b?narHash=sha256-obiYHJlgNeugve/5CNHWdyHEvbyjEbHXWOeBZ3ZbqOI%3D' (2026-07-11)
• Updated input 'hyprland/nixpkgs':
    'github:NixOS/nixpkgs/e73de5be04e0eff4190a1432b946d469c794e7b4?narHash=sha256-pGvFkM8N0xEkIIXDe5YYfbEAvHrk4IxBrjB/x8OomhE%3D' (2026-06-26)
  → 'github:NixOS/nixpkgs/0bb7ec54c8483066ec9d7720e780a5caa71f8612?narHash=sha256-iffAls3iaNTyJC2faYcUXSI%2BGp02cDjYl%2BMygxKl2GI%3D' (2026-07-08)
• Updated input 'hyprland/pre-commit-hooks':
    'github:cachix/git-hooks.nix/3bbec39bc90eadfa031e6f3b77272f3f60803e39?narHash=sha256-U3yTuGBnmXvXoQI3qkpfEDsn9RovQPAjN7ndRco%2B3u0%3D' (2026-06-17)
  → 'github:cachix/git-hooks.nix/bca82caa46d5ec0f5d422c61fb1e30bc51313cbe?narHash=sha256-jGiy6%2BsxjNWXSjp25uoJuNfyH9zBK1PEDY0lVoL4ibQ%3D' (2026-07-02)
• Removed input 'hyprland/pre-commit-hooks/gitignore'
• Removed input 'hyprland/pre-commit-hooks/gitignore/nixpkgs'
• Updated input 'hyprland/xdph':
    'github:hyprwm/xdg-desktop-portal-hyprland/882ad01e195ce201b07c618bbee44a0cad8b9e5a?narHash=sha256-07zLc2M3/ax%2BJsjxGTft17/Joua41LHE9/9AC/F9zeU%3D' (2026-06-24)
  → 'github:hyprwm/xdg-desktop-portal-hyprland/c01c99fc278ec68c82e9865923088f043c7c1621?narHash=sha256-/iSa/bL1QQFLv%2BuJ9gI0N87J8gOeZXvca7EjoPGKE6w%3D' (2026-06-28)
• Updated input 'hyprland-plugins':
    'github:hyprwm/hyprland-plugins/71b8953d7d92dbebe87a6ff9895bdd30e7495873?narHash=sha256-HAhqQOoz4S0gzIOMnClL49B%2BrMT7zdp3UDWeqxtMs/k%3D' (2026-06-29)
  → 'github:hyprwm/hyprland-plugins/a2c77641bc80b749a9b02ebe6ff8dd6d727baee9?narHash=sha256-7J/A/jatgo6jxtnALGbDgmJg1NEwDQmbojltzxtqsxE%3D' (2026-07-11)
• Updated input 'lanzaboote':
    'github:nix-community/lanzaboote/0368b35d4677854d897951d35b0bfd3649664383?narHash=sha256-qGYEthfxqPeGfEkcJzZv98cX3%2B8Mg29PZDfZEhZ%2BByg%3D' (2026-07-04)
  → 'github:nix-community/lanzaboote/6183ac79eadb079a1e72fa2c60915601be669100?narHash=sha256-6B6CQUk1dPc8l/%2BotaGiYbuX8qeX/0VmSUQ%2BqSn0/uA%3D' (2026-07-08)
• Updated input 'lanzaboote/crane':
    'github:ipetkov/crane/469fd08d0bcf6926321fa973c6777fbc87785dd7?narHash=sha256-SlXKwIRIhrOSAcTjCB3ftPLzJWZStQIPS7J1FlZPnKk%3D' (2026-06-18)
  → 'github:ipetkov/crane/80db5bdc391be8a1794f6d8a2d56e3a84ebcede2?narHash=sha256-G6R9IT/xwFuu%2BCYBWDUAok6AdC4ERC4ZfPPFtEpxnZE%3D' (2026-07-04)
• Updated input 'lanzaboote/pre-commit':
    'github:cachix/pre-commit-hooks.nix/3bbec39bc90eadfa031e6f3b77272f3f60803e39?narHash=sha256-U3yTuGBnmXvXoQI3qkpfEDsn9RovQPAjN7ndRco%2B3u0%3D' (2026-06-17)
  → 'github:cachix/git-hooks.nix/bca82caa46d5ec0f5d422c61fb1e30bc51313cbe?narHash=sha256-jGiy6%2BsxjNWXSjp25uoJuNfyH9zBK1PEDY0lVoL4ibQ%3D' (2026-07-02)
• Removed input 'lanzaboote/pre-commit/gitignore'
• Removed input 'lanzaboote/pre-commit/gitignore/nixpkgs'
• Updated input 'lanzaboote/rust-overlay':
    'github:oxalica/rust-overlay/fe5aee0952e8e1525533d61defd9e36513db811b?narHash=sha256-NQnzmXwpEAd5tjMBh2%2BP/y9NknF%2BWHv5%2B6yoXoN4h/Y%3D' (2026-07-04)
  → 'github:oxalica/rust-overlay/7dc3a177a239ed879c5581a80f6dc246c7e102f1?narHash=sha256-jmWf%2BH3iC/0z7/mmvTovaJx1E/LME1QyHkyk%2BAFfJPk%3D' (2026-07-08)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/65179426c83bb3f6bc14898b42ea1c6f01d374b0?narHash=sha256-xnJJk%2Bct%2BD2%2BwdRxj1wk36w5zV9RVESwRqcklPdt3fM%3D' (2026-07-02)
  → 'github:nixos/nixpkgs/e7a3ca8092b61ff85b6a45bf863ea2b2d6a661b3?narHash=sha256-UgCQzxeWI75XM8G%2BhPrPh%2BMKzEPjG3SpAj7dtqSbksA%3D' (2026-07-11)
• Updated input 'nur':
    'github:nix-community/NUR/98d2d02aa2189226050c1cc211dd3983ca4d18d2?narHash=sha256-jNyJzZIv3gNJSiR/Wye9Si1R5zYnPyRAR0fNoxMqrbQ%3D' (2026-07-05)
  → 'github:nix-community/NUR/d5c692909b88dd5ff24676f5d7e29fb5ef5f200e?narHash=sha256-5U21SX1%2B%2B/e9%2BsSmtvSs7Fmi7x2mU1eoW6hcCkr8kmk%3D' (2026-07-12)
• Updated input 'nur/nixpkgs':
    'github:nixos/nixpkgs/65179426c83bb3f6bc14898b42ea1c6f01d374b0?narHash=sha256-xnJJk%2Bct%2BD2%2BwdRxj1wk36w5zV9RVESwRqcklPdt3fM%3D' (2026-07-02)
  → 'github:nixos/nixpkgs/e7a3ca8092b61ff85b6a45bf863ea2b2d6a661b3?narHash=sha256-UgCQzxeWI75XM8G%2BhPrPh%2BMKzEPjG3SpAj7dtqSbksA%3D' (2026-07-11)
• Updated input 'plasma-manager':
    'github:nix-community/plasma-manager/a524a6160e6df89f7673ba293cf7d78b559eb1a5?narHash=sha256-b7Mp7P%2Bq2Md5AGt4rjHfMcBykzMumFTen10ST%2B%2BAuTU%3D' (2026-04-10)
  → 'github:nix-community/plasma-manager/c551f0687658e4bb699cfff6015436ad7ee57a0d?narHash=sha256-ICof1tV4/9XheBLBGf7dhMhfMq4dOs1zwTHrr7zGFlA%3D' (2026-07-09)
• Updated input 'zen-browser':
    'github:youwen5/zen-browser-flake/36b24209358c82e0ea5404ba003ae8dc37334c86?narHash=sha256-H6lM%2Bh8%2BZT25uWJwmYkER5yj5RJ9DP2%2B%2Bn5um/XH3J0%3D' (2026-07-03)
  → 'github:youwen5/zen-browser-flake/e8041a3571e8cadb57dc18a3d6362d753510b94a?narHash=sha256-EDJjJYGT5pQKTBqmz%2BOA2sqE20kjj6mP699JFGDzse4%3D' (2026-07-10)
```

## Per-host package diff

<details><summary><b>aanallein</b></summary>

```
<<< result-old
>>> result-new
Version changes:
[U.]  #001  alsa-lib                    1.2.15.3 x2 -> 1.2.16 x2
[U.]  #002  alsa-ucm-conf               1.2.15.3 x2 -> 1.2.16 x2
[U.]  #003  aws-c-http                  0.10.4 -> 0.11.0
[U.]  #004  aws-c-io                    0.22.0 -> 0.27.2
[U.]  #005  breeze-icons                6.27.0, 6.27.0-dev -> 6.28.0, 6.28.0-dev
[U*]  #006  cpupower                    6.18.37, 6.18.37_fish-completions -> 6.18.38, 6.18.38_fish-completions
[C*]  #007  curl                        8.12.1, 8.20.0 x2, 8.20.0-bin, 8.20.0-man -> 8.12.1, 8.21.0 x2, 8.21.0-bin, 8.21.0-man
[U.]  #008  dash                        0.5.13.3 -> 0.5.13.4
[U.]  #009  djvulibre                   3.5.29, 3.5.29-lib -> 3.5.30, 3.5.30-lib
[U*]  #010  docker                      29.6.0 -> 29.6.1
[U.]  #011  docker-buildx               0.31.1 -> 0.35.0
[U*]  #012  docker-compose              5.2.0 -> 5.3.1
[U.]  #013  docker-containerd           29.6.0 -> 29.6.1
[U.]  #014  docker-runc                 29.6.0 -> 29.6.1
[U.]  #015  docker-tini                 29.6.0 -> 29.6.1
[U.]  #016  double-conversion           3.3.1, 3.3.1-dev -> 3.4.0, 3.4.0-dev
[U.]  #017  elementary-icon-theme       8.2.0 -> 8.2.0-unstable-2026-07-06
[U.]  #018  elfutils                    0.194 x2 -> 0.195 x2
[C.]  #019  expat                       2.6.4, 2.8.1 x2, 2.8.1-dev -> 2.6.4, 2.8.2 x2, 2.8.2-dev
[U.]  #020  extra-cmake-modules         6.27.0 -> 6.28.0
[U.]  #021  ffmpeg-headless             8.1.1-data x2, 8.1.1-lib x2 -> 8.1.2-data x2, 8.1.2-lib x2
[U.]  #022  file                        5.47 x2 -> 5.48 x2
[U.]  #023  fluidsynth                  2.5.3 -> 2.5.5
[U*]  #024  fontconfig                  2.17.1 x2, 2.17.1-bin, 2.17.1-dev, 2.17.1_fish-completions, 2.17.1-lib x2 -> 2.18.1 x2, 2.18.1-bin, 2.18.1-dev, 2.18.1_fish-completions, 2.18.1-lib x2
[U.]  #025  fuse                        3.17.4 -> 3.18.2
[U.]  #026  fzf                         0.73.1, 0.73.1-fish-completions, 0.73.1-man -> 0.74.0, 0.74.0-fish-completions, 0.74.0-man
[U.]  #027  game-music-emu              0.6.4 -> 0.6.5
[U.]  #028  gh                          2.95.0, 2.95.0-fish-completions -> 2.96.0, 2.96.0-fish-completions
[U.]  #029  giflib                      5.2.2 x2 -> 6.1.3 x2
[C*]  #030  gnused                      4.9 x2, 4.9_fish-completions, 4.9-info -> 4.9, 4.10, 4.10_fish-completions, 4.10-info
[U.]  #031  gpgme                       2.0.1 -> 2.1.0
[U.]  #032  graphite2                   1.3.14 x2, 1.3.14-dev -> 1.3.15 x2, 1.3.15-dev
[U.]  #033  gssdp                       1.6.4 -> 1.6.5
[U.]  #034  gst-plugins-bad             1.26.11 -> 1.28.4
[U.]  #035  gst-plugins-base            1.26.11 x2 -> 1.28.4 x2
[U.]  #036  gst-plugins-good            1.26.11 -> 1.28.4
[U.]  #037  gstreamer                   1.26.11 x2 -> 1.28.4 x2
[U.]  #038  gupnp                       1.6.9 -> 1.6.10
[U.]  #039  hwdata                      0.406 x2 -> 0.408 x2
[U.]  #040  hwloc                       2.13.0-lib -> 2.14.0-lib
[U.]  #041  imagemagick                 7.1.2-24, 7.1.2-24-fish-completions -> 7.1.2-27, 7.1.2-27-fish-completions
[U.]  #042  initrd-linux                6.18.37 -> 6.18.38
[U*]  #043  iproute2                    7.0.0, 7.0.0_fish-completions -> 7.1.0, 7.1.0_fish-completions
[U.]  #044  jq                          1.8.1, 1.8.1-bin, 1.8.1-fish-completions, 1.8.1-man -> 1.8.2, 1.8.2-bin, 1.8.2-fish-completions, 1.8.2-man
[U.]  #045  lcms2                       2.18 x2 -> 2.19.1 x2
[U.]  #046  ldns                        1.9.0 -> 1.9.2
[C.]  #047  lerc                        4.1.0 x2 -> 4.1.0 x2, 4.1.0-dev
[U*]  #048  less                        692, 692-man -> 704, 704-man
[U.]  #049  libapparmor                 4.1.7 x2 -> 5.0.0 x2
[U.]  #050  libarchive                  3.8.7-lib x2 -> 3.8.8-lib x2
[U*]  #051  libcap                      2.77, 2.77-doc, 2.77-lib x2, 2.77-man -> 2.78, 2.78-doc, 2.78-lib x2, 2.78-man
[U.]  #052  libcbor                     0.13.0 x2 -> 0.14.0 x2
[U.]  #053  libconfig                   1.8 x2 -> 1.8.2 x2
[U.]  #054  libdrm                      2.4.133 x2, 2.4.133-bin x2, 2.4.133-dev x2 -> 2.4.134 x2, 2.4.134-bin x2, 2.4.134-dev x2
[U.]  #055  libdvdcss                   1.4.3 -> 1.5.0
[U.]  #056  libedit                     20251016-3.1 -> 20260508-3.1
[U.]  #057  libgpg-error                1.59 x2 -> 1.61 x2
[U.]  #058  libheif                     1.23.0-lib -> 1.23.1-lib
[U.]  #059  libidn                      1.43 -> 1.44
[U.]  #060  libjpeg-turbo               3.1.4 x2, 3.1.4-bin, 3.1.4-dev -> 3.1.4.1 x2, 3.1.4.1-bin, 3.1.4.1-dev
[U.]  #061  libksba                     1.6.7 -> 1.8.0
[U.]  #062  libmd                       1.1.0 -> 1.2.0
[U.]  #063  libmicrohttpd               1.0.2 x2 -> 1.0.5 x2
[U.]  #064  libmpg123                   1.33.4 x2 -> 1.33.5 x2
[U.]  #065  libnice                     0.1.22 -> 0.1.23
[U.]  #066  libopenmpt                  0.8.6 x2 -> 0.8.7 x2
[U.]  #067  libpaper                    1.1.29 -> 2.2.8
[U.]  #068  librsvg                     2.62.1 -> 2.62.3
[U.]  #069  libsodium                   1.0.22-unstable-2026-04-09 -> 1.0.22-unstable-2026-04-16
[U.]  #070  libtpms                     0.10.2 x2 -> 0.10.2-unstable-2026-05-06 x2
[U.]  #071  libusb                      1.0.29 x2, 1.0.29-dev -> 1.0.30 x2, 1.0.30-dev
[U.]  #072  libxi                       1.8.2 x2, 1.8.2-dev -> 1.8.3 x2, 1.8.3-dev
[U.]  #073  libxkbcommon                1.13.1, 1.13.1-dev -> 1.13.2, 1.13.2-dev
[U.]  #074  lilv                        0.26.4 x2 -> 0.28.0 x2
[U.]  #075  linux                       6.18.37, 6.18.37-modules x2 -> 6.18.38, 6.18.38-modules x2
[U.]  #076  linux-headers               6.18.7 -> 7.0
[U.]  #077  linux-headers-static        6.18.7 -> 7.0
[U*]  #078  linux-pam                   1.7.1 x2, 1.7.1-doc, 1.7.1-man -> 1.7.2 x2, 1.7.2-doc, 1.7.2-man
[U.]  #079  llhttp                      9.4.1 -> 9.4.2
[U.]  #080  lttng-ust                   2.14.0 x2, 2.14.0-bin, 2.14.0-dev -> 2.15.1 x2, 2.15.1-bin, 2.15.1-dev
[U*]  #081  lvm2                        2.03.39, 2.03.39-bin, 2.03.39-lib x2, 2.03.39-man, 2.03.39-scripts -> 2.03.41, 2.03.41-bin, 2.03.41-lib x2, 2.03.41-man, 2.03.41-scripts
[U.]  #082  md4c                        0.5.2, 0.5.2-dev, 0.5.2-lib -> 0.5.3, 0.5.3-dev, 0.5.3-lib
[U.]  #083  mesa                        26.1.3 x2 -> 26.1.4 x2
[U.]  #084  mesa-libgbm                 26.0.3 x2 -> 26.1.3 x2
[U.]  #085  moby                        29.6.0 -> 29.6.1
[U.]  #086  mpg123                      1.33.4 x2 -> 1.33.5 x2
[U.]  #087  nghttp3                     1.15.0 x2 -> 1.16.0 x2
[U.]  #088  ngtcp2                      1.22.1 x2 -> 1.23.0 x2
[U*]  #089  nh                          4.3.2, 4.3.2_fish-completions -> 4.4.1, 4.4.1_fish-completions
[U.]  #090  nh-unwrapped                4.3.2 -> 4.4.1
[U*]  #091  nix                         2.34.7 x2, 2.34.7-doc, 2.34.7-man -> 2.34.8 x2, 2.34.8-doc, 2.34.8-man
[U.]  #092  nix-cmd                     2.34.7 -> 2.34.8
[U.]  #093  nix-expr                    2.34.7 -> 2.34.8
[U.]  #094  nix-fetchers                2.34.7 -> 2.34.8
[U.]  #095  nix-flake                   2.34.7 -> 2.34.8
[U.]  #096  nix-main                    2.34.7 -> 2.34.8
[U.]  #097  nix-manual                  2.34.7, 2.34.7-man -> 2.34.8, 2.34.8-man
[U.]  #098  nix-nswrapper               2.34.7 -> 2.34.8
[C.]  #099  nix-store                   2.31.5, 2.34.7 -> 2.31.5, 2.34.8
[C.]  #100  nix-util                    2.31.5, 2.34.7 -> 2.31.5, 2.34.8
[U.]  #101  nixos-system-aanallein      26.11.20260702.6517942 -> 26.11.20260711.e7a3ca8
[U.]  #102  noto-fonts                  2026.06.01 -> 2026.07.01
[U.]  #103  nss-cacert                  3.123, 3.123-fish-completions, 3.123-p11kit -> 3.125, 3.125-fish-completions, 3.125-p11kit
[U.]  #104  ocl-icd                     2.3.4 x2 -> 2.3.5 x2
[C.]  #105  openssl                     3.4.1, 3.6.2 x2, 3.6.2-bin, 3.6.2-dev -> 3.4.1, 3.6.3 x2, 3.6.3-bin, 3.6.3-dev
[U.]  #106  orc                         0.4.41 x2 -> 0.4.42 x2
[U.]  #107  perl5.42.0-Config-IniFiles  3.000003 -> 3.002000
[U.]  #108  perl5.42.0-HTML-Parser      3.81 -> 3.85
[U.]  #109  perl5.42.0-HTTP-Message     6.45 -> 7.02
[U.]  #110  perl5.42.0-libwww-perl      6.72 -> 6.83
[U*]  #111  pipewire                    1.6.5 x2, 1.6.5-doc, 1.6.5-man -> 1.6.7 x2, 1.6.7-doc, 1.6.7-man
[U.]  #112  poppler-glib                25.10.0, 25.10.0-fish-completions -> 26.06.0, 26.06.0-fish-completions
[C*]  #113  procps                      4.0.6, 4.0.6_fish-completions -> 4.0.6, 4.0.6-doc, 4.0.6-man
[C.]  #114  python3                     3.12.9, 3.13.13 x2, 3.13.13-env x2 -> 3.12.9, 3.14.6 x2, 3.14.6-env x2
[U.]  #115  socat                       1.8.1.1 -> 1.8.1.3
[U.]  #116  sord                        0.16.20 x2 -> 0.16.22 x2
[C.]  #117  sqlite                      3.48.0, 3.51.2 x2, 3.51.2-bin, 3.51.2-dev -> 3.48.0, 3.53.1 x2, 3.53.1-bin, 3.53.1-dev
[U.]  #118  srt                         1.5.4 x2 -> 1.5.5 x2
[U.]  #119  svt-av1                     3.1.2 x2 -> 4.1.0 x2
[C*]  #120  systemd                     <none>, 260.2 x2, 260.2-dev, 260.2-man -> <none>, 261 x2, 261-dev, 261-man
[U.]  #121  systemd-minimal             260.2 x2 -> 261 x2
[U.]  #122  systemd-minimal-libs        260.2 x2, 260.2-dev -> 261 x2, 261-dev
[U.]  #123  unifont                     17.0.04 -> 17.0.05
[U*]  #124  util-linux                  2.42, 2.42-bin, 2.42-dev, 2.42-lastlog, 2.42-lib, 2.42-login, 2.42-man, 2.42-mount, 2.42-swap -> 2.42.2, 2.42.2-bin, 2.42.2-dev, 2.42.2-lastlog, 2.42.2-lib, 2.42.2-login, 2.42.2-man, 2.42.2-mount, 2.42.2-swap
[C.]  #125  util-linux-minimal          2.40.4-lib, 2.42-bin, 2.42-lib x2, 2.42-login x2, 2.42-mount x2, 2.42-swap x2 -> 2.40.4-lib, 2.42.2-bin, 2.42.2-lib x2, 2.42.2-login x2, 2.42.2-mount x2, 2.42.2-swap x2
[U.]  #126  vulkan-headers              1.4.341.0 -> 1.4.350.0
[U.]  #127  vulkan-loader               1.4.341.0 x2, 1.4.341.0-dev -> 1.4.350.0 x2, 1.4.350.0-dev
[U.]  #128  wayland-protocols           1.48 -> 1.49
[U*]  #129  which                       2.23, 2.23-info, 2.23-man -> 2.25, 2.25-info, 2.25-man
[U.]  #130  x265                        4.1 x2 -> 4.2 x2
[C*]  #131  xz                          5.6.4, 5.8.3 x2, 5.8.3-bin, 5.8.3-doc, 5.8.3-man -> 5.6.4, 5.8.3 x2, 5.8.3-bin, 5.8.3-dev, 5.8.3-doc, 5.8.3-man
Added packages:
[A.]  #01  bcachefs-tools                 1.38.8
[A.]  #02  ldacbt                         2.0.72 x2
[A.]  #03  perl5.42.0-Compress-Raw-Bzip2  2.218
[A.]  #04  perl5.42.0-Compress-Raw-Zlib   2.222
[A.]  #05  perl5.42.0-IO-Compress         2.221
[A.]  #06  python3.14-dbus-python         1.4.0
[A.]  #07  python3.14-mako                1.3.12
[A.]  #08  python3.14-markdown            3.10.2
[A.]  #09  python3.14-markupsafe          3.0.3
[A.]  #10  python3.14-packaging           26.2
[A.]  #11  python3.14-pyxdg               0.28
[A.]  #12  python3.14-setuptools          82.0.1
[A.]  #13  python3.14-shtab               1.8.0
[A.]  #14  python3.14-termcolor           3.3.0

_… diff truncated (165 lines total); see the `closure-diff-aanallein` artifact for the full output._

</details>

<details><summary><b>rhuidean</b></summary>

```
<<< result-old
>>> result-new
Version changes:
[U.]  #001  alsa-lib                    1.2.15.3 x2 -> 1.2.16 x2
[U.]  #002  alsa-ucm-conf               1.2.15.3 x2 -> 1.2.16 x2
[U.]  #003  appstream                   1.1.2 -> 1.1.3
[U.]  #004  appstream-qt                1.1.2 -> 1.1.3
[U.]  #005  attica                      6.27.0 -> 6.28.0
[U.]  #006  aws-c-http                  0.10.4 -> 0.11.0
[U.]  #007  aws-c-io                    0.22.0 -> 0.27.2
[U.]  #008  breeze-icons                6.27.0, 6.27.0-dev -> 6.28.0, 6.28.0-dev
[U*]  #009  cpupower                    6.18.37, 6.18.37_fish-completions -> 6.18.38, 6.18.38_fish-completions
[C*]  #010  curl                        8.12.1, 8.20.0 x3, 8.20.0-bin x3, 8.20.0-man x2 -> 8.12.1, 8.21.0 x3, 8.21.0-bin x3, 8.21.0-man x2
[U.]  #011  dash                        0.5.13.3 -> 0.5.13.4
[U.]  #012  discord                     1.0.144, 1.0.144-fish-completions -> 1.0.146, 1.0.146-fish-completions
[U.]  #013  djvulibre                   3.5.29, 3.5.29-lib -> 3.5.30, 3.5.30-lib
[U*]  #014  docker                      29.6.0 -> 29.6.1
[U.]  #015  docker-buildx               0.31.1 -> 0.35.0
[U*]  #016  docker-compose              5.2.0 -> 5.3.1
[U.]  #017  docker-containerd           29.6.0 -> 29.6.1
[U.]  #018  docker-runc                 29.6.0 -> 29.6.1
[U.]  #019  docker-tini                 29.6.0 -> 29.6.1
[U.]  #020  double-conversion           3.3.1, 3.3.1-dev -> 3.4.0, 3.4.0-dev
[U.]  #021  easyeffects                 8.2.5, 8.2.5-fish-completions -> 8.2.7, 8.2.7-fish-completions
[U.]  #022  elementary-icon-theme       8.2.0 -> 8.2.0-unstable-2026-07-06
[U.]  #023  elfutils                    0.194 x2 -> 0.195 x2
[C.]  #024  expat                       2.6.4, 2.8.1 x2, 2.8.1-dev -> 2.6.4, 2.8.2 x2, 2.8.2-dev
[U.]  #025  extra-cmake-modules         6.27.0 -> 6.28.0
[C.]  #026  ffmpeg                      4.4.8-data, 4.4.8-lib, 7.1.5-data, 7.1.5-lib, 8.1.1-data, 8.1.1-lib -> 4.4.8-data, 4.4.8-lib, 7.1.5-data, 7.1.5-lib, 8.1.2-data, 8.1.2-lib
[U.]  #027  ffmpeg-headless             8.1.1-data x2, 8.1.1-lib x2 -> 8.1.2-data x2, 8.1.2-lib x2
[U.]  #028  file                        5.47 x2, 5.47-man -> 5.48 x2, 5.48-man
[U.]  #029  fluidsynth                  2.5.3 -> 2.5.5
[U*]  #030  fontconfig                  2.17.1 x2, 2.17.1-bin, 2.17.1-dev, 2.17.1_fish-completions, 2.17.1-lib x2 -> 2.18.1 x2, 2.18.1-bin, 2.18.1-dev, 2.18.1_fish-completions, 2.18.1-lib x2
[U.]  #031  frameworkintegration        6.27.0 -> 6.28.0
[C*]  #032  fuse                        2.9.9-bin, 2.9.9-man, 3.17.4, 3.17.4-bin, 3.17.4-man -> 2.9.9-bin, 2.9.9-man, 3.18.2, 3.18.2-bin, 3.18.2-man
[U.]  #033  fzf                         0.73.1, 0.73.1-fish-completions, 0.73.1-man -> 0.74.0, 0.74.0-fish-completions, 0.74.0-man
[U.]  #034  game-music-emu              0.6.4 -> 0.6.5
[U.]  #035  gh                          2.95.0, 2.95.0-fish-completions -> 2.96.0, 2.96.0-fish-completions
[U.]  #036  giflib                      5.2.2 x2 -> 6.1.3 x2
[C*]  #037  gnused                      4.9 x3, 4.9_fish-completions, 4.9-info -> 4.9, 4.10 x2, 4.10_fish-completions, 4.10-info
[U.]  #038  gpgme                       2.0.1 -> 2.1.0
[U.]  #039  gpgmepp                     2.0.0 -> 2.1.0
[U.]  #040  graphite2                   1.3.14 x2, 1.3.14-dev -> 1.3.15 x2, 1.3.15-dev
[U.]  #041  graphviz                    12.2.1 -> 14.1.2
[U.]  #042  gssdp                       1.6.4 -> 1.6.5
[U.]  #043  gst-devtools                1.26.11 -> 1.28.4
[U.]  #044  gst-editing-services        1.26.11 -> 1.28.4
[U.]  #045  gst-libav                   1.26.11 -> 1.28.4
[U.]  #046  gst-plugins-bad             1.26.11 -> 1.28.4
[U.]  #047  gst-plugins-base            1.26.11 x2 -> 1.28.4 x2
[U.]  #048  gst-plugins-good            1.26.11 x2 -> 1.28.4 x2
[U.]  #049  gst-plugins-ugly            1.26.11 -> 1.28.4
[U.]  #050  gst-rtsp-server             1.26.11 -> 1.28.4
[U.]  #051  gstreamer                   1.26.11 x2, 1.26.11-bin -> 1.28.4 x2, 1.28.4-bin
[U.]  #052  gupnp                       1.6.9 -> 1.6.10
[U.]  #053  hunspell                    1.7.2 -> 1.7.3
[U.]  #054  hwdata                      0.406 x2 -> 0.408 x2
[U.]  #055  hwloc                       2.13.0-lib -> 2.14.0-lib
[U.]  #056  hyphen                      2.8.8 -> 2.8.9
[U.]  #057  ibus                        1.5.33 -> 1.5.34
[U*]  #058  ibus-with-plugins           1.5.33, 1.5.33_fish-completions -> 1.5.34, 1.5.34_fish-completions
[U.]  #059  imagemagick                 7.1.2-24, 7.1.2-24-fish-completions -> 7.1.2-27, 7.1.2-27-fish-completions
[U.]  #060  initrd-linux                6.18.37 -> 6.18.38
[U*]  #061  iproute2                    7.0.0, 7.0.0_fish-completions -> 7.1.0, 7.1.0_fish-completions
[U.]  #062  jq                          1.8.1 x2, 1.8.1-bin x2, 1.8.1-fish-completions, 1.8.1-man -> 1.8.2 x2, 1.8.2-bin x2, 1.8.2-fish-completions, 1.8.2-man
[U.]  #063  karchive                    6.27.0 -> 6.28.0
[U.]  #064  kauth                       6.27.0 -> 6.28.0
[U.]  #065  kbookmarks                  6.27.0 -> 6.28.0
[U.]  #066  kcmutils                    6.27.0 -> 6.28.0
[U.]  #067  kcodecs                     6.27.0 -> 6.28.0
[U.]  #068  kcolorscheme                6.27.0 -> 6.28.0
[U.]  #069  kcompletion                 6.27.0 -> 6.28.0
[U.]  #070  kconfig                     6.27.0 -> 6.28.0
[U.]  #071  kconfigwidgets              6.27.0 -> 6.28.0
[U.]  #072  kcoreaddons                 6.27.0 -> 6.28.0
[U.]  #073  kcrash                      6.27.0 -> 6.28.0
[U.]  #074  kdbusaddons                 6.27.0 -> 6.28.0
[U.]  #075  kdoctools                   6.27.0 -> 6.28.0
[U.]  #076  kglobalaccel                6.27.0 -> 6.28.0
[U.]  #077  kguiaddons                  6.27.0 -> 6.28.0
[U.]  #078  ki18n                       6.27.0 -> 6.28.0
[U.]  #079  kiconthemes                 6.27.0 -> 6.28.0
[U.]  #080  kio                         6.27.0 -> 6.28.0
[U.]  #081  kirigami                    6.27.0 -> 6.28.0
[U.]  #082  kitemmodels                 6.27.0 -> 6.28.0
[U.]  #083  kitemviews                  6.27.0 -> 6.28.0
[U.]  #084  kjobwidgets                 6.27.0 -> 6.28.0
[U.]  #085  knewstuff                   6.27.0 -> 6.28.0
[U.]  #086  knotifications              6.27.0 -> 6.28.0
[U.]  #087  kpackage                    6.27.0 -> 6.28.0
[U.]  #088  kservice                    6.27.0 -> 6.28.0
[U.]  #089  ktextwidgets                6.27.0 -> 6.28.0
[U.]  #090  kwallet                     6.27.0 -> 6.28.0
[U.]  #091  kwidgetsaddons              6.27.0 -> 6.28.0
[U.]  #092  kwindowsystem               6.27.0 -> 6.28.0
[U.]  #093  kxmlgui                     6.27.0 -> 6.28.0
[U.]  #094  lcms2                       2.18 x2 -> 2.19.1 x2
[U.]  #095  ldns                        1.9.0 -> 1.9.2
[C.]  #096  lerc                        4.1.0 x2 -> 4.1.0 x2, 4.1.0-dev
[U*]  #097  less                        692, 692-man -> 704, 704-man
[U.]  #098  libapparmor                 4.1.7 x2 -> 5.0.0 x2
[U.]  #099  libarchive                  3.8.7, 3.8.7-lib x2 -> 3.8.8, 3.8.8-lib x2
[U.]  #100  libavif                     1.4.1 -> 1.4.2
[U.]  #101  libbacktrace                0-unstable-2024-03-02 -> 0-unstable-2026-05-03
[U*]  #102  libcap                      2.77, 2.77-doc, 2.77-lib x2, 2.77-man -> 2.78, 2.78-doc, 2.78-lib x2, 2.78-man
[U.]  #103  libcbor                     0.13.0 x2 -> 0.14.0 x2
[U.]  #104  libconfig                   1.8 x2 -> 1.8.2 x2
[U.]  #105  libdrm                      2.4.133 x2, 2.4.133-bin x2, 2.4.133-dev x2 -> 2.4.134 x2, 2.4.134-bin x2, 2.4.134-dev x2
[U.]  #106  libdvdcss                   1.4.3 -> 1.5.0
[U.]  #107  libedit                     20251016-3.1 x2 -> 20260508-3.1 x2
[U.]  #108  libei                       1.5.0 -> 1.6.0
[U.]  #109  libgpg-error                1.59 x2 -> 1.61 x2
[U.]  #110  libheif                     1.23.0-lib -> 1.23.1-lib
[U.]  #111  libidn                      1.43 x2, 1.43-bin -> 1.44 x2, 1.44-bin
[U.]  #112  libjpeg-turbo               3.1.4 x2, 3.1.4-bin, 3.1.4-dev, 3.1.4-man -> 3.1.4.1 x2, 3.1.4.1-bin, 3.1.4.1-dev, 3.1.4.1-man
[U.]  #113  libksba                     1.6.7 -> 1.8.0
[U.]  #114  libmd                       1.1.0 -> 1.2.0
[U.]  #115  libmicrohttpd               1.0.2 x2 -> 1.0.5 x2
[U.]  #116  libmpc                      1.4.0 -> 1.4.1
[U.]  #117  libmpg123                   1.33.4 x2, 1.33.4-man -> 1.33.5 x2, 1.33.5-man
[U.]  #118  libnice                     0.1.22 -> 0.1.23
[U.]  #119  libopenmpt                  0.8.6 x2 -> 0.8.7 x2
[U.]  #120  libpaper                    1.1.29 -> 2.2.8
[U.]  #121  libphonenumber              9.0.33 -> 9.0.34
[U.]  #122  librsvg                     2.62.1 -> 2.62.3
[U.]  #123  libsodium                   1.0.22-unstable-2026-04-09 -> 1.0.22-unstable-2026-04-16
[U.]  #124  libtpms                     0.10.2 x2 -> 0.10.2-unstable-2026-05-06 x2
[U.]  #125  libusb                      1.0.29 x2, 1.0.29-dev -> 1.0.30 x2, 1.0.30-dev
[U.]  #126  libxi                       1.8.2 x2, 1.8.2-dev, 1.8.2-man -> 1.8.3 x2, 1.8.3-dev, 1.8.3-man
[U.]  #127  libxkbcommon                1.13.1 x2, 1.13.1-dev -> 1.13.2 x2, 1.13.2-dev
[U.]  #128  libxkbfile                  1.1.3 -> 1.2.0
[U.]  #129  libxmlb                     0.3.25-lib -> 0.3.27-lib
[U.]  #130  lilv                        0.26.4 x2 -> 0.28.0 x2
[U.]  #131  linux                       6.18.37, 6.18.37-modules x2 -> 6.18.38, 6.18.38-modules x2
[U.]  #132  linux-headers               6.18.7 -> 7.0
[U.]  #133  linux-headers-static        6.18.7 -> 7.0
[U*]  #134  linux-pam                   1.7.1 x2, 1.7.1-doc, 1.7.1-man -> 1.7.2 x2, 1.7.2-doc, 1.7.2-man
[U.]  #135  llhttp                      9.4.1 -> 9.4.2
[U.]  #136  lttng-ust                   2.14.0 x2, 2.14.0-bin, 2.14.0-dev -> 2.15.1 x2, 2.15.1-bin, 2.15.1-dev
[U*]  #137  lvm2                        2.03.39, 2.03.39-bin, 2.03.39-lib x2, 2.03.39-man, 2.03.39-scripts -> 2.03.41, 2.03.41-bin, 2.03.41-lib x2, 2.03.41-man, 2.03.41-scripts
[U.]  #138  md4c                        0.5.2, 0.5.2-dev, 0.5.2-lib -> 0.5.3, 0.5.3-dev, 0.5.3-lib
[U.]  #139  mesa                        26.1.3 x2 -> 26.1.4 x2
[U.]  #140  mesa-libgbm                 26.0.3 x2 -> 26.1.3 x2
[U.]  #141  moby                        29.6.0 -> 29.6.1
[U.]  #142  mpg123                      1.33.4 x2 -> 1.33.5 x2
[U.]  #143  nghttp3                     1.15.0 x2 -> 1.16.0 x2
[C.]  #144  ngtcp2                      1.22.1 x2, 1.24.0 -> 1.23.0 x2, 1.24.0
[U*]  #145  nh                          4.3.2, 4.3.2_fish-completions -> 4.4.1, 4.4.1_fish-completions
[U.]  #146  nh-unwrapped                4.3.2 -> 4.4.1

_… diff truncated (256 lines total); see the `closure-diff-rhuidean` artifact for the full output._

</details>

<details><summary><b>tanchico</b></summary>

```
<<< result-old
>>> result-new
Version changes:
[U.]  #001  alsa-lib                    1.2.15.3 x2 -> 1.2.16 x2
[U.]  #002  alsa-ucm-conf               1.2.15.3 x2 -> 1.2.16 x2
[U.]  #003  appstream                   1.1.2 -> 1.1.3
[U.]  #004  appstream-qt                1.1.2 -> 1.1.3
[U.]  #005  attica                      6.27.0 -> 6.28.0
[U.]  #006  aws-c-http                  0.10.4 -> 0.11.0
[U.]  #007  aws-c-io                    0.22.0 -> 0.27.2
[U.]  #008  breeze-icons                6.27.0, 6.27.0-dev -> 6.28.0, 6.28.0-dev
[U*]  #009  cpupower                    6.18.37, 6.18.37_fish-completions -> 6.18.38, 6.18.38_fish-completions
[C*]  #010  curl                        8.12.1, 8.20.0 x3, 8.20.0-bin x3, 8.20.0-man x2 -> 8.12.1, 8.21.0 x3, 8.21.0-bin x3, 8.21.0-man x2
[U.]  #011  dash                        0.5.13.3 -> 0.5.13.4
[U.]  #012  discord                     1.0.144, 1.0.144-fish-completions -> 1.0.146, 1.0.146-fish-completions
[U.]  #013  djvulibre                   3.5.29, 3.5.29-lib -> 3.5.30, 3.5.30-lib
[U*]  #014  docker                      29.6.0 -> 29.6.1
[U.]  #015  docker-buildx               0.31.1 -> 0.35.0
[U*]  #016  docker-compose              5.2.0 -> 5.3.1
[U.]  #017  docker-containerd           29.6.0 -> 29.6.1
[U.]  #018  docker-runc                 29.6.0 -> 29.6.1
[U.]  #019  docker-tini                 29.6.0 -> 29.6.1
[U.]  #020  double-conversion           3.3.1, 3.3.1-dev -> 3.4.0, 3.4.0-dev
[U.]  #021  easyeffects                 8.2.5, 8.2.5-fish-completions -> 8.2.7, 8.2.7-fish-completions
[U.]  #022  elementary-icon-theme       8.2.0 -> 8.2.0-unstable-2026-07-06
[U.]  #023  elfutils                    0.194 x2 -> 0.195 x2
[C.]  #024  expat                       2.6.4, 2.8.1 x2, 2.8.1-dev -> 2.6.4, 2.8.2 x2, 2.8.2-dev
[U.]  #025  extra-cmake-modules         6.27.0 -> 6.28.0
[C.]  #026  ffmpeg                      4.4.8-data, 4.4.8-lib, 7.1.5-data, 7.1.5-lib, 8.1.1-data, 8.1.1-lib -> 4.4.8-data, 4.4.8-lib, 7.1.5-data, 7.1.5-lib, 8.1.2-data, 8.1.2-lib
[U.]  #027  ffmpeg-headless             8.1.1-data x2, 8.1.1-lib x2 -> 8.1.2-data x2, 8.1.2-lib x2
[U.]  #028  file                        5.47 x2, 5.47-man -> 5.48 x2, 5.48-man
[U.]  #029  fluidsynth                  2.5.3 -> 2.5.5
[U*]  #030  fontconfig                  2.17.1 x2, 2.17.1-bin, 2.17.1-dev, 2.17.1_fish-completions, 2.17.1-lib x2 -> 2.18.1 x2, 2.18.1-bin, 2.18.1-dev, 2.18.1_fish-completions, 2.18.1-lib x2
[U.]  #031  frameworkintegration        6.27.0 -> 6.28.0
[C*]  #032  fuse                        2.9.9-bin, 2.9.9-man, 3.17.4, 3.17.4-bin, 3.17.4-man -> 2.9.9-bin, 2.9.9-man, 3.18.2, 3.18.2-bin, 3.18.2-man
[U.]  #033  fzf                         0.73.1, 0.73.1-fish-completions, 0.73.1-man -> 0.74.0, 0.74.0-fish-completions, 0.74.0-man
[U.]  #034  game-music-emu              0.6.4 -> 0.6.5
[U.]  #035  gh                          2.95.0, 2.95.0-fish-completions -> 2.96.0, 2.96.0-fish-completions
[U.]  #036  giflib                      5.2.2 x2 -> 6.1.3 x2
[C*]  #037  gnused                      4.9 x3, 4.9_fish-completions, 4.9-info -> 4.9, 4.10 x2, 4.10_fish-completions, 4.10-info
[U.]  #038  gpgme                       2.0.1 -> 2.1.0
[U.]  #039  gpgmepp                     2.0.0 -> 2.1.0
[U.]  #040  graphite2                   1.3.14 x2, 1.3.14-dev -> 1.3.15 x2, 1.3.15-dev
[U.]  #041  graphviz                    12.2.1 -> 14.1.2
[U.]  #042  gssdp                       1.6.4 -> 1.6.5
[U.]  #043  gst-devtools                1.26.11 -> 1.28.4
[U.]  #044  gst-editing-services        1.26.11 -> 1.28.4
[U.]  #045  gst-libav                   1.26.11 -> 1.28.4
[U.]  #046  gst-plugins-bad             1.26.11 -> 1.28.4
[U.]  #047  gst-plugins-base            1.26.11 x2 -> 1.28.4 x2
[U.]  #048  gst-plugins-good            1.26.11 x2 -> 1.28.4 x2
[U.]  #049  gst-plugins-ugly            1.26.11 -> 1.28.4
[U.]  #050  gst-rtsp-server             1.26.11 -> 1.28.4
[U.]  #051  gstreamer                   1.26.11 x2, 1.26.11-bin -> 1.28.4 x2, 1.28.4-bin
[U.]  #052  gupnp                       1.6.9 -> 1.6.10
[U.]  #053  hunspell                    1.7.2 -> 1.7.3
[U.]  #054  hwdata                      0.406 x2 -> 0.408 x2
[U.]  #055  hwloc                       2.13.0-lib -> 2.14.0-lib
[U.]  #056  hyphen                      2.8.8 -> 2.8.9
[U.]  #057  ibus                        1.5.33 -> 1.5.34
[U*]  #058  ibus-with-plugins           1.5.33, 1.5.33_fish-completions -> 1.5.34, 1.5.34_fish-completions
[U.]  #059  imagemagick                 7.1.2-24, 7.1.2-24-fish-completions -> 7.1.2-27, 7.1.2-27-fish-completions
[U.]  #060  initrd-linux                6.18.37 -> 6.18.38
[U*]  #061  iproute2                    7.0.0, 7.0.0_fish-completions -> 7.1.0, 7.1.0_fish-completions
[U.]  #062  jq                          1.8.1 x2, 1.8.1-bin x2, 1.8.1-fish-completions, 1.8.1-man -> 1.8.2 x2, 1.8.2-bin x2, 1.8.2-fish-completions, 1.8.2-man
[U.]  #063  karchive                    6.27.0 -> 6.28.0
[U.]  #064  kauth                       6.27.0 -> 6.28.0
[U.]  #065  kbookmarks                  6.27.0 -> 6.28.0
[U.]  #066  kcmutils                    6.27.0 -> 6.28.0
[U.]  #067  kcodecs                     6.27.0 -> 6.28.0
[U.]  #068  kcolorscheme                6.27.0 -> 6.28.0
[U.]  #069  kcompletion                 6.27.0 -> 6.28.0
[U.]  #070  kconfig                     6.27.0 -> 6.28.0
[U.]  #071  kconfigwidgets              6.27.0 -> 6.28.0
[U.]  #072  kcoreaddons                 6.27.0 -> 6.28.0
[U.]  #073  kcrash                      6.27.0 -> 6.28.0
[U.]  #074  kdbusaddons                 6.27.0 -> 6.28.0
[U.]  #075  kdoctools                   6.27.0 -> 6.28.0
[U.]  #076  kglobalaccel                6.27.0 -> 6.28.0
[U.]  #077  kguiaddons                  6.27.0 -> 6.28.0
[U.]  #078  ki18n                       6.27.0 -> 6.28.0
[U.]  #079  kiconthemes                 6.27.0 -> 6.28.0
[U.]  #080  kio                         6.27.0 -> 6.28.0
[U.]  #081  kirigami                    6.27.0 -> 6.28.0
[U.]  #082  kitemmodels                 6.27.0 -> 6.28.0
[U.]  #083  kitemviews                  6.27.0 -> 6.28.0
[U.]  #084  kjobwidgets                 6.27.0 -> 6.28.0
[U.]  #085  knewstuff                   6.27.0 -> 6.28.0
[U.]  #086  knotifications              6.27.0 -> 6.28.0
[U.]  #087  kpackage                    6.27.0 -> 6.28.0
[U.]  #088  kservice                    6.27.0 -> 6.28.0
[U.]  #089  ktextwidgets                6.27.0 -> 6.28.0
[U.]  #090  kwallet                     6.27.0 -> 6.28.0
[U.]  #091  kwidgetsaddons              6.27.0 -> 6.28.0
[U.]  #092  kwindowsystem               6.27.0 -> 6.28.0
[U.]  #093  kxmlgui                     6.27.0 -> 6.28.0
[U.]  #094  lcms2                       2.18 x2 -> 2.19.1 x2
[U.]  #095  ldns                        1.9.0 -> 1.9.2
[C.]  #096  lerc                        4.1.0 x2 -> 4.1.0 x2, 4.1.0-dev
[U*]  #097  less                        692, 692-man -> 704, 704-man
[U.]  #098  libapparmor                 4.1.7 x2 -> 5.0.0 x2
[U.]  #099  libarchive                  3.8.7, 3.8.7-lib x2 -> 3.8.8, 3.8.8-lib x2
[U.]  #100  libavif                     1.4.1 -> 1.4.2
[U.]  #101  libbacktrace                0-unstable-2024-03-02 -> 0-unstable-2026-05-03
[U*]  #102  libcap                      2.77, 2.77-doc, 2.77-lib x2, 2.77-man -> 2.78, 2.78-doc, 2.78-lib x2, 2.78-man
[U.]  #103  libcbor                     0.13.0 x2 -> 0.14.0 x2
[U.]  #104  libconfig                   1.8 x2 -> 1.8.2 x2
[U.]  #105  libdrm                      2.4.133 x2, 2.4.133-bin x2, 2.4.133-dev x2 -> 2.4.134 x2, 2.4.134-bin x2, 2.4.134-dev x2
[U.]  #106  libdvdcss                   1.4.3 -> 1.5.0
[U.]  #107  libedit                     20251016-3.1 x2 -> 20260508-3.1 x2
[U.]  #108  libei                       1.5.0 -> 1.6.0
[U.]  #109  libgpg-error                1.59 x2 -> 1.61 x2
[U.]  #110  libheif                     1.23.0-lib -> 1.23.1-lib
[U.]  #111  libidn                      1.43 x2, 1.43-bin -> 1.44 x2, 1.44-bin
[U.]  #112  libjpeg-turbo               3.1.4 x2, 3.1.4-bin, 3.1.4-dev, 3.1.4-man -> 3.1.4.1 x2, 3.1.4.1-bin, 3.1.4.1-dev, 3.1.4.1-man
[U.]  #113  libksba                     1.6.7 -> 1.8.0
[U.]  #114  libmd                       1.1.0 -> 1.2.0
[U.]  #115  libmicrohttpd               1.0.2 x2 -> 1.0.5 x2
[U.]  #116  libmpc                      1.4.0 -> 1.4.1
[U.]  #117  libmpg123                   1.33.4 x2, 1.33.4-man -> 1.33.5 x2, 1.33.5-man
[U.]  #118  libnice                     0.1.22 -> 0.1.23
[U.]  #119  libopenmpt                  0.8.6 x2 -> 0.8.7 x2
[U.]  #120  libpaper                    1.1.29 -> 2.2.8
[U.]  #121  libphonenumber              9.0.33 -> 9.0.34
[U.]  #122  librsvg                     2.62.1 -> 2.62.3
[U.]  #123  libsodium                   1.0.22-unstable-2026-04-09 -> 1.0.22-unstable-2026-04-16
[U.]  #124  libtpms                     0.10.2 x2 -> 0.10.2-unstable-2026-05-06 x2
[U.]  #125  libusb                      1.0.29 x2, 1.0.29-dev -> 1.0.30 x2, 1.0.30-dev
[U.]  #126  libxi                       1.8.2 x2, 1.8.2-dev, 1.8.2-man -> 1.8.3 x2, 1.8.3-dev, 1.8.3-man
[U.]  #127  libxkbcommon                1.13.1 x2, 1.13.1-dev -> 1.13.2 x2, 1.13.2-dev
[U.]  #128  libxkbfile                  1.1.3 -> 1.2.0
[U.]  #129  libxmlb                     0.3.25-lib -> 0.3.27-lib
[U.]  #130  lilv                        0.26.4 x2 -> 0.28.0 x2
[U.]  #131  linux                       6.18.37, 6.18.37-modules x2 -> 6.18.38, 6.18.38-modules x2
[U.]  #132  linux-headers               6.18.7 -> 7.0
[U.]  #133  linux-headers-static        6.18.7 -> 7.0
[U*]  #134  linux-pam                   1.7.1 x2, 1.7.1-doc, 1.7.1-man -> 1.7.2 x2, 1.7.2-doc, 1.7.2-man
[U.]  #135  llhttp                      9.4.1 -> 9.4.2
[U.]  #136  lttng-ust                   2.14.0 x2, 2.14.0-bin, 2.14.0-dev -> 2.15.1 x2, 2.15.1-bin, 2.15.1-dev
[U*]  #137  lvm2                        2.03.39, 2.03.39-bin, 2.03.39-lib x2, 2.03.39-man, 2.03.39-scripts -> 2.03.41, 2.03.41-bin, 2.03.41-lib x2, 2.03.41-man, 2.03.41-scripts
[U.]  #138  md4c                        0.5.2, 0.5.2-dev, 0.5.2-lib -> 0.5.3, 0.5.3-dev, 0.5.3-lib
[U.]  #139  mesa                        26.1.3 x2 -> 26.1.4 x2
[U.]  #140  mesa-libgbm                 26.0.3 x2 -> 26.1.3 x2
[U.]  #141  moby                        29.6.0 -> 29.6.1
[U.]  #142  mpg123                      1.33.4 x2 -> 1.33.5 x2
[U.]  #143  nghttp3                     1.15.0 x2 -> 1.16.0 x2
[C.]  #144  ngtcp2                      1.22.1 x2, 1.24.0 -> 1.23.0 x2, 1.24.0
[U*]  #145  nh                          4.3.2, 4.3.2_fish-completions -> 4.4.1, 4.4.1_fish-completions
[U.]  #146  nh-unwrapped                4.3.2 -> 4.4.1

_… diff truncated (256 lines total); see the `closure-diff-tanchico` artifact for the full output._

</details>

<details><summary><b>terangreal</b></summary>

```
<<< result-old
>>> result-new
Version changes:
[C*]  #001  acl                               2.3.2 x4, 2.3.2-bin, 2.3.2-doc, 2.3.2-man -> 2.3.2 x5, 2.3.2-bin, 2.3.2-doc, 2.3.2-man
[C.]  #002  alsa-lib                          1.2.13, 1.2.15.3 x2 -> 1.2.13, 1.2.15.3, 1.2.16 x2
[C.]  #003  alsa-plugins                      1.2.12 -> 1.2.12 x2
[C.]  #004  alsa-topology-conf                1.2.5.1 x3 -> 1.2.5.1 x4
[C.]  #005  alsa-ucm-conf                     1.2.12, 1.2.15.3 x2 -> 1.2.12, 1.2.15.3, 1.2.16 x2
[U.]  #006  appstream                         1.1.2 -> 1.1.3
[U.]  #007  appstream-qt                      1.1.2 -> 1.1.3
[U.]  #008  astyle                            3.6.16 -> 3.6.17
[U.]  #009  attica                            6.27.0 -> 6.28.0
[C*]  #010  attr                              2.5.2 x4, 2.5.2-bin, 2.5.2-doc, 2.5.2-man -> 2.5.2 x5, 2.5.2-bin, 2.5.2-doc, 2.5.2-man
[C.]  #011  audit                             4.0.3-lib, 4.1.4-lib x2 -> 4.0.3-lib, 4.1.4-lib x3
[U.]  #012  aws-c-http                        0.10.4 -> 0.11.0
[U.]  #013  aws-c-io                          0.22.0 -> 0.27.2
[C.]  #014  bash                              5.2p37 x2, 5.3p9 x2 -> 5.2p37 x2, 5.3p9 x3
[C*]  #015  bash-interactive                  5.2p37 x2, 5.3p9, 5.3p9-doc, 5.3p9-info, 5.3p9-man -> 5.2p37 x2, 5.3p9 x2, 5.3p9-doc, 5.3p9-info, 5.3p9-man
[U.]  #016  bottom                            0.14.2, 0.14.2-fish-completions -> 0.14.4, 0.14.4-fish-completions
[U.]  #017  breeze-icons                      6.27.0, 6.27.0-dev -> 6.28.0, 6.28.0-dev
[C.]  #018  brotli                            1.1.0-lib x2, 1.2.0, 1.2.0-dev, 1.2.0-lib x2 -> 1.1.0-lib x2, 1.2.0, 1.2.0-dev, 1.2.0-lib x3
[C*]  #019  bzip2                             1.0.8 x4, 1.0.8-bin x2, 1.0.8-dev, 1.0.8-man -> 1.0.8 x5, 1.0.8-bin x2, 1.0.8-dev, 1.0.8-man
[U.]  #020  cage                              0.3.0 -> 0.3.1
[C.]  #021  cjson                             1.7.19 x2 -> 1.7.19 x3
[C.]  #022  coreutils                         9.6 x2, 9.11 x2 -> 9.6 x2, 9.11 x3
[U*]  #023  cpupower                          6.18.37, 6.18.37_fish-completions -> 6.18.38, 6.18.38_fish-completions
[C*]  #024  curl                              8.12.1 x2, 8.20.0 x2, 8.20.0-bin, 8.20.0-dev, 8.20.0-man -> 8.12.1 x2, 8.20.0, 8.21.0 x2, 8.21.0-bin, 8.21.0-dev, 8.21.0-man
[U.]  #025  dash                              0.5.13.3 -> 0.5.13.4
[C.]  #026  dav1d                             1.5.3 x2 -> 1.5.3 x3
[C.]  #027  db                                4.8.30 x3, 5.3.28 -> 4.8.30 x4, 5.3.28
[C*]  #028  dbus                              1, 1.14.10-lib, 1.16.2, 1.16.2-dev, 1.16.2-doc, 1.16.2-lib x2, 1.16.2-man -> 1, 1.14.10-lib, 1.16.2, 1.16.2-dev, 1.16.2-doc, 1.16.2-lib x3, 1.16.2-man
[C*]  #029  dconf                             0.40.0-lib, 0.49.0, 0.49.0_fish-completions, 0.49.0-lib x2 -> 0.40.0-lib, 0.49.0, 0.49.0_fish-completions, 0.49.0-lib x3
[C.]  #030  dejavu-fonts-minimal              2.37 x3 -> 2.37 x4
[U.]  #031  discord                           1.0.144, 1.0.144-fish-completions -> 1.0.146, 1.0.146-fish-completions
[U.]  #032  djvulibre                         3.5.29, 3.5.29-lib -> 3.5.30, 3.5.30-lib
[C.]  #033  dns-root-data                     2024-06-20, 2025-04-14 x2 -> 2024-06-20, 2025-04-14 x3
[U*]  #034  docker                            29.6.0 -> 29.6.1
[U.]  #035  docker-buildx                     0.31.1 -> 0.35.0
[U*]  #036  docker-compose                    5.2.0 -> 5.3.1
[U.]  #037  docker-containerd                 29.6.0 -> 29.6.1
[U.]  #038  docker-runc                       29.6.0 -> 29.6.1
[U.]  #039  docker-tini                       29.6.0 -> 29.6.1
[U.]  #040  double-conversion                 3.3.1, 3.3.1-dev -> 3.4.0, 3.4.0-dev
[U.]  #041  easyeffects                       8.2.5, 8.2.5-fish-completions -> 8.2.7, 8.2.7-fish-completions
[U.]  #042  elementary-icon-theme             8.2.0 -> 8.2.0-unstable-2026-07-06
[C.]  #043  elfutils                          0.192, 0.194 x2 -> 0.192, 0.195 x2
[U.]  #044  emacs-ghostel                     0.39.0-unstable-2026-06-26 -> 0.41.0-unstable-2026-07-06
[C.]  #045  expat                             2.6.4 x2, 2.8.1 x2, 2.8.1-dev -> 2.6.4 x2, 2.8.1, 2.8.2 x2, 2.8.2-dev
[U.]  #046  extra-cmake-modules               6.27.0 -> 6.28.0
[C.]  #047  ffmpeg                            7.1.5-data, 7.1.5-lib, 8.1.1-data, 8.1.1-lib -> 7.1.5-data, 7.1.5-lib, 8.1.1-data, 8.1.1-lib, 8.1.2-data, 8.1.2-lib
[U.]  #048  ffmpeg-headless                   8.1.1-data x2, 8.1.1-lib x2 -> 8.1.2-data x2, 8.1.2-lib x2
[C.]  #049  fftw-single                       3.3.11 x2 -> 3.3.11 x3
[C.]  #050  file                              5.46, 5.47 x2 -> 5.46, 5.48 x2
[C.]  #051  flac                              1.5.0 x2 -> 1.5.0 x3
[U.]  #052  fluidsynth                        2.5.3 -> 2.5.5
[C*]  #053  fontconfig                        2.16.0, 2.16.0-lib, 2.17.1 x2, 2.17.1-bin, 2.17.1-dev, 2.17.1_fish-completions, 2.17.1-lib x2 -> 2.16.0, 2.16.0-lib, 2.17.1, 2.17.1-lib, 2.18.1 x2, 2.18.1-bin, 2.18.1-dev, 2.18.1_fish-completions, 2.18.1-lib x2
[U.]  #054  frameworkintegration              6.27.0 -> 6.28.0
[C.]  #055  freetype                          2.13.3, 2.14.3 x2, 2.14.3-dev -> 2.13.3, 2.14.3 x3, 2.14.3-dev
[C.]  #056  fribidi                           1.0.16 x3, 1.0.16-dev -> 1.0.16 x4, 1.0.16-dev
[C*]  #057  fuse                              2.9.9, 2.9.9-bin, 2.9.9-man, 3.17.4, 3.17.4-bin, 3.17.4-man -> 2.9.9-bin, 2.9.9-man, 3.18.2, 3.18.2-bin, 3.18.2-man
[U.]  #058  fzf                               0.73.1, 0.73.1-fish-completions, 0.73.1-man -> 0.74.0, 0.74.0-fish-completions, 0.74.0-man
[U.]  #059  game-music-emu                    0.6.4 -> 0.6.5
[C.]  #060  gcc                               14-20241116-lib x2, 14-20241116-libgcc x2, 15.2.0 x2, 15.2.0-lib x3, 15.2.0-libgcc x3, 16.1.0-lib, 16.1.0-libgcc -> 14-20241116-lib x2, 14-20241116-libgcc x2, 15.2.0 x2, 15.2.0-lib x4, 15.2.0-libgcc x4, 16.1.0-lib, 16.1.0-libgcc
[C.]  #061  gdbm                              1.24-lib, 1.26-lib x2 -> 1.24-lib, 1.26-lib x3
[C.]  #062  gdk-pixbuf                        2.42.12, 2.44.6, 2.44.6-dev -> 2.42.12, 2.44.6 x2, 2.44.6-dev
[U.]  #063  getopt-util-linux                 2.42 -> 2.42.2
[C.]  #064  gettext                           0.22.5, 1.0 -> 0.22.5, 1.0 x2
[U.]  #065  gh                                2.95.0, 2.95.0-fish-completions -> 2.96.0, 2.96.0-fish-completions
[C.]  #066  giflib                            5.2.2 x3 -> 5.2.2 x2, 6.1.3 x2
[C*]  #067  git                               2.54.0, 2.54.0-doc, 2.54.0_fish-completions x2 -> 2.54.0 x2, 2.54.0-doc x2, 2.54.0_fish-completions x2
[C.]  #068  glib                              2.82.5, 2.88.1 x2, 2.88.1-bin, 2.88.1-dev, 2.88.1-fish-completions -> 2.82.5, 2.88.1 x3, 2.88.1-bin, 2.88.1-dev, 2.88.1-fish-completions
[C*]  #069  glibc                             2.40-66 x2, 2.40-66-getent, 2.42-67 x2, 2.42-67-bin, 2.42-67-dev, 2.42-67-getent -> 2.40-66 x2, 2.40-66-getent, 2.42-67 x3, 2.42-67-bin, 2.42-67-dev, 2.42-67-getent
[U.]  #070  glslang                           16.2.0 -> 16.3.0
[C.]  #071  gmp-with-cxx                      6.3.0 x7, 6.3.0-dev -> 6.3.0 x9, 6.3.0-dev
[C*]  #072  gnugrep                           3.11 x2, 3.12, 3.12_fish-completions, 3.12-info -> 3.11 x2, 3.12 x2, 3.12_fish-completions, 3.12-info
[C*]  #073  gnused                            4.9 x2, 4.9_fish-completions, 4.9-info -> 4.9 x2, 4.10, 4.10_fish-completions, 4.10-info
[C.]  #074  gnutls                            3.8.9, 3.8.13 x2, 3.8.13-bin -> 3.8.9, 3.8.13 x3
[U.]  #075  gpgme                             2.0.1 -> 2.1.0
[U.]  #076  gpgmepp                           2.0.0 -> 2.1.0
[C.]  #077  graphite2                         1.3.14 x3, 1.3.14-dev -> 1.3.14 x2, 1.3.15 x2, 1.3.15-dev
[U.]  #078  graphviz                          12.2.1 -> 14.1.2
[U.]  #079  grpc                              1.80.0 -> 1.81.0
[U.]  #080  gssdp                             1.6.4 -> 1.6.5
[U.]  #081  gst-libav                         1.26.11 -> 1.28.4
[U.]  #082  gst-plugins-bad                   1.26.11 -> 1.28.4
[U.]  #083  gst-plugins-base                  1.26.11 x2 -> 1.28.4 x2
[U.]  #084  gst-plugins-good                  1.26.11 -> 1.28.4
[U.]  #085  gstreamer                         1.26.11 x2 -> 1.28.4 x2
[C.]  #086  gtest                             1.17.0 x2 -> 1.17.0 x2, 1.17.0-dev
[U.]  #087  gupnp                             1.6.9 -> 1.6.10
[C*]  #088  gzip                              1.13, 1.14, 1.14-info, 1.14-man -> 1.13, 1.14 x2, 1.14-info, 1.14-man
[C.]  #089  harfbuzz                          10.2.0, 13.2.1 x2, 13.2.1-dev -> 10.2.0, 13.2.1 x3, 13.2.1-dev
[U.]  #090  hunspell                          1.7.2, 1.7.2-bin -> 1.7.3, 1.7.3-bin
[U.]  #091  hunspell-with-dicts               1.7.2 -> 1.7.3
[C.]  #092  hwdata                            0.406 x2 -> 0.406, 0.408 x2
[U.]  #093  hwloc                             2.13.0-lib -> 2.14.0-lib
[U.]  #094  hyphen                            2.8.8 -> 2.8.9
[C*]  #095  hyprland                          0.55.0+date=2026-07-04_7a52146, 0.55.0+date=2026-07-04_7a52146-man, 0.55.4 -> 0.55.0+date=2026-07-11_824ed12, 0.55.0+date=2026-07-11_824ed12-man, 0.55.4
[C.]  #096  icu4c                             76.1 x3, 76.1-dev, 77.1, 78.3, 78.3-dev -> 76.1 x3, 76.1-dev, 77.1
[U.]  #097  imagemagick                       7.1.2-24, 7.1.2-24-fish-completions -> 7.1.2-27, 7.1.2-27-fish-completions
[U.]  #098  initrd-linux                      6.18.37 -> 6.18.38
[U*]  #099  iproute2                          7.0.0, 7.0.0_fish-completions -> 7.1.0, 7.1.0_fish-completions
[U.]  #100  jq                                1.8.1, 1.8.1-bin, 1.8.1-fish-completions, 1.8.1-man -> 1.8.2, 1.8.2-bin, 1.8.2-fish-completions, 1.8.2-man
[U.]  #101  karchive                          6.27.0 -> 6.28.0
[U.]  #102  kauth                             6.27.0 -> 6.28.0
[U.]  #103  kbookmarks                        6.27.0 -> 6.28.0
[U.]  #104  kcmutils                          6.27.0 -> 6.28.0
[U.]  #105  kcodecs                           6.27.0 -> 6.28.0
[U.]  #106  kcolorscheme                      6.27.0 -> 6.28.0
[U.]  #107  kcompletion                       6.27.0 -> 6.28.0
[U.]  #108  kconfig                           6.27.0 -> 6.28.0
[U.]  #109  kconfigwidgets                    6.27.0 -> 6.28.0
[U.]  #110  kcoreaddons                       6.27.0 -> 6.28.0
[U.]  #111  kcrash                            6.27.0 -> 6.28.0
[U.]  #112  kdbusaddons                       6.27.0 -> 6.28.0
[U.]  #113  kdoctools                         6.27.0 -> 6.28.0
[C.]  #114  keyutils                          1.6.3-lib x4 -> 1.6.3-lib x5
[U.]  #115  kglobalaccel                      6.27.0 -> 6.28.0
[U.]  #116  kguiaddons                        6.27.0 -> 6.28.0
[U.]  #117  ki18n                             6.27.0 -> 6.28.0
[U.]  #118  kiconthemes                       6.27.0 -> 6.28.0
[U.]  #119  kio                               6.27.0 -> 6.28.0
[U.]  #120  kirigami                          6.27.0 -> 6.28.0
[U.]  #121  kitemmodels                       6.27.0 -> 6.28.0
[U.]  #122  kitemviews                        6.27.0 -> 6.28.0
[U.]  #123  kjobwidgets                       6.27.0 -> 6.28.0
[C*]  #124  kmod                              31 x3, 31-lib x3, 31-man -> 31 x4, 31-lib x4, 31-man
[U.]  #125  knewstuff                         6.27.0 -> 6.28.0
[U.]  #126  knotifications                    6.27.0 -> 6.28.0
[U.]  #127  kpackage                          6.27.0 -> 6.28.0
[C.]  #128  krb5                              1.21.3-lib x2, 1.22.2, 1.22.2-dev, 1.22.2-lib x2 -> 1.21.3-lib x2, 1.22.2, 1.22.2-dev, 1.22.2-lib x3
[U.]  #129  kservice                          6.27.0 -> 6.28.0
[U.]  #130  ktextwidgets                      6.27.0 -> 6.28.0
[U.]  #131  kwallet                           6.27.0 -> 6.28.0
[U.]  #132  kwidgetsaddons                    6.27.0 -> 6.28.0
[U.]  #133  kwindowsystem                     6.27.0 -> 6.28.0
[U.]  #134  kxmlgui                           6.27.0 -> 6.28.0
[C.]  #135  lame                              3.100-lib x2 -> 3.100-lib x3
[C.]  #136  lcms2                             2.17, 2.18 x2 -> 2.17, 2.18, 2.19.1 x2
[C.]  #137  ldns                              1.9.0 -> 1.9.0, 1.9.2
[C.]  #138  lerc                              4.0.0, 4.1.0 x2 -> 4.0.0, 4.1.0 x3, 4.1.0-dev
[U*]  #139  less                              692, 692-man -> 704, 704-man
[C.]  #140  libaom                            3.12.1 x2 -> 3.12.1 x3
[C.]  #141  libapparmor                       4.0.3, 4.1.7 x2 -> 4.0.3, 5.0.0 x2
[C.]  #142  libarchive                        3.7.7-lib, 3.8.7-lib x2 -> 3.7.7-lib, 3.8.8-lib x2
[C.]  #143  libass                            0.17.4 x2 -> 0.17.4 x3
[U.]  #144  libavif                           1.4.1 -> 1.4.2
[U.]  #145  libbacktrace                      0-unstable-2024-03-02 -> 0-unstable-2026-05-03
[C.]  #146  libbluray                         1.4.1 x2 -> 1.4.1 x3

_… diff truncated (725 lines total); see the `closure-diff-terangreal` artifact for the full output._

</details>

<details><summary><b>tuathaan</b></summary>

```
<<< result-old
>>> result-new
Version changes:
[C*]  #001  acl                               2.3.2 x4, 2.3.2-bin, 2.3.2-doc, 2.3.2-man -> 2.3.2 x5, 2.3.2-bin, 2.3.2-doc, 2.3.2-man
[C.]  #002  alsa-lib                          1.2.13, 1.2.15.3 x2 -> 1.2.13, 1.2.15.3, 1.2.16 x2
[C.]  #003  alsa-plugins                      1.2.12 -> 1.2.12 x2
[C.]  #004  alsa-topology-conf                1.2.5.1 x3 -> 1.2.5.1 x4
[C.]  #005  alsa-ucm-conf                     1.2.12, 1.2.15.3 x2 -> 1.2.12, 1.2.15.3, 1.2.16 x2
[U.]  #006  appstream                         1.1.2 -> 1.1.3
[U.]  #007  appstream-qt                      1.1.2 -> 1.1.3
[U.]  #008  astyle                            3.6.16 -> 3.6.17
[U.]  #009  attica                            6.27.0 -> 6.28.0
[C*]  #010  attr                              2.5.2 x4, 2.5.2-bin, 2.5.2-doc, 2.5.2-man -> 2.5.2 x5, 2.5.2-bin, 2.5.2-doc, 2.5.2-man
[C.]  #011  audit                             4.0.3-lib, 4.1.4-lib x2 -> 4.0.3-lib, 4.1.4-lib x3
[U.]  #012  aws-c-http                        0.10.4 -> 0.11.0
[U.]  #013  aws-c-io                          0.22.0 -> 0.27.2
[C.]  #014  bash                              5.2p37 x2, 5.3p9 x2 -> 5.2p37 x2, 5.3p9 x3
[C*]  #015  bash-interactive                  5.2p37 x2, 5.3p9, 5.3p9-doc, 5.3p9-info, 5.3p9-man -> 5.2p37 x2, 5.3p9 x2, 5.3p9-doc, 5.3p9-info, 5.3p9-man
[U.]  #016  bottom                            0.14.2, 0.14.2-fish-completions -> 0.14.4, 0.14.4-fish-completions
[U.]  #017  breeze-icons                      6.27.0, 6.27.0-dev -> 6.28.0, 6.28.0-dev
[C.]  #018  brotli                            1.1.0-lib x2, 1.2.0, 1.2.0-dev, 1.2.0-lib x2 -> 1.1.0-lib x2, 1.2.0, 1.2.0-dev, 1.2.0-lib x3
[C*]  #019  bzip2                             1.0.8 x4, 1.0.8-bin x2, 1.0.8-dev, 1.0.8-man -> 1.0.8 x5, 1.0.8-bin x2, 1.0.8-dev, 1.0.8-man
[U.]  #020  cage                              0.3.0 -> 0.3.1
[C.]  #021  cjson                             1.7.19 x2 -> 1.7.19 x3
[C.]  #022  coreutils                         9.6 x2, 9.11 x2 -> 9.6 x2, 9.11 x3
[U*]  #023  cpupower                          6.18.37, 6.18.37_fish-completions -> 6.18.38, 6.18.38_fish-completions
[C*]  #024  curl                              8.12.1 x2, 8.20.0 x2, 8.20.0-bin, 8.20.0-dev, 8.20.0-man -> 8.12.1 x2, 8.20.0, 8.21.0 x2, 8.21.0-bin, 8.21.0-dev, 8.21.0-man
[U.]  #025  dash                              0.5.13.3 -> 0.5.13.4
[C.]  #026  dav1d                             1.5.3 x2 -> 1.5.3 x3
[C.]  #027  db                                4.8.30 x3, 5.3.28 -> 4.8.30 x4, 5.3.28
[C*]  #028  dbus                              1, 1.14.10-lib, 1.16.2, 1.16.2-dev, 1.16.2-doc, 1.16.2-lib x2, 1.16.2-man -> 1, 1.14.10-lib, 1.16.2, 1.16.2-dev, 1.16.2-doc, 1.16.2-lib x3, 1.16.2-man
[C*]  #029  dconf                             0.40.0-lib, 0.49.0, 0.49.0_fish-completions, 0.49.0-lib x2 -> 0.40.0-lib, 0.49.0, 0.49.0_fish-completions, 0.49.0-lib x3
[C.]  #030  dejavu-fonts-minimal              2.37 x3 -> 2.37 x4
[U.]  #031  discord                           1.0.144, 1.0.144-fish-completions -> 1.0.146, 1.0.146-fish-completions
[U.]  #032  djvulibre                         3.5.29, 3.5.29-lib -> 3.5.30, 3.5.30-lib
[C.]  #033  dns-root-data                     2024-06-20, 2025-04-14 x2 -> 2024-06-20, 2025-04-14 x3
[U*]  #034  docker                            29.6.0 -> 29.6.1
[U.]  #035  docker-buildx                     0.31.1 -> 0.35.0
[U*]  #036  docker-compose                    5.2.0 -> 5.3.1
[U.]  #037  docker-containerd                 29.6.0 -> 29.6.1
[U.]  #038  docker-runc                       29.6.0 -> 29.6.1
[U.]  #039  docker-tini                       29.6.0 -> 29.6.1
[U.]  #040  double-conversion                 3.3.1, 3.3.1-dev -> 3.4.0, 3.4.0-dev
[U.]  #041  easyeffects                       8.2.5, 8.2.5-fish-completions -> 8.2.7, 8.2.7-fish-completions
[U.]  #042  elementary-icon-theme             8.2.0 -> 8.2.0-unstable-2026-07-06
[C.]  #043  elfutils                          0.192, 0.194 x2 -> 0.192, 0.195 x2
[U.]  #044  emacs-ghostel                     0.39.0-unstable-2026-06-26 -> 0.41.0-unstable-2026-07-06
[C.]  #045  expat                             2.6.4 x2, 2.8.1 x2, 2.8.1-dev -> 2.6.4 x2, 2.8.1, 2.8.2 x2, 2.8.2-dev
[U.]  #046  extra-cmake-modules               6.27.0 -> 6.28.0
[C.]  #047  ffmpeg                            7.1.5-data, 7.1.5-lib, 8.1.1-data, 8.1.1-lib -> 7.1.5-data, 7.1.5-lib, 8.1.1-data, 8.1.1-lib, 8.1.2-data, 8.1.2-lib
[U.]  #048  ffmpeg-headless                   8.1.1-data x2, 8.1.1-lib x2 -> 8.1.2-data x2, 8.1.2-lib x2
[C.]  #049  fftw-single                       3.3.11 x2 -> 3.3.11 x3
[C.]  #050  file                              5.46, 5.47 x2 -> 5.46, 5.48 x2
[C.]  #051  flac                              1.5.0 x2 -> 1.5.0 x3
[U.]  #052  fluidsynth                        2.5.3 -> 2.5.5
[C*]  #053  fontconfig                        2.16.0, 2.16.0-lib, 2.17.1 x2, 2.17.1-bin, 2.17.1-dev, 2.17.1_fish-completions, 2.17.1-lib x2 -> 2.16.0, 2.16.0-lib, 2.17.1, 2.17.1-lib, 2.18.1 x2, 2.18.1-bin, 2.18.1-dev, 2.18.1_fish-completions, 2.18.1-lib x2
[U.]  #054  frameworkintegration              6.27.0 -> 6.28.0
[C.]  #055  freetype                          2.13.3, 2.14.3 x2, 2.14.3-dev -> 2.13.3, 2.14.3 x3, 2.14.3-dev
[C.]  #056  fribidi                           1.0.16 x3, 1.0.16-dev -> 1.0.16 x4, 1.0.16-dev
[C*]  #057  fuse                              2.9.9-bin, 2.9.9-man, 3.17.4, 3.17.4-bin, 3.17.4-man -> 2.9.9-bin, 2.9.9-man, 3.18.2, 3.18.2-bin, 3.18.2-man
[U.]  #058  fzf                               0.73.1, 0.73.1-fish-completions, 0.73.1-man -> 0.74.0, 0.74.0-fish-completions, 0.74.0-man
[U.]  #059  game-music-emu                    0.6.4 -> 0.6.5
[C.]  #060  gcc                               14-20241116-lib x2, 14-20241116-libgcc x2, 15.2.0 x2, 15.2.0-lib x3, 15.2.0-libgcc x3, 16.1.0-lib, 16.1.0-libgcc -> 14-20241116-lib x2, 14-20241116-libgcc x2, 15.2.0 x2, 15.2.0-lib x4, 15.2.0-libgcc x4, 16.1.0-lib, 16.1.0-libgcc
[C.]  #061  gdbm                              1.24-lib, 1.26-lib x2 -> 1.24-lib, 1.26-lib x3
[C.]  #062  gdk-pixbuf                        2.42.12, 2.44.6, 2.44.6-dev -> 2.42.12, 2.44.6 x2, 2.44.6-dev
[U.]  #063  getopt-util-linux                 2.42 -> 2.42.2
[C.]  #064  gettext                           0.22.5, 1.0 -> 0.22.5, 1.0 x2
[U.]  #065  gh                                2.95.0, 2.95.0-fish-completions -> 2.96.0, 2.96.0-fish-completions
[C.]  #066  giflib                            5.2.2 x3 -> 5.2.2 x2, 6.1.3 x2
[C*]  #067  git                               2.54.0, 2.54.0-doc, 2.54.0_fish-completions x2 -> 2.54.0 x2, 2.54.0-doc x2, 2.54.0_fish-completions x2
[C.]  #068  glib                              2.82.5, 2.88.1 x2, 2.88.1-bin, 2.88.1-dev, 2.88.1-fish-completions -> 2.82.5, 2.88.1 x3, 2.88.1-bin, 2.88.1-dev, 2.88.1-fish-completions
[C*]  #069  glibc                             2.40-66 x2, 2.40-66-getent, 2.42-67 x2, 2.42-67-bin, 2.42-67-dev, 2.42-67-getent -> 2.40-66 x2, 2.40-66-getent, 2.42-67 x3, 2.42-67-bin, 2.42-67-dev, 2.42-67-getent
[U.]  #070  glslang                           16.2.0 -> 16.3.0
[C.]  #071  gmp-with-cxx                      6.3.0 x7, 6.3.0-dev -> 6.3.0 x9, 6.3.0-dev
[C*]  #072  gnugrep                           3.11 x2, 3.12, 3.12_fish-completions, 3.12-info -> 3.11 x2, 3.12 x2, 3.12_fish-completions, 3.12-info
[C*]  #073  gnused                            4.9 x2, 4.9_fish-completions, 4.9-info -> 4.9 x2, 4.10, 4.10_fish-completions, 4.10-info
[C.]  #074  gnutls                            3.8.9, 3.8.13 x2 -> 3.8.9, 3.8.13 x3
[U.]  #075  gpgme                             2.0.1 -> 2.1.0
[U.]  #076  gpgmepp                           2.0.0 -> 2.1.0
[C.]  #077  graphite2                         1.3.14 x3, 1.3.14-dev -> 1.3.14 x2, 1.3.15 x2, 1.3.15-dev
[U.]  #078  graphviz                          12.2.1 -> 14.1.2
[U.]  #079  grpc                              1.80.0 -> 1.81.0
[U.]  #080  gssdp                             1.6.4 -> 1.6.5
[U.]  #081  gst-libav                         1.26.11 -> 1.28.4
[U.]  #082  gst-plugins-bad                   1.26.11 -> 1.28.4
[U.]  #083  gst-plugins-base                  1.26.11 x2 -> 1.28.4 x2
[U.]  #084  gst-plugins-good                  1.26.11 -> 1.28.4
[U.]  #085  gstreamer                         1.26.11 x2 -> 1

_… PR body truncated to stay under GitHub's size limit; see the closure-diff-* artifacts for full diffs._\n