### PR TITLE
Auto update 2026-07-19

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -356,11 +356,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1783792734,
-        "narHash": "sha256-50rvY9GdFvpYDcMLcD/4cWSi0hVxArT5wsGlVsHy8eY=",
+        "lastModified": 1784310968,
+        "narHash": "sha256-rkSPTePrKqs4dg+i7ZFCq93+HrClac6oSwXX927SVjA=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "8efb4337e857949f4cfac86d12ef1066f417f31f",
+        "rev": "779c32a00155994c86cde8213a8dd4df139d4355",
         "type": "github"
       },
       "original": {
@@ -376,11 +376,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783823409,
-        "narHash": "sha256-OI4IkRjRXa1e7hYmCGJDPDq5H/kPwhsyoS80cNUF9fI=",
+        "lastModified": 1784407317,
+        "narHash": "sha256-iZrxHToDJWnvt+5LGAtvuQMTy1NZYlNEKbKaVtBJNcc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7566825d4652a1b885bd4ce65bd9e8def432fec9",
+        "rev": "39411a8e12a5526d992e65bc7e3dc9a4414d6713",
         "type": "github"
       },
       "original": {
@@ -490,11 +490,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782748876,
-        "narHash": "sha256-ODZh4jYjGieX2W15VAv/yIUnio74CnaDOe18X77tEwM=",
+        "lastModified": 1784196509,
+        "narHash": "sha256-9HGaGEH02u4Du65bqfY4tHKOzuzUVz3j4hm2XmUq+84=",
         "owner": "hyprwm",
         "repo": "hypridle",
-        "rev": "128dcfa96dfc9c90136c9a80c6e2443f8b54928c",
+        "rev": "ba40c0aa16a998c393167ed85de990dd8b6e1ccd",
         "type": "github"
       },
       "original": {
@@ -520,11 +520,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1783804259,
-        "narHash": "sha256-obiYHJlgNeugve/5CNHWdyHEvbyjEbHXWOeBZ3ZbqOI=",
+        "lastModified": 1784359482,
+        "narHash": "sha256-2EHBXr5rQ/wytZA3drczqyckSWsZ1C+5Kc815Pf0nys=",
         "owner": "hyprwm",
         "repo": "hyprland",
-        "rev": "824ed12c9d40a857bb5952b5b209d27d78e01d5b",
+        "rev": "55ce25bd67ab6f2ae7d60883f6c626be7d2ee12f",
         "type": "github"
       },
       "original": {
@@ -617,11 +617,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783772407,
-        "narHash": "sha256-7J/A/jatgo6jxtnALGbDgmJg1NEwDQmbojltzxtqsxE=",
+        "lastModified": 1784102347,
+        "narHash": "sha256-piRpwar7VZI3YviYo0a/UMFz9+rLesfv3nRLGKxjVGg=",
         "owner": "hyprwm",
         "repo": "hyprland-plugins",
-        "rev": "a2c77641bc80b749a9b02ebe6ff8dd6d727baee9",
+        "rev": "7644cecdb947060682891a0db2a0cdc5c0b9e704",
         "type": "github"
       },
       "original": {
@@ -981,11 +981,11 @@
     },
     "import-tree": {
       "locked": {
-        "lastModified": 1778781969,
-        "narHash": "sha256-Jjuz5CmSkur8KvLDoGa+vylEp+RkQtv4mt/qcMznpH0=",
+        "lastModified": 1784254960,
+        "narHash": "sha256-iI88R3wHz8wTKQb5orvpc51L/Xr64AJyxid/0MKa/b8=",
         "owner": "vic",
         "repo": "import-tree",
-        "rev": "d321337efd0f23a9eb14a42adb7b2c29313ab274",
+        "rev": "4ebb10ae17d5f1ad366e7aef5b92cb8eecf24f69",
         "type": "github"
       },
       "original": {
@@ -1229,11 +1229,11 @@
     },
     "nixpkgs_10": {
       "locked": {
-        "lastModified": 1783776592,
-        "narHash": "sha256-UgCQzxeWI75XM8G+hPrPh+MKzEPjG3SpAj7dtqSbksA=",
+        "lastModified": 1784356753,
+        "narHash": "sha256-12KrbMiWLcf8m7pCvAtZh1ZrgF85ZXDXvfR/fWTKy84=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e7a3ca8092b61ff85b6a45bf863ea2b2d6a661b3",
+        "rev": "61b7c44c4073f0b827768aff0049561b5110ea5a",
         "type": "github"
       },
       "original": {
@@ -1370,11 +1370,11 @@
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1783776592,
-        "narHash": "sha256-UgCQzxeWI75XM8G+hPrPh+MKzEPjG3SpAj7dtqSbksA=",
+        "lastModified": 1784356753,
+        "narHash": "sha256-12KrbMiWLcf8m7pCvAtZh1ZrgF85ZXDXvfR/fWTKy84=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e7a3ca8092b61ff85b6a45bf863ea2b2d6a661b3",
+        "rev": "61b7c44c4073f0b827768aff0049561b5110ea5a",
         "type": "github"
       },
       "original": {
@@ -1390,11 +1390,11 @@
         "nixpkgs": "nixpkgs_10"
       },
       "locked": {
-        "lastModified": 1783853070,
-        "narHash": "sha256-5U21SX1++/e9+sSmtvSs7Fmi7x2mU1eoW6hcCkr8kmk=",
+        "lastModified": 1784438123,
+        "narHash": "sha256-Ljf1xtOMZrdc5wn65u7A015/ZMTn9pJ0D50rQlLy+g0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d5c692909b88dd5ff24676f5d7e29fb5ef5f200e",
+        "rev": "e871d24b96c3832766f4cd0cb70597a955ea0f64",
         "type": "github"
       },
       "original": {
@@ -1516,11 +1516,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783008725,
-        "narHash": "sha256-jGiy6+sxjNWXSjp25uoJuNfyH9zBK1PEDY0lVoL4ibQ=",
+        "lastModified": 1784288435,
+        "narHash": "sha256-ReRHaLgr/uVqdD8afFSn+myXIfpHeOhP0yYe0TJqAA8=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "bca82caa46d5ec0f5d422c61fb1e30bc51313cbe",
+        "rev": "43b3c1ab9d40fb1dbb008f451988a91e375825e9",
         "type": "github"
       },
       "original": {
@@ -1708,11 +1708,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783668749,
-        "narHash": "sha256-EDJjJYGT5pQKTBqmz+OA2sqE20kjj6mP699JFGDzse4=",
+        "lastModified": 1784354557,
+        "narHash": "sha256-z2XthIV/68GNghbqmaPVrShPIfMPwpZKTA47REKC5bA=",
         "owner": "youwen5",
         "repo": "zen-browser-flake",
-        "rev": "e8041a3571e8cadb57dc18a3d6362d753510b94a",
+        "rev": "239dc504b56eabcfc1dce945e7e22ca99694be89",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automatic flake update on 2026-07-19.

Review the per-host package changes below before merging.

## Input changes

```
unpacking 'github:nix-community/disko/de5708739256238fb912c62f03988815db89ec9a' into the Git cache...
unpacking 'github:Gako358/emacs-flake/97795f5999cb7c5634662c554ba2cbd4fb0d1cea' into the Git cache...
unpacking 'github:hercules-ci/flake-parts/17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e' into the Git cache...
unpacking 'github:nixos/nixos-hardware/779c32a00155994c86cde8213a8dd4df139d4355' into the Git cache...
unpacking 'github:nix-community/home-manager/39411a8e12a5526d992e65bc7e3dc9a4414d6713' into the Git cache...
unpacking 'github:hyprwm/hypridle/ba40c0aa16a998c393167ed85de990dd8b6e1ccd' into the Git cache...
unpacking 'github:hyprwm/hyprland/55ce25bd67ab6f2ae7d60883f6c626be7d2ee12f' into the Git cache...
unpacking 'github:hyprwm/contrib/3dcbce715ae8b93107fa8632db15bf976862a573' into the Git cache...
unpacking 'github:hyprwm/hyprland-plugins/7644cecdb947060682891a0db2a0cdc5c0b9e704' into the Git cache...
unpacking 'github:hyprwm/hyprpaper/c011bd20886ea3301474e77d7fa4d22ab013ece0' into the Git cache...
unpacking 'github:nix-community/impermanence/7b1d382faf603b6d264f58627330f9faa5cba149' into the Git cache...
unpacking 'github:vic/import-tree/4ebb10ae17d5f1ad366e7aef5b92cb8eecf24f69' into the Git cache...
unpacking 'github:nix-community/lanzaboote/6183ac79eadb079a1e72fa2c60915601be669100' into the Git cache...
unpacking 'github:misterio77/nix-colors/b01f024090d2c4fc3152cd0cf12027a7b8453ba1' into the Git cache...
unpacking 'github:nixos/nixpkgs/61b7c44c4073f0b827768aff0049561b5110ea5a' into the Git cache...
unpacking 'github:nix-community/NUR/e871d24b96c3832766f4cd0cb70597a955ea0f64' into the Git cache...
unpacking 'github:nix-community/plasma-manager/c551f0687658e4bb699cfff6015436ad7ee57a0d' into the Git cache...
unpacking 'github:cachix/pre-commit-hooks.nix/43b3c1ab9d40fb1dbb008f451988a91e375825e9' into the Git cache...
unpacking 'github:gako358/scram/133f9daca96d9961f60bfe86ee8da66ce076fb0a' into the Git cache...
unpacking 'github:Mic92/sops-nix/f1406619a3884cd5c47992a70b8b35c9c0fcb4c9' into the Git cache...
unpacking 'github:youwen5/zen-browser-flake/239dc504b56eabcfc1dce945e7e22ca99694be89' into the Git cache...
warning: updating lock file "/home/runner/work/dotfiles/dotfiles/flake.lock":
• Updated input 'hardware':
    'github:nixos/nixos-hardware/8efb4337e857949f4cfac86d12ef1066f417f31f?narHash=sha256-50rvY9GdFvpYDcMLcD/4cWSi0hVxArT5wsGlVsHy8eY%3D' (2026-07-11)
  → 'github:nixos/nixos-hardware/779c32a00155994c86cde8213a8dd4df139d4355?narHash=sha256-rkSPTePrKqs4dg%2Bi7ZFCq93%2BHrClac6oSwXX927SVjA%3D' (2026-07-17)
• Updated input 'home-manager':
    'github:nix-community/home-manager/7566825d4652a1b885bd4ce65bd9e8def432fec9?narHash=sha256-OI4IkRjRXa1e7hYmCGJDPDq5H/kPwhsyoS80cNUF9fI%3D' (2026-07-12)
  → 'github:nix-community/home-manager/39411a8e12a5526d992e65bc7e3dc9a4414d6713?narHash=sha256-iZrxHToDJWnvt%2B5LGAtvuQMTy1NZYlNEKbKaVtBJNcc%3D' (2026-07-18)
• Updated input 'hypridle':
    'github:hyprwm/hypridle/128dcfa96dfc9c90136c9a80c6e2443f8b54928c?narHash=sha256-ODZh4jYjGieX2W15VAv/yIUnio74CnaDOe18X77tEwM%3D' (2026-06-29)
  → 'github:hyprwm/hypridle/ba40c0aa16a998c393167ed85de990dd8b6e1ccd?narHash=sha256-9HGaGEH02u4Du65bqfY4tHKOzuzUVz3j4hm2XmUq%2B84%3D' (2026-07-16)
• Updated input 'hyprland':
    'github:hyprwm/hyprland/824ed12c9d40a857bb5952b5b209d27d78e01d5b?narHash=sha256-obiYHJlgNeugve/5CNHWdyHEvbyjEbHXWOeBZ3ZbqOI%3D' (2026-07-11)
  → 'github:hyprwm/hyprland/55ce25bd67ab6f2ae7d60883f6c626be7d2ee12f?narHash=sha256-2EHBXr5rQ/wytZA3drczqyckSWsZ1C%2B5Kc815Pf0nys%3D' (2026-07-18)
• Updated input 'hyprland-plugins':
    'github:hyprwm/hyprland-plugins/a2c77641bc80b749a9b02ebe6ff8dd6d727baee9?narHash=sha256-7J/A/jatgo6jxtnALGbDgmJg1NEwDQmbojltzxtqsxE%3D' (2026-07-11)
  → 'github:hyprwm/hyprland-plugins/7644cecdb947060682891a0db2a0cdc5c0b9e704?narHash=sha256-piRpwar7VZI3YviYo0a/UMFz9%2BrLesfv3nRLGKxjVGg%3D' (2026-07-15)
• Updated input 'import-tree':
    'github:vic/import-tree/d321337efd0f23a9eb14a42adb7b2c29313ab274?narHash=sha256-Jjuz5CmSkur8KvLDoGa%2BvylEp%2BRkQtv4mt/qcMznpH0%3D' (2026-05-14)
  → 'github:vic/import-tree/4ebb10ae17d5f1ad366e7aef5b92cb8eecf24f69?narHash=sha256-iI88R3wHz8wTKQb5orvpc51L/Xr64AJyxid/0MKa/b8%3D' (2026-07-17)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/e7a3ca8092b61ff85b6a45bf863ea2b2d6a661b3?narHash=sha256-UgCQzxeWI75XM8G%2BhPrPh%2BMKzEPjG3SpAj7dtqSbksA%3D' (2026-07-11)
  → 'github:nixos/nixpkgs/61b7c44c4073f0b827768aff0049561b5110ea5a?narHash=sha256-12KrbMiWLcf8m7pCvAtZh1ZrgF85ZXDXvfR/fWTKy84%3D' (2026-07-18)
• Updated input 'nur':
    'github:nix-community/NUR/d5c692909b88dd5ff24676f5d7e29fb5ef5f200e?narHash=sha256-5U21SX1%2B%2B/e9%2BsSmtvSs7Fmi7x2mU1eoW6hcCkr8kmk%3D' (2026-07-12)
  → 'github:nix-community/NUR/e871d24b96c3832766f4cd0cb70597a955ea0f64?narHash=sha256-Ljf1xtOMZrdc5wn65u7A015/ZMTn9pJ0D50rQlLy%2Bg0%3D' (2026-07-19)
• Updated input 'nur/nixpkgs':
    'github:nixos/nixpkgs/e7a3ca8092b61ff85b6a45bf863ea2b2d6a661b3?narHash=sha256-UgCQzxeWI75XM8G%2BhPrPh%2BMKzEPjG3SpAj7dtqSbksA%3D' (2026-07-11)
  → 'github:nixos/nixpkgs/61b7c44c4073f0b827768aff0049561b5110ea5a?narHash=sha256-12KrbMiWLcf8m7pCvAtZh1ZrgF85ZXDXvfR/fWTKy84%3D' (2026-07-18)
• Updated input 'pre-commit-hooks-nix':
    'github:cachix/pre-commit-hooks.nix/bca82caa46d5ec0f5d422c61fb1e30bc51313cbe?narHash=sha256-jGiy6%2BsxjNWXSjp25uoJuNfyH9zBK1PEDY0lVoL4ibQ%3D' (2026-07-02)
  → 'github:cachix/pre-commit-hooks.nix/43b3c1ab9d40fb1dbb008f451988a91e375825e9?narHash=sha256-ReRHaLgr/uVqdD8afFSn%2BmyXIfpHeOhP0yYe0TJqAA8%3D' (2026-07-17)
• Updated input 'zen-browser':
    'github:youwen5/zen-browser-flake/e8041a3571e8cadb57dc18a3d6362d753510b94a?narHash=sha256-EDJjJYGT5pQKTBqmz%2BOA2sqE20kjj6mP699JFGDzse4%3D' (2026-07-10)
  → 'github:youwen5/zen-browser-flake/239dc504b56eabcfc1dce945e7e22ca99694be89?narHash=sha256-z2XthIV/68GNghbqmaPVrShPIfMPwpZKTA47REKC5bA%3D' (2026-07-18)
```

## Per-host package diff

<details><summary><b>aanallein</b></summary>

```
<<< result-old
>>> result-new
Version changes:
[U.]  #1  broot                   1.57.0, 1.57.0-fish-completions -> 1.58.0, 1.58.0-fish-completions
[U.]  #2  eza                     0.23.4, 0.23.4-fish-completions, 0.23.4-man -> 0.23.5, 0.23.5-fish-completions, 0.23.5-man
[U*]  #3  fish                    4.8.0, 4.8.0-doc, 4.8.0-fish-completions x2 -> 4.8.1, 4.8.1-doc, 4.8.1_fish-completions x2
[U.]  #4  mesa                    26.1.4 x2 -> 26.1.5 x2
[U.]  #5  nix-index               0.1.10 x2, 0.1.10-fish-completions -> 0.1.11 x2, 0.1.11-fish-completions
[U.]  #6  nixos-system-aanallein  26.11.20260711.e7a3ca8 -> 26.11.20260718.61b7c44
[U.]  #7  ouch                    0.8.0, 0.8.0-fish-completions -> 0.8.1, 0.8.1-fish-completions
[U.]  #8  rage                    0.11.2, 0.11.2-fish-completions -> 0.12.1, 0.12.1-fish-completions
[U.]  #9  ripgrep                 15.1.0, 15.1.0-fish-completions -> 15.2.0, 15.2.0-fish-completions
Removed packages:
[R.]  #1  libidn  1.44
Closure size: 1842 -> 1841 (215 paths added, 216 paths removed, delta -1, disk usage +2.4MiB).
```

</details>

<details><summary><b>rhuidean</b></summary>

```
<<< result-old
>>> result-new
Version changes:
[U*]  #01  accountsservice        26.13.3 -> 26.27.3
[U.]  #02  breeze                 6.7.2 -> 6.7.3
[U.]  #03  broot                  1.57.0, 1.57.0-fish-completions -> 1.58.0, 1.58.0-fish-completions
[U.]  #04  eza                    0.23.4, 0.23.4-fish-completions, 0.23.4-man -> 0.23.5, 0.23.5-fish-completions, 0.23.5-man
[U*]  #05  fish                   4.8.0, 4.8.0-doc, 4.8.0-fish-completions x2 -> 4.8.1, 4.8.1-doc, 4.8.1_fish-completions x2
[U.]  #06  freerdp                3.27.1 -> 3.29.0
[U.]  #07  kdecoration            6.7.2 -> 6.7.3
[U.]  #08  kirigami-addons        1.12.1 -> 1.13.0
[C.]  #09  libidn                 1.44 x2, 1.44-bin -> 1.44, 1.44-bin
[U.]  #10  liblouis               3.33.0 -> 3.38.0
[U.]  #11  libphonenumber         9.0.34 -> 9.0.35
[U.]  #12  libxmp                 4.7.0 -> 4.7.1
[U.]  #13  mesa                   26.1.4 x2 -> 26.1.5 x2
[U.]  #14  nix-index              0.1.10 x2, 0.1.10-fish-completions -> 0.1.11 x2, 0.1.11-fish-completions
[U.]  #15  nixos-system-rhuidean  26.11.20260711.e7a3ca8 -> 26.11.20260718.61b7c44
[U.]  #16  ntfs3g                 2026.2.25 -> 2026.7.7
[U.]  #17  ouch                   0.8.0, 0.8.0-fish-completions -> 0.8.1, 0.8.1-fish-completions
[U.]  #18  proton-pass            1.36.1, 1.36.1-fish-completions -> 1.38.0, 1.38.0-fish-completions
[U.]  #19  rage                   0.11.2, 0.11.2-fish-completions -> 0.12.1, 0.12.1-fish-completions
[U.]  #20  ripgrep                15.1.0, 15.1.0-fish-completions -> 15.2.0, 15.2.0-fish-completions
[U*]  #21  steam                  1.0.0.85, 1.0.0.85-bwrap, 1.0.0.85-fhsenv-profile, 1.0.0.85-fhsenv-rootfs, 1.0.0.85-init -> 1.0.0.87, 1.0.0.87-bwrap, 1.0.0.87-fhsenv-profile, 1.0.0.87-fhsenv-rootfs, 1.0.0.87-init
[C*]  #22  steam-run              <none>, 1.0.0.85 x2, 1.0.0.85-bwrap x2, 1.0.0.85-fhsenv-profile x2, 1.0.0.85-fhsenv-rootfs x2, 1.0.0.85-init -> <none>, 1.0.0.87 x2, 1.0.0.87-bwrap x2, 1.0.0.87-fhsenv-profile x2, 1.0.0.87-fhsenv-rootfs x2, 1.0.0.87-init
[U.]  #23  steam-unwrapped        1.0.0.85 -> 1.0.0.87
[U*]  #24  xsetroot               1.1.3, 1.1.3_fish-completions -> 1.1.4, 1.1.4_fish-completions
[U.]  #25  zen-browser            1.21.6b, 1.21.6b-fish-completions -> 1.21.8b, 1.21.8b-fish-completions
[U.]  #26  zen-browser-unwrapped  1.21.6b -> 1.21.8b
Closure size: 2678 -> 2677 (392 paths added, 393 paths removed, delta -1, disk usage -2.1MiB).
```

</details>

<details><summary><b>tanchico</b></summary>

```
<<< result-old
>>> result-new
Version changes:
[U*]  #01  accountsservice        26.13.3 -> 26.27.3
[U.]  #02  breeze                 6.7.2 -> 6.7.3
[U.]  #03  broot                  1.57.0, 1.57.0-fish-completions -> 1.58.0, 1.58.0-fish-completions
[U.]  #04  eza                    0.23.4, 0.23.4-fish-completions, 0.23.4-man -> 0.23.5, 0.23.5-fish-completions, 0.23.5-man
[U*]  #05  fish                   4.8.0, 4.8.0-doc, 4.8.0-fish-completions x2 -> 4.8.1, 4.8.1-doc, 4.8.1_fish-completions x2
[U.]  #06  freerdp                3.27.1 -> 3.29.0
[U.]  #07  kdecoration            6.7.2 -> 6.7.3
[U.]  #08  kirigami-addons        1.12.1 -> 1.13.0
[C.]  #09  libidn                 1.44 x2, 1.44-bin -> 1.44, 1.44-bin
[U.]  #10  liblouis               3.33.0 -> 3.38.0
[U.]  #11  libphonenumber         9.0.34 -> 9.0.35
[U.]  #12  libxmp                 4.7.0 -> 4.7.1
[U.]  #13  mesa                   26.1.4 x2 -> 26.1.5 x2
[U.]  #14  nix-index              0.1.10 x2, 0.1.10-fish-completions -> 0.1.11 x2, 0.1.11-fish-completions
[U.]  #15  nixos-system-tanchico  26.11.20260711.e7a3ca8 -> 26.11.20260718.61b7c44
[U.]  #16  ntfs3g                 2026.2.25 -> 2026.7.7
[U.]  #17  ouch                   0.8.0, 0.8.0-fish-completions -> 0.8.1, 0.8.1-fish-completions
[U.]  #18  proton-pass            1.36.1, 1.36.1-fish-completions -> 1.38.0, 1.38.0-fish-completions
[U.]  #19  rage                   0.11.2, 0.11.2-fish-completions -> 0.12.1, 0.12.1-fish-completions
[U.]  #20  ripgrep                15.1.0, 15.1.0-fish-completions -> 15.2.0, 15.2.0-fish-completions
[U*]  #21  steam                  1.0.0.85, 1.0.0.85-bwrap, 1.0.0.85-fhsenv-profile, 1.0.0.85-fhsenv-rootfs, 1.0.0.85-init -> 1.0.0.87, 1.0.0.87-bwrap, 1.0.0.87-fhsenv-profile, 1.0.0.87-fhsenv-rootfs, 1.0.0.87-init
[C*]  #22  steam-run              <none>, 1.0.0.85 x2, 1.0.0.85-bwrap x2, 1.0.0.85-fhsenv-profile x2, 1.0.0.85-fhsenv-rootfs x2, 1.0.0.85-init -> <none>, 1.0.0.87 x2, 1.0.0.87-bwrap x2, 1.0.0.87-fhsenv-profile x2, 1.0.0.87-fhsenv-rootfs x2, 1.0.0.87-init
[U.]  #23  steam-unwrapped        1.0.0.85 -> 1.0.0.87
[U*]  #24  xsetroot               1.1.3, 1.1.3_fish-completions -> 1.1.4, 1.1.4_fish-completions
[U.]  #25  zen-browser            1.21.6b, 1.21.6b-fish-completions -> 1.21.8b, 1.21.8b-fish-completions
[U.]  #26  zen-browser-unwrapped  1.21.6b -> 1.21.8b
Closure size: 2675 -> 2674 (391 paths added, 392 paths removed, delta -1, disk usage -2.4MiB).
```

</details>

<details><summary><b>terangreal</b></summary>

```
<<< result-old
>>> result-new
Version changes:
[U*]  #01  accountsservice          26.13.3 -> 26.27.3
[U.]  #02  breeze                   6.7.2 -> 6.7.3
[U.]  #03  broot                    1.57.0, 1.57.0-fish-completions -> 1.58.0, 1.58.0-fish-completions
[U.]  #04  cloud-hypervisor         52.0 -> 53.0
[U.]  #05  eza                      0.23.4, 0.23.4-fish-completions, 0.23.4-man -> 0.23.5, 0.23.5-fish-completions, 0.23.5-man
[U*]  #06  fish                     4.8.0, 4.8.0-doc, 4.8.0-fish-completions x2 -> 4.8.1, 4.8.1-doc, 4.8.1_fish-completions x2
[U.]  #07  hypridle                 0.1.7+date=2026-06-29_128dcfa -> 0.1.7+date=2026-07-16_ba40c0a
[C*]  #08  hyprland                 0.55.0+date=2026-07-11_824ed12, 0.55.0+date=2026-07-11_824ed12-man, 0.55.4 -> 0.55.0+date=2026-07-18_55ce25b, 0.55.0+date=2026-07-18_55ce25b-man, 0.55.4
[U.]  #09  kdecoration              6.7.2 -> 6.7.3
[U.]  #10  kirigami-addons          1.12.1 -> 1.13.0
[C.]  #11  libei                    1.6.0 -> 1.6.0 x2
[U.]  #12  libphonenumber           9.0.34 -> 9.0.35
[U.]  #13  mesa                     26.1.4 x2 -> 26.1.5 x2
[U.]  #14  multipath-tools          0.14.1 -> 0.14.3
[U.]  #15  nix-index                0.1.10 x2, 0.1.10-fish-completions -> 0.1.11 x2, 0.1.11-fish-completions
[U.]  #16  nixos-system-terangreal  26.11.20260711.e7a3ca8 -> 26.11.20260718.61b7c44
[U.]  #17  ntfs3g                   2026.2.25 -> 2026.7.7
[U.]  #18  ouch                     0.8.0, 0.8.0-fish-completions -> 0.8.1, 0.8.1-fish-completions
[U.]  #19  proton-pass              1.36.1, 1.36.1-fish-completions -> 1.38.0, 1.38.0-fish-completions
[U.]  #20  python3.14-httplib2      0.31.1 -> 0.32.0
[U.]  #21  rage                     0.11.2, 0.11.2-fish-completions -> 0.12.1, 0.12.1-fish-completions
[U.]  #22  ripgrep                  15.1.0, 15.1.0-fish-completions -> 15.2.0, 15.2.0-fish-completions
[U.]  #23  vue-language-server      3.3.6 -> 3.3.7
[U.]  #24  zen-browser              1.21.6b, 1.21.6b-fish-completions -> 1.21.8b, 1.21.8b-fish-completions
[U.]  #25  zen-browser-unwrapped    1.21.6b -> 1.21.8b
Closure size: 3010 -> 3011 (373 paths added, 372 paths removed, delta +1, disk usage +1.5MiB).
```

</details>

<details><summary><b>tuathaan</b></summary>

```
<<< result-old
>>> result-new
Version changes:
[U*]  #01  accountsservice        26.13.3 -> 26.27.3
[U.]  #02  breeze                 6.7.2 -> 6.7.3
[U.]  #03  broot                  1.57.0, 1.57.0-fish-completions -> 1.58.0, 1.58.0-fish-completions
[U.]  #04  eza                    0.23.4, 0.23.4-fish-completions, 0.23.4-man -> 0.23.5, 0.23.5-fish-completions, 0.23.5-man
[U*]  #05  fish                   4.8.0, 4.8.0-doc, 4.8.0-fish-completions x2 -> 4.8.1, 4.8.1-doc, 4.8.1_fish-completions x2
[U.]  #06  hypridle               0.1.7+date=2026-06-29_128dcfa -> 0.1.7+date=2026-07-16_ba40c0a
[C*]  #07  hyprland               0.55.0+date=2026-07-11_824ed12, 0.55.0+date=2026-07-11_824ed12-man, 0.55.4 -> 0.55.0+date=2026-07-18_55ce25b, 0.55.0+date=2026-07-18_55ce25b-man, 0.55.4
[U.]  #08  kdecoration            6.7.2 -> 6.7.3
[U.]  #09  kirigami-addons        1.12.1 -> 1.13.0
[C.]  #10  libei                  1.6.0 -> 1.6.0 x2
[U.]  #11  libphonenumber         9.0.34 -> 9.0.35
[U.]  #12  mesa                   26.1.4 x2 -> 26.1.5 x2
[U.]  #13  nix-index              0.1.10 x2, 0.1.10-fish-completions -> 0.1.11 x2, 0.1.11-fish-completions
[U.]  #14  nixos-system-tuathaan  26.11.20260711.e7a3ca8 -> 26.11.20260718.61b7c44
[U.]  #15  ntfs3g                 2026.2.25 -> 2026.7.7
[U.]  #16  ouch                   0.8.0, 0.8.0-fish-completions -> 0.8.1, 0.8.1-fish-completions
[U.]  #17  proton-pass            1.36.1, 1.36.1-fish-completions -> 1.38.0, 1.38.0-fish-completions
[U.]  #18  python3.14-httplib2    0.31.1 -> 0.32.0
[U.]  #19  rage                   0.11.2, 0.11.2-fish-completions -> 0.12.1, 0.12.1-fish-completions
[U.]  #20  ripgrep                15.1.0, 15.1.0-fish-completions -> 15.2.0, 15.2.0-fish-completions
[U.]  #21  vue-language-server    3.3.6 -> 3.3.7
[U.]  #22  zen-browser            1.21.6b, 1.21.6b-fish-completions -> 1.21.8b, 1.21.8b-fish-completions
[U.]  #23  zen-browser-unwrapped  1.21.6b -> 1.21.8b
Closure size: 2941 -> 2942 (348 paths added, 347 paths removed, delta +1, disk usage -1.9MiB).
```

</details>

