### PR TITLE
Auto update 2026-08-02

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784368054,
-        "narHash": "sha256-zF1iJkBQSDWmRO4/LEeHR1SpKY0lqZaxkoQJpPS9K9U=",
+        "lastModified": 1785330427,
+        "narHash": "sha256-RTKedehLwWxGblFY5Nop3T08EGKH1T+4zmDTddmZ8k4=",
         "owner": "hyprwm",
         "repo": "aquamarine",
-        "rev": "9b5f14d9483445e766294eb8fbe0b8f370269ed0",
+        "rev": "fc39af0ccec9171aec8185eaea8afb71a46eff90",
         "type": "github"
       },
       "original": {
@@ -67,11 +67,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1784407669,
-        "narHash": "sha256-gcFMcRjw0ZSn380Rx2QLlU1goUQeSrKX/DF12omI6+o=",
+        "lastModified": 1784564969,
+        "narHash": "sha256-TkTWNhJV/8Wk3czlbz4bwHZkFCaCHPsOy+oJe4PUiXg=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "1316b7d278ad77a16aec024b71d971366e123bec",
+        "rev": "7930f6c291de6f83c257839d434592aa085f290a",
         "type": "github"
       },
       "original": {
@@ -111,11 +111,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785146295,
-        "narHash": "sha256-29mddy9NFz8/ePgZV2zwRV9vrYt6bKXX0/9+CBK+tNw=",
+        "lastModified": 1785563007,
+        "narHash": "sha256-00cOL/2oPEnSnmRK4yarCdUTBeFglwjhozeCC8MhJvY=",
         "owner": "Gako358",
         "repo": "emacs-flake",
-        "rev": "3eac795c811c52509465605a164810122322945c",
+        "rev": "b1fb553b01afaa7e5f6af10f7cc74ea8902b6635",
         "type": "github"
       },
       "original": {
@@ -261,11 +261,11 @@
         "nixpkgs-lib": "nixpkgs-lib_3"
       },
       "locked": {
-        "lastModified": 1782949081,
-        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
+        "lastModified": 1785627969,
+        "narHash": "sha256-4dtXQk/NMePegK/nWp5NSeuZKLATItOq61lpEvmXqGw=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
+        "rev": "427bf4bd9435fdf21321c8cc628c24efc14c0f7a",
         "type": "github"
       },
       "original": {
@@ -372,11 +372,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1784723954,
-        "narHash": "sha256-1CfD8ZUjCkTgjsneLZ/lxCHhgDfqxxE7/GX0MmsgiqA=",
+        "lastModified": 1785232496,
+        "narHash": "sha256-65EQYIRRpTdpH8lUiB6Mvo5uBkG60aBIzAJuALfx+O0=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "a017f5b72210026af5b3ac5949f08d94380a6fbd",
+        "rev": "2e790b0a6be8ec2b76174ac0931b8ff11919ec98",
         "type": "github"
       },
       "original": {
@@ -392,11 +392,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785119578,
-        "narHash": "sha256-3VMVuOJ6fK+RNOXVmqusqUwQ1sDfPeddNKaM2JR/4Y0=",
+        "lastModified": 1785531816,
+        "narHash": "sha256-vkMnV0JIyw+g/NmcfoajlGaAO+9a0ezia+FZohQJrik=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e83dffa86cccb6237fe194d4eeb47f41557749d1",
+        "rev": "bf9ce9fec78f95f374e8dd3b503863a3ec128ebe",
         "type": "github"
       },
       "original": {
@@ -536,11 +536,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1785081751,
-        "narHash": "sha256-0vZbjVqutPmzfAQjNv9QJ/GhvTaeCG+Hh6gfyBNU/s8=",
+        "lastModified": 1785600170,
+        "narHash": "sha256-FUYhESvUq9i4/VtGGr75w3nb3LA8qPKXG4Vs7+IjYD0=",
         "owner": "hyprwm",
         "repo": "hyprland",
-        "rev": "d8dc50309c551cfa44fee70744397311b8b7c5fc",
+        "rev": "88c6386994c960006e14c7bfa4ccfee873252882",
         "type": "github"
       },
       "original": {
@@ -603,11 +603,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784196523,
-        "narHash": "sha256-ahtKMGXFJdlQNhatQm1+BBU/pGfGYnAqQt3vWvq4p8s=",
+        "lastModified": 1784533903,
+        "narHash": "sha256-Ee78BRFi+MrmgHmmW+2dZUEI1R3cssEzza0ar3fsNX8=",
         "owner": "hyprwm",
         "repo": "hyprland-guiutils",
-        "rev": "a6ccb6cb112ed5a244c0191fb972347ecfa893e0",
+        "rev": "a16ad89ed5fb4192c966018a80c652de8d96f748",
         "type": "github"
       },
       "original": {
@@ -884,11 +884,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784323413,
-        "narHash": "sha256-XnAVV+H4f8Xdv0yZcSwJ5kCjLyE8fHxPeLX6a3HSrAU=",
+        "lastModified": 1784458610,
+        "narHash": "sha256-A9Gb5wW2vMkYEec7DyCOBpEM6LwwpmQ/TIXEHhGgHUY=",
         "owner": "hyprwm",
         "repo": "hyprutils",
-        "rev": "5f03477ab3a005ff27c527486f551883535aea2f",
+        "rev": "83da5ee98d806cef2d05a1072b8d8b832bf52891",
         "type": "github"
       },
       "original": {
@@ -963,11 +963,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778410714,
-        "narHash": "sha256-o6RzFj4nJXaPRY7EM01siuCQeT41RfwwmcmFQqwFJJg=",
+        "lastModified": 1784465130,
+        "narHash": "sha256-ak5fWEmWZyax8trkV4aphdvjrbUiSyl6qS+y5GwBS7Y=",
         "owner": "hyprwm",
         "repo": "hyprwire",
-        "rev": "85148a8e612808cf5ddb25d0b3c5840f3498a7dc",
+        "rev": "7d935bb54674aa0fbd327d2a6888bd0630079ed0",
         "type": "github"
       },
       "original": {
@@ -1061,11 +1061,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1784568171,
-        "narHash": "sha256-t17AqLEhPG6m27ipkp8mJd8Ug0XkdANFDVsgyIFBZcQ=",
+        "lastModified": 1785452604,
+        "narHash": "sha256-d0NKOOtI90kk8DAXNDkgYUZD8KK908bczz6zNLTC/zw=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "f4b0aef3dba28677a5ca4b3416827aade60b5a0b",
+        "rev": "c191775376b8734af02970153b4e5d86841dff19",
         "type": "github"
       },
       "original": {
@@ -1185,11 +1185,11 @@
     },
     "nixpkgs-lib_3": {
       "locked": {
-        "lastModified": 1782614948,
-        "narHash": "sha256-ePjCwr1sNm9NYUqywL7QfK3JnlS015msC+eBu2zKlp8=",
+        "lastModified": 1785031560,
+        "narHash": "sha256-OmshNvn2vupOFpYinLUu+1Dnpu4n7Q5N3ggGVNHpkUI=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "db3f255737b94216eb71cce308e2912cf6bc2d7c",
+        "rev": "0e79af5e3d4dcfcd676ab5ba3f95d2e3352e078c",
         "type": "github"
       },
       "original": {
@@ -1260,11 +1260,11 @@
     },
     "nixpkgs_10": {
       "locked": {
-        "lastModified": 1785090369,
-        "narHash": "sha256-m0pDuRJG7EDo9ri+4Ksu83VsI+PlxNC9lNBfydejce4=",
+        "lastModified": 1785571196,
+        "narHash": "sha256-KoTsyMQqnXQZq8deCEnu4QkyldkwH/bpMMhUcfMdGIw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "624af665418d3c65d544145b4d34ad696439570e",
+        "rev": "148bab9c1c3c53136ecb44a6ea356a0ed5b39b06",
         "type": "github"
       },
       "original": {
@@ -1305,11 +1305,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1784356753,
-        "narHash": "sha256-12KrbMiWLcf8m7pCvAtZh1ZrgF85ZXDXvfR/fWTKy84=",
+        "lastModified": 1785454630,
+        "narHash": "sha256-LQy14TZp77TwbQf40gg1V3jo8FwJG0jGDkAH+zRHqg8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "61b7c44c4073f0b827768aff0049561b5110ea5a",
+        "rev": "1559d3daa3ecc813a650b79375ea61b6741b8746",
         "type": "github"
       },
       "original": {
@@ -1401,11 +1401,11 @@
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1785090369,
-        "narHash": "sha256-m0pDuRJG7EDo9ri+4Ksu83VsI+PlxNC9lNBfydejce4=",
+        "lastModified": 1785571196,
+        "narHash": "sha256-KoTsyMQqnXQZq8deCEnu4QkyldkwH/bpMMhUcfMdGIw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "624af665418d3c65d544145b4d34ad696439570e",
+        "rev": "148bab9c1c3c53136ecb44a6ea356a0ed5b39b06",
         "type": "github"
       },
       "original": {
@@ -1421,11 +1421,11 @@
         "nixpkgs": "nixpkgs_10"
       },
       "locked": {
-        "lastModified": 1785138165,
-        "narHash": "sha256-JMQ1L59Z4M0KPKou9gS+rbYYhGEXIGtdPTX0kbbRx2o=",
+        "lastModified": 1785658849,
+        "narHash": "sha256-PgPkNVPZK8pl4h/FVAdqrWGsdYPrF0mYiA98myeAnfQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "15544328ef656ca54155e43fc73fb664e5b993c8",
+        "rev": "6755bdc2722c00441ce2c22ba57829310e199378",
         "type": "github"
       },
       "original": {
@@ -1616,11 +1616,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784438913,
-        "narHash": "sha256-NYF7ZM5ip0u+w1pBFDpIGEbrbgN/wpnLFAmBkWkYMXw=",
+        "lastModified": 1785044261,
+        "narHash": "sha256-ehF/c4fLdgmNu7YXEClnmwhoBYddhYIVoSQpsZoorC4=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "afacd6819d3765a05814ee8e3de74c77d42ac799",
+        "rev": "fe2124391e739e7b3e8720cd8a73f06edd0aceba",
         "type": "github"
       },
       "original": {
@@ -1727,11 +1727,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784371182,
-        "narHash": "sha256-S8A1lezEalltWcCp3gAic5lssS0xTSISK6fKODefhOk=",
+        "lastModified": 1785359135,
+        "narHash": "sha256-sRAGZVUPgwxpx19uZwaSERa86g1AbsBUQ3SxhaRPgeg=",
         "owner": "hyprwm",
         "repo": "xdg-desktop-portal-hyprland",
-        "rev": "08d99f727944dd15e4740090305e31c5fb92a50a",
+        "rev": "cc8e5ef8fb2acef3db488b9a33b0c48c2a4ee204",
         "type": "github"
       },
       "original": {
@@ -1747,11 +1747,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785047627,
-        "narHash": "sha256-W32Jxn9mnGEjDc5c7sC5YfNLzrh3n9Srkg5JbC1YYdY=",
+        "lastModified": 1785480078,
+        "narHash": "sha256-wWRW/Teo+58EMeTpVVEAqYid1qLzpB/PViQJCv7Xxvc=",
         "owner": "youwen5",
         "repo": "zen-browser-flake",
-        "rev": "0d2fc291f34fce699b2a559f74189ecfe61e30e3",
+        "rev": "b7d4cc2778143a228675cd8bb7efdfa111638ac8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automatic flake update on 2026-08-02.

Review the per-host package changes below before merging.

## Input changes

```
unpacking 'github:nix-community/disko/de5708739256238fb912c62f03988815db89ec9a' into the Git cache...
unpacking 'github:Gako358/emacs-flake/b1fb553b01afaa7e5f6af10f7cc74ea8902b6635' into the Git cache...
unpacking 'github:hercules-ci/flake-parts/427bf4bd9435fdf21321c8cc628c24efc14c0f7a' into the Git cache...
unpacking 'github:nixos/nixos-hardware/2e790b0a6be8ec2b76174ac0931b8ff11919ec98' into the Git cache...
unpacking 'github:nix-community/home-manager/bf9ce9fec78f95f374e8dd3b503863a3ec128ebe' into the Git cache...
unpacking 'github:hyprwm/hypridle/e5c01af0842bd66617f7004568df9406111d6e80' into the Git cache...
unpacking 'github:hyprwm/hyprland/88c6386994c960006e14c7bfa4ccfee873252882' into the Git cache...
unpacking 'github:hyprwm/contrib/3dcbce715ae8b93107fa8632db15bf976862a573' into the Git cache...
unpacking 'github:hyprwm/hyprland-plugins/81516add9b432b6ffc9f0906b92c9302c479c236' into the Git cache...
unpacking 'github:hyprwm/hyprpaper/c011bd20886ea3301474e77d7fa4d22ab013ece0' into the Git cache...
unpacking 'github:nix-community/impermanence/7b1d382faf603b6d264f58627330f9faa5cba149' into the Git cache...
unpacking 'github:vic/import-tree/4ebb10ae17d5f1ad366e7aef5b92cb8eecf24f69' into the Git cache...
unpacking 'github:nix-community/lanzaboote/c191775376b8734af02970153b4e5d86841dff19' into the Git cache...
unpacking 'github:misterio77/nix-colors/b01f024090d2c4fc3152cd0cf12027a7b8453ba1' into the Git cache...
unpacking 'github:nixos/nixpkgs/148bab9c1c3c53136ecb44a6ea356a0ed5b39b06' into the Git cache...
unpacking 'github:nix-community/NUR/6755bdc2722c00441ce2c22ba57829310e199378' into the Git cache...
unpacking 'github:nix-community/plasma-manager/c551f0687658e4bb699cfff6015436ad7ee57a0d' into the Git cache...
unpacking 'github:cachix/pre-commit-hooks.nix/43b3c1ab9d40fb1dbb008f451988a91e375825e9' into the Git cache...
unpacking 'github:gako358/scram/c32556f403be2aa42aafd72087da28d8f477010e' into the Git cache...
unpacking 'github:Mic92/sops-nix/f1406619a3884cd5c47992a70b8b35c9c0fcb4c9' into the Git cache...
unpacking 'github:youwen5/zen-browser-flake/b7d4cc2778143a228675cd8bb7efdfa111638ac8' into the Git cache...
warning: updating lock file "/home/runner/work/dotfiles/dotfiles/flake.lock":
• Updated input 'emacs-flake':
    'github:Gako358/emacs-flake/3eac795c811c52509465605a164810122322945c?narHash=sha256-29mddy9NFz8/ePgZV2zwRV9vrYt6bKXX0/9%2BCBK%2BtNw%3D' (2026-07-27)
  → 'github:Gako358/emacs-flake/b1fb553b01afaa7e5f6af10f7cc74ea8902b6635?narHash=sha256-00cOL/2oPEnSnmRK4yarCdUTBeFglwjhozeCC8MhJvY%3D' (2026-08-01)
• Updated input 'flake-parts':
    'github:hercules-ci/flake-parts/17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e?narHash=sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w%2B6NWK9yA%3D' (2026-07-01)
  → 'github:hercules-ci/flake-parts/427bf4bd9435fdf21321c8cc628c24efc14c0f7a?narHash=sha256-4dtXQk/NMePegK/nWp5NSeuZKLATItOq61lpEvmXqGw%3D' (2026-08-01)
• Updated input 'flake-parts/nixpkgs-lib':
    'github:nix-community/nixpkgs.lib/db3f255737b94216eb71cce308e2912cf6bc2d7c?narHash=sha256-ePjCwr1sNm9NYUqywL7QfK3JnlS015msC%2BeBu2zKlp8%3D' (2026-06-28)
  → 'github:nix-community/nixpkgs.lib/0e79af5e3d4dcfcd676ab5ba3f95d2e3352e078c?narHash=sha256-OmshNvn2vupOFpYinLUu%2B1Dnpu4n7Q5N3ggGVNHpkUI%3D' (2026-07-26)
• Updated input 'hardware':
    'github:nixos/nixos-hardware/a017f5b72210026af5b3ac5949f08d94380a6fbd?narHash=sha256-1CfD8ZUjCkTgjsneLZ/lxCHhgDfqxxE7/GX0MmsgiqA%3D' (2026-07-22)
  → 'github:nixos/nixos-hardware/2e790b0a6be8ec2b76174ac0931b8ff11919ec98?narHash=sha256-65EQYIRRpTdpH8lUiB6Mvo5uBkG60aBIzAJuALfx%2BO0%3D' (2026-07-28)
• Updated input 'home-manager':
    'github:nix-community/home-manager/e83dffa86cccb6237fe194d4eeb47f41557749d1?narHash=sha256-3VMVuOJ6fK%2BRNOXVmqusqUwQ1sDfPeddNKaM2JR/4Y0%3D' (2026-07-27)
  → 'github:nix-community/home-manager/bf9ce9fec78f95f374e8dd3b503863a3ec128ebe?narHash=sha256-vkMnV0JIyw%2Bg/NmcfoajlGaAO%2B9a0ezia%2BFZohQJrik%3D' (2026-07-31)
• Updated input 'hyprland':
    'github:hyprwm/hyprland/d8dc50309c551cfa44fee70744397311b8b7c5fc?narHash=sha256-0vZbjVqutPmzfAQjNv9QJ/GhvTaeCG%2BHh6gfyBNU/s8%3D' (2026-07-26)
  → 'github:hyprwm/hyprland/88c6386994c960006e14c7bfa4ccfee873252882?narHash=sha256-FUYhESvUq9i4/VtGGr75w3nb3LA8qPKXG4Vs7%2BIjYD0%3D' (2026-08-01)
• Updated input 'hyprland/aquamarine':
    'github:hyprwm/aquamarine/9b5f14d9483445e766294eb8fbe0b8f370269ed0?narHash=sha256-zF1iJkBQSDWmRO4/LEeHR1SpKY0lqZaxkoQJpPS9K9U%3D' (2026-07-18)
  → 'github:hyprwm/aquamarine/fc39af0ccec9171aec8185eaea8afb71a46eff90?narHash=sha256-RTKedehLwWxGblFY5Nop3T08EGKH1T%2B4zmDTddmZ8k4%3D' (2026-07-29)
• Updated input 'hyprland/hyprland-guiutils':
    'github:hyprwm/hyprland-guiutils/a6ccb6cb112ed5a244c0191fb972347ecfa893e0?narHash=sha256-ahtKMGXFJdlQNhatQm1%2BBBU/pGfGYnAqQt3vWvq4p8s%3D' (2026-07-16)
  → 'github:hyprwm/hyprland-guiutils/a16ad89ed5fb4192c966018a80c652de8d96f748?narHash=sha256-Ee78BRFi%2BMrmgHmmW%2B2dZUEI1R3cssEzza0ar3fsNX8%3D' (2026-07-20)
• Updated input 'hyprland/hyprutils':
    'github:hyprwm/hyprutils/5f03477ab3a005ff27c527486f551883535aea2f?narHash=sha256-XnAVV%2BH4f8Xdv0yZcSwJ5kCjLyE8fHxPeLX6a3HSrAU%3D' (2026-07-17)
  → 'github:hyprwm/hyprutils/83da5ee98d806cef2d05a1072b8d8b832bf52891?narHash=sha256-A9Gb5wW2vMkYEec7DyCOBpEM6LwwpmQ/TIXEHhGgHUY%3D' (2026-07-19)
• Updated input 'hyprland/hyprwire':
    'github:hyprwm/hyprwire/85148a8e612808cf5ddb25d0b3c5840f3498a7dc?narHash=sha256-o6RzFj4nJXaPRY7EM01siuCQeT41RfwwmcmFQqwFJJg%3D' (2026-05-10)
  → 'github:hyprwm/hyprwire/7d935bb54674aa0fbd327d2a6888bd0630079ed0?narHash=sha256-ak5fWEmWZyax8trkV4aphdvjrbUiSyl6qS%2By5GwBS7Y%3D' (2026-07-19)
• Updated input 'hyprland/nixpkgs':
    'github:NixOS/nixpkgs/61b7c44c4073f0b827768aff0049561b5110ea5a?narHash=sha256-12KrbMiWLcf8m7pCvAtZh1ZrgF85ZXDXvfR/fWTKy84%3D' (2026-07-18)
  → 'github:NixOS/nixpkgs/1559d3daa3ecc813a650b79375ea61b6741b8746?narHash=sha256-LQy14TZp77TwbQf40gg1V3jo8FwJG0jGDkAH%2BzRHqg8%3D' (2026-07-30)
• Updated input 'hyprland/xdph':
    'github:hyprwm/xdg-desktop-portal-hyprland/08d99f727944dd15e4740090305e31c5fb92a50a?narHash=sha256-S8A1lezEalltWcCp3gAic5lssS0xTSISK6fKODefhOk%3D' (2026-07-18)
  → 'github:hyprwm/xdg-desktop-portal-hyprland/cc8e5ef8fb2acef3db488b9a33b0c48c2a4ee204?narHash=sha256-sRAGZVUPgwxpx19uZwaSERa86g1AbsBUQ3SxhaRPgeg%3D' (2026-07-29)
• Updated input 'lanzaboote':
    'github:nix-community/lanzaboote/f4b0aef3dba28677a5ca4b3416827aade60b5a0b?narHash=sha256-t17AqLEhPG6m27ipkp8mJd8Ug0XkdANFDVsgyIFBZcQ%3D' (2026-07-20)
  → 'github:nix-community/lanzaboote/c191775376b8734af02970153b4e5d86841dff19?narHash=sha256-d0NKOOtI90kk8DAXNDkgYUZD8KK908bczz6zNLTC/zw%3D' (2026-07-30)
• Updated input 'lanzaboote/crane':
    'github:ipetkov/crane/1316b7d278ad77a16aec024b71d971366e123bec?narHash=sha256-gcFMcRjw0ZSn380Rx2QLlU1goUQeSrKX/DF12omI6%2Bo%3D' (2026-07-18)
  → 'github:ipetkov/crane/7930f6c291de6f83c257839d434592aa085f290a?narHash=sha256-TkTWNhJV/8Wk3czlbz4bwHZkFCaCHPsOy%2BoJe4PUiXg%3D' (2026-07-20)
• Updated input 'lanzaboote/rust-overlay':
    'github:oxalica/rust-overlay/afacd6819d3765a05814ee8e3de74c77d42ac799?narHash=sha256-NYF7ZM5ip0u%2Bw1pBFDpIGEbrbgN/wpnLFAmBkWkYMXw%3D' (2026-07-19)
  → 'github:oxalica/rust-overlay/fe2124391e739e7b3e8720cd8a73f06edd0aceba?narHash=sha256-ehF/c4fLdgmNu7YXEClnmwhoBYddhYIVoSQpsZoorC4%3D' (2026-07-26)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/624af665418d3c65d544145b4d34ad696439570e?narHash=sha256-m0pDuRJG7EDo9ri%2B4Ksu83VsI%2BPlxNC9lNBfydejce4%3D' (2026-07-26)
  → 'github:nixos/nixpkgs/148bab9c1c3c53136ecb44a6ea356a0ed5b39b06?narHash=sha256-KoTsyMQqnXQZq8deCEnu4QkyldkwH/bpMMhUcfMdGIw%3D' (2026-08-01)
• Updated input 'nur':
    'github:nix-community/NUR/15544328ef656ca54155e43fc73fb664e5b993c8?narHash=sha256-JMQ1L59Z4M0KPKou9gS%2BrbYYhGEXIGtdPTX0kbbRx2o%3D' (2026-07-27)
  → 'github:nix-community/NUR/6755bdc2722c00441ce2c22ba57829310e199378?narHash=sha256-PgPkNVPZK8pl4h/FVAdqrWGsdYPrF0mYiA98myeAnfQ%3D' (2026-08-02)
• Updated input 'nur/nixpkgs':
    'github:nixos/nixpkgs/624af665418d3c65d544145b4d34ad696439570e?narHash=sha256-m0pDuRJG7EDo9ri%2B4Ksu83VsI%2BPlxNC9lNBfydejce4%3D' (2026-07-26)
  → 'github:nixos/nixpkgs/148bab9c1c3c53136ecb44a6ea356a0ed5b39b06?narHash=sha256-KoTsyMQqnXQZq8deCEnu4QkyldkwH/bpMMhUcfMdGIw%3D' (2026-08-01)
• Updated input 'zen-browser':
    'github:youwen5/zen-browser-flake/0d2fc291f34fce699b2a559f74189ecfe61e30e3?narHash=sha256-W32Jxn9mnGEjDc5c7sC5YfNLzrh3n9Srkg5JbC1YYdY%3D' (2026-07-26)
  → 'github:youwen5/zen-browser-flake/b7d4cc2778143a228675cd8bb7efdfa111638ac8?narHash=sha256-wWRW/Teo%2B58EMeTpVVEAqYid1qLzpB/PViQJCv7Xxvc%3D' (2026-07-31)
```

## Per-host package diff

<details><summary><b>aanallein</b></summary>

```
<<< result-old
>>> result-new
Version changes:
[C*]  #001  acl                               2.4.0 x2, 2.4.0-bin, 2.4.0-doc, 2.4.0-man -> 2.4.0 x3, 2.4.0-bin, 2.4.0-doc, 2.4.0-man
[C*]  #002  attr                              2.6.0 x2, 2.6.0-bin, 2.6.0-doc, 2.6.0-man -> 2.6.0 x3, 2.6.0-bin, 2.6.0-doc, 2.6.0-man
[C.]  #003  audit                             4.1.4-lib x2 -> 4.1.4-lib, 4.2-lib x2
[C.]  #004  bash                              5.3p15 x2 -> 5.3p15 x3
[C*]  #005  bash-interactive                  5.3p15, 5.3p15-doc, 5.3p15-info, 5.3p15-man -> 5.3p15 x2, 5.3p15-doc, 5.3p15-info, 5.3p15-man
[U*]  #006  bind                              9.20.24-host, 9.20.24-lib, 9.20.24-man -> 9.20.26-host, 9.20.26-lib, 9.20.26-man
[C.]  #007  brotli                            1.2.0, 1.2.0-dev, 1.2.0-lib x2 -> 1.2.0, 1.2.0-dev, 1.2.0-lib x3
[C*]  #008  bzip2                             1.0.8 x2, 1.0.8-bin, 1.0.8-dev, 1.0.8-man -> 1.0.8 x3, 1.0.8-bin, 1.0.8-dev, 1.0.8-man
[C.]  #009  coreutils                         9.11 x2 -> 9.11 x3
[U*]  #010  cpupower                          6.18.40, 6.18.40_fish-completions -> 6.18.41, 6.18.41_fish-completions
[C*]  #011  curl                              8.21.0 x2, 8.21.0-bin, 8.21.0-man -> 8.21.0 x3, 8.21.0-bin, 8.21.0-man
[U.]  #012  dash                              0.5.13.4 -> 0.5.13.5
[C.]  #013  db                                4.8.30 x2, 5.3.28 -> 4.8.30 x3, 5.3.28
[C.]  #014  dns-root-data                     2025-04-14 x2 -> 2025-04-14 x3
[U.]  #015  ethtool                           7.0 -> 7.1
[C.]  #016  expat                             2.8.2 x2, 2.8.2-dev -> 2.8.2 x3, 2.8.2-dev
[U*]  #017  findutils                         4.10.0, 4.10.0_fish-completions, 4.10.0-info -> 4.11.0, 4.11.0_fish-completions, 4.11.0-info
[U.]  #018  fluidsynth                        2.5.5 -> 2.5.6
[U*]  #019  fontconfig                        2.18.1 x2, 2.18.1-bin, 2.18.1-dev, 2.18.1_fish-completions, 2.18.1-lib x2 -> 2.18.2 x2, 2.18.2-bin, 2.18.2-dev, 2.18.2_fish-completions, 2.18.2-lib x2
[U.]  #020  fzf                               0.74.1, 0.74.1-fish-completions, 0.74.1-man -> 0.74.2, 0.74.2-fish-completions, 0.74.2-man
[C.]  #021  gcc                               15.3.0-lib x2, 15.3.0-libgcc x2 -> 15.3.0-lib x3, 15.3.0-libgcc x3
[C.]  #022  gdbm                              1.26-lib x2 -> 1.26-lib x3
[C.]  #023  gettext                           1.0 -> 1.0 x2
[U.]  #024  gh                                2.96.0, 2.96.0-fish-completions -> 2.97.0, 2.97.0-fish-completions
[C*]  #025  git                               2.55.0, 2.55.0-doc, 2.55.0-fish-completions x2 -> 2.55.0 x2, 2.55.0-doc x2, 2.55.0_fish-completions x2
[C*]  #026  glibc                             2.42-67 x2, 2.42-67-bin, 2.42-67-dev, 2.42-67-getent -> 2.42-67 x3, 2.42-67-bin, 2.42-67-dev, 2.42-67-getent
[C.]  #027  gmp-with-cxx                      6.3.0 x4, 6.3.0-dev -> 6.3.0 x5, 6.3.0-dev
[C*]  #028  gnugrep                           3.12, 3.12_fish-completions, 3.12-info -> 3.12 x2, 3.12_fish-completions, 3.12-info
[C*]  #029  gnused                            4.10, 4.10_fish-completions, 4.10-info -> 4.10 x2, 4.10_fish-completions, 4.10-info
[U.]  #030  gst-plugins-bad                   1.28.4 -> 1.28.5
[U.]  #031  gst-plugins-base                  1.28.4 x2 -> 1.28.5 x2
[U.]  #032  gst-plugins-good                  1.28.4 -> 1.28.5
[U.]  #033  gstreamer                         1.28.4 x2 -> 1.28.5 x2
[C*]  #034  gzip                              1.14, 1.14-info, 1.14-man -> 1.14 x2, 1.14-info, 1.14-man
[U.]  #035  headsetcontrol                    3.1.0, 3.1.0-fish-completions -> 4.0.0, 4.0.0-fish-completions
[U.]  #036  imagemagick                       7.1.2-27, 7.1.2-27-fish-completions -> 7.1.2-29, 7.1.2-29-fish-completions
[U.]  #037  initrd-linux                      6.18.40 -> 6.18.41
[C.]  #038  keyutils                          1.6.3-lib x2 -> 1.6.3-lib x3
[C.]  #039  krb5                              1.22.2-lib x2 -> 1.22.2-lib x3
[C.]  #040  ldns                              1.9.2 -> 1.9.2 x2
[U.]  #041  libapparmor                       5.0.1 x2 -> 5.0.2 x2
[C.]  #042  libcap-ng                         0.9.3 x2 -> 0.9.3 x3
[C.]  #043  libcbor                           0.14.0 x2 -> 0.14.0 x3
[C.]  #044  libedit                           20260508-3.1 -> 20260508-3.1 x2
[C.]  #045  libffi                            3.7.0 x2, 3.7.0-dev -> 3.7.0, 3.7.1 x2, 3.7.1-dev
[C.]  #046  libfido2                          1.17.0 x2 -> 1.17.0 x3
[C.]  #047  libidn2                           2.3.8 x2 -> 2.3.8 x3
[U.]  #048  libmicrohttpd                     1.0.5 x2 -> 1.0.6 x2
[U.]  #049  libmysofa                         1.3.3 x2 -> 1.3.4 x2
[C.]  #050  libpsl                            0.21.5 x2 -> 0.21.5 x3
[U.]  #051  libsodium                         1.0.22-unstable-2026-04-16 -> 1.0.22-unstable-2026-07-08
[U.]  #052  libssh                            0.12.0 x2 -> 0.12.1 x2
[C.]  #053  libssh2                           1.11.1 x2 -> 1.11.1 x3
[U.]  #054  libtiff                           4.7.1 x2, 4.7.1-bin, 4.7.1-dev -> 4.7.2 x2, 4.7.2-bin, 4.7.2-dev
[U.]  #055  libtool                           2.5.4-lib x2 -> 2.6.2-lib x2
[C.]  #056  libunistring                      1.4.2 x2 -> 1.4.2 x3
[C.]  #057  libxcrypt                         4.5.2 x2 -> 4.5.2 x3
[U.]  #058  linux                             6.18.40, 6.18.40-modules x2 -> 6.18.41, 6.18.41-modules x2
[U.]  #059  linux-headers                     7.0 -> 7.1
[U.]  #060  linux-headers-static              7.0 -> 7.1
[C*]  #061  linux-pam                         1.7.2 x2, 1.7.2-doc, 1.7.2-man -> 1.7.2 x3, 1.7.2-doc, 1.7.2-man
[C.]  #062  mailcap                           2.1.54 x2 -> 2.1.54 x3
[U.]  #063  mbedtls                           3.6.6 x2 -> 3.6.7 x2
[U.]  #064  mesa                              26.1.5 x2 -> 26.1.6 x2
[C.]  #065  mpdecimal                         4.0.1 x2 -> 4.0.1 x3
[C*]  #066  ncurses                           6.6 x2, 6.6-man -> 6.6 x3, 6.6-man
[C.]  #067  nghttp2                           1.69.0-lib x2 -> 1.69.0-lib x3
[C.]  #068  nghttp3                           1.16.0 x2 -> 1.16.0 x3
[C.]  #069  ngtcp2                            1.23.0 x2 -> 1.23.0 x3
[U*]  #070  nh                                4.4.1, 4.4.1_fish-completions -> 4.4.2, 4.4.2_fish-completions
[U.]  #071  nh-unwrapped                      4.4.1 -> 4.4.2
[U*]  #072  nix-output-monitor                2.1.8, 2.1.8-fish-completions -> 2.2.0, 2.2.0-fish-completions
[U.]  #073  nixos-system-aanallein            26.11.20260726.624af66 -> 26.11.20260801.148bab9
[U.]  #074  nss-cacert                        3.125, 3.125-fish-completions, 3.125-p11kit -> 3.126, 3.126-fish-completions, 3.126-p11kit
[U.]  #075  openexr                           3.4.11 -> 3.4.13
[C*]  #076  openssh                           10.4p1, 10.4p1-man -> 10.4p1 x2, 10.4p1-man
[C.]  #077  openssl                           3.6.3 x2, 3.6.3-bin, 3.6.3-dev -> 3.6.3 x3, 3.6.3-bin, 3.6.3-dev
[U.]  #078  passt                             2025_09_19.623dbf6 -> 2026_07_16.090d739
[C.]  #079  pcre2                             10.47 x2, 10.47-bin, 10.47-dev -> 10.47 x3, 10.47-bin, 10.47-dev
[C*]  #080  pcsclite                          2.4.1, 2.4.1-doc, 2.4.1-lib x2, 2.4.1-man -> 2.4.1, 2.4.1-doc, 2.4.1-lib x3, 2.4.1-man
[C*]  #081  perl                              5.42.0, 5.42.0-env x3, 5.42.0-man -> 5.42.0 x2, 5.42.0-env x3, 5.42.0-man
[C.]  #082  perl5.42.0-Authen-SASL            2.1900 -> 2.1900 x2
[C.]  #083  perl5.42.0-CGI                    4.59 -> 4.59 x2
[C.]  #084  perl5.42.0-CGI-Fast               2.16 -> 2.16 x2
[C.]  #085  perl5.42.0-Clone                  0.46 -> 0.46 x2
[C.]  #086  perl5.42.0-Compress-Raw-Bzip2     2.218 -> 2.218 x2
[C.]  #087  perl5.42.0-Compress-Raw-Zlib      2.222 -> 2.222 x2
[C.]  #088  perl5.42.0-Crypt-URandom          0.55 -> 0.55 x2
[C.]  #089  perl5.42.0-Digest-HMAC            1.05 -> 1.05 x2
[C.]  #090  perl5.42.0-Encode-Locale          1.05 -> 1.05 x2
[C.]  #091  perl5.42.0-FCGI                   0.82 -> 0.82 x2
[C.]  #092  perl5.42.0-FCGI-ProcManager       0.28 -> 0.28 x2
[C.]  #093  perl5.42.0-File-Listing           6.16 -> 6.16 x2
[C.]  #094  perl5.42.0-HTML-Parser            3.85 -> 3.85 x2
[C.]  #095  perl5.42.0-HTML-TagCloud          0.38 -> 0.38 x2
[C.]  #096  perl5.42.0-HTML-Tagset            3.20 -> 3.20 x2
[C.]  #097  perl5.42.0-HTTP-CookieJar         0.014 -> 0.014 x2
[C.]  #098  perl5.42.0-HTTP-Cookies           6.10 -> 6.10 x2
[C.]  #099  perl5.42.0-HTTP-Daemon            6.17 -> 6.17 x2
[C.]  #100  perl5.42.0-HTTP-Date              6.06 -> 6.06 x2
[C.]  #101  perl5.42.0-HTTP-Message           7.02 -> 7.02 x2
[C.]  #102  perl5.42.0-HTTP-Negotiate         6.01 -> 6.01 x2
[C.]  #103  perl5.42.0-IO-Compress            2.221 -> 2.221 x2
[C.]  #104  perl5.42.0-IO-HTML                1.004 -> 1.004 x2
[C.]  #105  perl5.42.0-IO-Socket-SSL          2.083 -> 2.083 x2
[C.]  #106  perl5.42.0-LWP-MediaTypes         6.04 -> 6.04 x2
[C.]  #107  perl5.42.0-Mozilla-CA             20230821 -> 20230821 x2
[C.]  #108  perl5.42.0-Net-HTTP               6.23 -> 6.23 x2
[C.]  #109  perl5.42.0-Net-SMTP-SSL           1.04 -> 1.04 x2
[C.]  #110  perl5.42.0-Net-SSLeay             1.92 -> 1.92 x2
[C.]  #111  perl5.42.0-TermReadKey            2.38 -> 2.38 x2
[C.]  #112  perl5.42.0-Test-Fatal             0.017 -> 0.017 x2
[C.]  #113  perl5.42.0-Test-Needs             0.002010 -> 0.002010 x2
[C.]  #114  perl5.42.0-Test-RequiresInternet  0.05 -> 0.05 x2
[C.]  #115  perl5.42.0-TimeDate               2.33 -> 2.33 x2
[C.]  #116  perl5.42.0-Try-Tiny               0.31 -> 0.31 x2
[C.]  #117  perl5.42.0-URI                    5.21 -> 5.21 x2
[C.]  #118  perl5.42.0-WWW-RobotRules         6.02 -> 6.02 x2
[C.]  #119  perl5.42.0-libnet                 3.15 -> 3.15 x2
[C.]  #120  perl5.42.0-libwww-perl            6.83 -> 6.83 x2
[C.]  #121  publicsuffix-list                 0-unstable-2026-06-24 x2 -> 0-unstable-2026-06-24 x3
[C.]  #122  python3                           3.14.6 x2, 3.14.6-env x2 -> 3.14.6 x3, 3.14.6-env x2
[C.]  #123  readline                          8.3p3 x2 -> 8.3p3 x3
[U.]  #124  s2n-tls                           1.7.2 -> 1.7.6
[C.]  #125  sqlite                            3.53.3 x2, 3.53.3-bin, 3.53.3-dev -> 3.53.3 x3, 3.53.3-bin, 3.53.3-dev
[U.]  #126  srt                               1.5.5 x2 -> 1.5.6 x2
[C*]  #127  systemd                           <none>, 261 x2, 261-dev, 261-man -> <none>, 261.1 x3, 261.1-dev, 261.1-man
[U.]  #128  systemd-minimal                   261 x2 -> 261.1 x2
[C.]  #129  systemd-minimal-libs              261 x2, 261-dev -> 261, 261.1 x2, 261.1-dev
[C.]  #130  tzdata                            2026b x2 -> 2026b, 2026c x2
[U.]  #131  unbound                           1.25.1-lib x2 -> 1.25.2-lib x2
[C.]  #132  util-linux-minimal                2.42.2-bin, 2.42.2-lib x2, 2.42.2-login x2, 2.42.2-mount x2, 2.42.2-swap x2 -> 2.42.2-bin, 2.42.2-lib x3, 2.42.2-login x3, 2.42.2-mount x2, 2.42.2-swap x2
[C.]  #133  xgcc                              15.3.0-libgcc x2 -> 15.3.0-libgcc x3
[C*]  #134  xz                                5.8.3 x2, 5.8.3-bin, 5.8.3-dev, 5.8.3-doc, 5.8.3-man -> 5.8.3 x3, 5.8.3-bin, 5.8.3-dev, 5.8.3-doc, 5.8.3-man
[C.]  #135  zlib                              1.3.2 x2, 1.3.2-dev, 1.3.2-static x2 -> 1.3.2 x3, 1.3.2-dev, 1.3.2-static x2
[C.]  #136  zlib-ng                           2.3.3 -> 2.3.3 x2
[C*]  #137  zstd                              1.5.7 x2, 1.5.7-bin, 1.5.7-dev, 1.5.7-man -> 1.5.7 x3, 1.5.7-bin, 1.5.7-dev, 1.5.7-man
[U.]  #138  zxing-cpp                         2.3.0 -> 3.0.2
Added packages:
[A.]  #1  sox   14.4.2-unstable-2021-05-09-lib x2
[A.]  #2  zint  2.16.0-lib
Removed packages:
[R.]  #1  clang             21.1.8 x2, 21.1.8-lib x2
[R.]  #2  gnome-icon-theme  3.12.0
[R.]  #3  sox-unstable      2021-05-09-lib x2
Closure size: 1792 -> 1889 (1754 paths added, 1657 paths removed, delta +97, disk usage -1.2GiB).

_… diff truncated (151 lines total); see the `closure-diff-aanallein` artifact for the full output._

</details>

<details><summary><b>rhuidean</b></summary>

```
<<< result-old
>>> result-new
Version changes:
[C*]  #001  acl                               2.4.0 x2, 2.4.0-bin, 2.4.0-doc, 2.4.0-man -> 2.4.0 x3, 2.4.0-bin, 2.4.0-doc, 2.4.0-man
[C*]  #002  attr                              2.6.0 x2, 2.6.0-bin, 2.6.0-doc, 2.6.0-man -> 2.6.0 x3, 2.6.0-bin, 2.6.0-doc, 2.6.0-man
[C.]  #003  audit                             4.1.4-lib x2 -> 4.1.4-lib, 4.2-lib x2
[C.]  #004  bash                              5.3p15 x2 -> 5.3p15 x3
[C*]  #005  bash-interactive                  5.3p15 x3, 5.3p15-doc, 5.3p15-info, 5.3p15-man x2 -> 5.3p15 x4, 5.3p15-doc, 5.3p15-info, 5.3p15-man x2
[U*]  #006  bind                              9.20.24-host, 9.20.24-lib, 9.20.24-man -> 9.20.26-host, 9.20.26-lib, 9.20.26-man
[C.]  #007  brotli                            1.2.0, 1.2.0-dev, 1.2.0-lib x2 -> 1.2.0, 1.2.0-dev, 1.2.0-lib x3
[C*]  #008  bzip2                             1.0.8 x2, 1.0.8-bin, 1.0.8-dev, 1.0.8-man -> 1.0.8 x3, 1.0.8-bin, 1.0.8-dev, 1.0.8-man
[C.]  #009  coreutils                         9.11 x2 -> 9.11 x3
[U*]  #010  cpupower                          6.18.40, 6.18.40_fish-completions -> 6.18.41, 6.18.41_fish-completions
[C*]  #011  curl                              8.21.0 x3, 8.21.0-bin x3, 8.21.0-man x2 -> 8.21.0 x4, 8.21.0-bin x3, 8.21.0-man x2
[U.]  #012  dash                              0.5.13.4 -> 0.5.13.5
[C.]  #013  db                                4.8.30 x2, 5.3.28 -> 4.8.30 x3, 5.3.28
[C.]  #014  dns-root-data                     2025-04-14 x2 -> 2025-04-14 x3
[U.]  #015  electron                          41.9.1 -> 41.10.3
[U.]  #016  electron-unwrapped                41.9.1 -> 41.10.3
[U.]  #017  ethtool                           7.0 x2 -> 7.1 x2
[C.]  #018  expat                             2.8.2 x2, 2.8.2-dev -> 2.8.2 x3, 2.8.2-dev
[U*]  #019  findutils                         4.10.0, 4.10.0_fish-completions, 4.10.0-info -> 4.11.0, 4.11.0_fish-completions, 4.11.0-info
[U.]  #020  fluidsynth                        2.5.5 -> 2.5.6
[U*]  #021  fontconfig                        2.18.1 x2, 2.18.1-bin, 2.18.1-dev, 2.18.1_fish-completions, 2.18.1-lib x2 -> 2.18.2 x2, 2.18.2-bin, 2.18.2-dev, 2.18.2_fish-completions, 2.18.2-lib x2
[U.]  #022  fzf                               0.74.1, 0.74.1-fish-completions, 0.74.1-man -> 0.74.2, 0.74.2-fish-completions, 0.74.2-man
[C.]  #023  gcc                               15.3.0-lib x2, 15.3.0-libgcc x2 -> 15.3.0-lib x3, 15.3.0-libgcc x3
[C.]  #024  gdbm                              1.26-lib x2 -> 1.26-lib x3
[U*]  #025  geoclue                           2.7.2, 2.7.2_fish-completions -> 2.8.1, 2.8.1_fish-completions
[C.]  #026  gettext                           1.0 -> 1.0 x2
[U.]  #027  gh                                2.96.0, 2.96.0-fish-completions -> 2.97.0, 2.97.0-fish-completions
[C*]  #028  git                               2.55.0, 2.55.0-doc, 2.55.0-fish-completions x2 -> 2.55.0 x2, 2.55.0-doc x2, 2.55.0_fish-completions x2
[C*]  #029  glibc                             2.42-67 x2, 2.42-67-bin x2, 2.42-67-dev, 2.42-67-getent -> 2.42-67 x3, 2.42-67-bin x2, 2.42-67-dev, 2.42-67-getent
[C.]  #030  gmp-with-cxx                      6.3.0 x4, 6.3.0-dev -> 6.3.0 x5, 6.3.0-dev
[C*]  #031  gnugrep                           3.12 x2, 3.12_fish-completions, 3.12-info -> 3.12 x3, 3.12_fish-completions, 3.12-info
[C*]  #032  gnused                            4.10 x2, 4.10_fish-completions, 4.10-info -> 4.10 x3, 4.10_fish-completions, 4.10-info
[C*]  #033  gnutar                            1.35 x2, 1.35_fish-completions, 1.35-info -> 1.35, 1.35_fish-completions, 1.35-info
[U.]  #034  graphviz                          14.1.2 -> 15.1.0
[U.]  #035  gst-devtools                      1.28.4 -> 1.28.5
[U.]  #036  gst-editing-services              1.28.4 -> 1.28.5
[U.]  #037  gst-libav                         1.28.4 -> 1.28.5
[U.]  #038  gst-plugins-bad                   1.28.4 -> 1.28.5
[U.]  #039  gst-plugins-base                  1.28.4 x2 -> 1.28.5 x2
[U.]  #040  gst-plugins-good                  1.28.4 x2 -> 1.28.5 x2
[U.]  #041  gst-plugins-ugly                  1.28.4 -> 1.28.5
[U.]  #042  gst-rtsp-server                   1.28.4 -> 1.28.5
[U.]  #043  gstreamer                         1.28.4 x2, 1.28.4-bin -> 1.28.5 x2, 1.28.5-bin
[C*]  #044  gzip                              1.14, 1.14-info, 1.14-man -> 1.14 x2, 1.14-info, 1.14-man
[U.]  #045  headsetcontrol                    3.1.0, 3.1.0-fish-completions -> 4.0.0, 4.0.0-fish-completions
[U.]  #046  imagemagick                       7.1.2-27, 7.1.2-27-fish-completions -> 7.1.2-29, 7.1.2-29-fish-completions
[U.]  #047  initrd-linux                      6.18.40 -> 6.18.41
[C.]  #048  keyutils                          1.6.3-lib x2 -> 1.6.3-lib x3
[U.]  #049  kirigami-addons                   1.13.0 -> 1.13.1
[C.]  #050  krb5                              1.22.2, 1.22.2-lib x2 -> 1.22.2, 1.22.2-lib x3
[C.]  #051  ldns                              1.9.2 -> 1.9.2 x2
[U.]  #052  libapparmor                       5.0.1 x2 -> 5.0.2 x2
[C.]  #053  libcap-ng                         0.9.3 x2 -> 0.9.3 x3
[C.]  #054  libcbor                           0.14.0 x2 -> 0.14.0 x3
[C.]  #055  libedit                           20260508-3.1 x2 -> 20260508-3.1 x3
[C.]  #056  libffi                            3.7.0 x2, 3.7.0-dev -> 3.7.0, 3.7.1 x2, 3.7.1-dev
[C.]  #057  libfido2                          1.17.0 x2 -> 1.17.0 x3
[C.]  #058  libidn2                           2.3.8 x2 -> 2.3.8 x3
[U.]  #059  libmicrohttpd                     1.0.5 x2 -> 1.0.6 x2
[U.]  #060  libmysofa                         1.3.3 x2 -> 1.3.4 x2
[U.]  #061  libphonenumber                    9.0.35 -> 9.0.36
[C.]  #062  libpsl                            0.21.5 x2 -> 0.21.5 x3
[U.]  #063  libsodium                         1.0.22-unstable-2026-04-16 -> 1.0.22-unstable-2026-07-08
[U.]  #064  libssh                            0.12.0 x2 -> 0.12.1 x2
[C.]  #065  libssh2                           1.11.1 x2 -> 1.11.1 x3
[U.]  #066  libtiff                           4.7.1 x2, 4.7.1-bin, 4.7.1-dev, 4.7.1-man -> 4.7.2 x2, 4.7.2-bin, 4.7.2-dev, 4.7.2-man
[U.]  #067  libtool                           2.5.4-lib x2 -> 2.6.2-lib x2
[C.]  #068  libunistring                      1.4.2 x2 -> 1.4.2 x3
[C.]  #069  libxcrypt                         4.5.2 x2, 4.5.2-man -> 4.5.2 x3, 4.5.2-man
[U.]  #070  linux                             6.18.40, 6.18.40-modules x2 -> 6.18.41, 6.18.41-modules x2
[U.]  #071  linux-headers                     7.0 -> 7.1
[U.]  #072  linux-headers-static              7.0 -> 7.1
[C*]  #073  linux-pam                         1.7.2 x2, 1.7.2-doc, 1.7.2-man -> 1.7.2 x3, 1.7.2-doc, 1.7.2-man
[C.]  #074  mailcap                           2.1.54 x2 -> 2.1.54 x3
[U.]  #075  mbedtls                           3.6.6 x2 -> 3.6.7 x2
[U.]  #076  mesa                              26.1.5 x2 -> 26.1.6 x2
[C.]  #077  mpdecimal                         4.0.1 x2 -> 4.0.1 x3
[C*]  #078  ncurses                           6.6 x2, 6.6-man -> 6.6 x3, 6.6-man
[C.]  #079  nghttp2                           1.69.0-lib x2 -> 1.69.0-lib x3
[C.]  #080  nghttp3                           1.16.0 x2 -> 1.16.0 x3
[C.]  #081  ngtcp2                            1.23.0 x2, 1.24.0 -> 1.23.0 x3, 1.25.0
[U*]  #082  nh                                4.4.1, 4.4.1_fish-completions -> 4.4.2, 4.4.2_fish-completions
[U.]  #083  nh-unwrapped                      4.4.1 -> 4.4.2
[U*]  #084  nix-output-monitor                2.1.8, 2.1.8-fish-completions -> 2.2.0, 2.2.0-fish-completions
[U.]  #085  nixos-system-rhuidean             26.11.20260726.624af66 -> 26.11.20260801.148bab9
[U.]  #086  nss-cacert                        3.125, 3.125-fish-completions, 3.125-p11kit -> 3.126, 3.126-fish-completions, 3.126-p11kit
[U.]  #087  openexr                           3.4.11 -> 3.4.13
[C*]  #088  openssh                           10.4p1, 10.4p1-man -> 10.4p1 x2, 10.4p1-man
[C.]  #089  openssl                           3.6.3 x2, 3.6.3-bin, 3.6.3-dev, 3.6.3-man -> 3.6.3 x3, 3.6.3-bin, 3.6.3-dev, 3.6.3-man
[U.]  #090  passt                             2025_09_19.623dbf6 -> 2026_07_16.090d739
[C.]  #091  pcre2                             10.47 x2, 10.47-bin, 10.47-dev -> 10.47 x3, 10.47-bin, 10.47-dev
[C*]  #092  pcsclite                          2.4.1, 2.4.1-doc, 2.4.1-lib x2, 2.4.1-man -> 2.4.1, 2.4.1-doc, 2.4.1-lib x3, 2.4.1-man
[C*]  #093  perl                              5.42.0 x2, 5.42.0-env x3, 5.42.0-man -> 5.42.0 x3, 5.42.0-env x3, 5.42.0-man
[C.]  #094  perl5.42.0-Authen-SASL            2.1900 -> 2.1900 x2
[C.]  #095  perl5.42.0-CGI                    4.59 -> 4.59 x2
[C.]  #096  perl5.42.0-CGI-Fast               2.16 -> 2.16 x2
[C.]  #097  perl5.42.0-Clone                  0.46 x2 -> 0.46 x3
[C.]  #098  perl5.42.0-Compress-Raw-Bzip2     2.218 x2 -> 2.218 x3
[C.]  #099  perl5.42.0-Compress-Raw-Zlib      2.222 x2 -> 2.222 x3
[C.]  #100  perl5.42.0-Crypt-URandom          0.55 -> 0.55 x2
[C.]  #101  perl5.42.0-Digest-HMAC            1.05 -> 1.05 x2
[C.]  #102  perl5.42.0-Encode-Locale          1.05 x2 -> 1.05 x3
[C.]  #103  perl5.42.0-FCGI                   0.82 -> 0.82 x2
[C.]  #104  perl5.42.0-FCGI-ProcManager       0.28 -> 0.28 x2
[C.]  #105  perl5.42.0-File-Listing           6.16 x2 -> 6.16 x3
[C.]  #106  perl5.42.0-HTML-Parser            3.85 x2 -> 3.85 x3
[C.]  #107  perl5.42.0-HTML-TagCloud          0.38 -> 0.38 x2
[C.]  #108  perl5.42.0-HTML-Tagset            3.20 x2 -> 3.20 x3
[C.]  #109  perl5.42.0-HTTP-CookieJar         0.014 x2 -> 0.014 x3
[C.]  #110  perl5.42.0-HTTP-Cookies           6.10 x2 -> 6.10 x3
[C.]  #111  perl5.42.0-HTTP-Daemon            6.17 x2 -> 6.17 x3
[C.]  #112  perl5.42.0-HTTP-Date              6.06 x2 -> 6.06 x3
[C.]  #113  perl5.42.0-HTTP-Message           7.02 x2 -> 7.02 x3
[C.]  #114  perl5.42.0-HTTP-Negotiate         6.01 x2 -> 6.01 x3
[C.]  #115  perl5.42.0-IO-Compress            2.221 x2 -> 2.221 x3
[C.]  #116  perl5.42.0-IO-HTML                1.004 x2 -> 1.004 x3
[C.]  #117  perl5.42.0-IO-Socket-SSL          2.083 -> 2.083 x2
[C.]  #118  perl5.42.0-LWP-MediaTypes         6.04 x2 -> 6.04 x3
[C.]  #119  perl5.42.0-Mozilla-CA             20230821 -> 20230821 x2
[C.]  #120  perl5.42.0-Net-HTTP               6.23 x2 -> 6.23 x3
[C.]  #121  perl5.42.0-Net-SMTP-SSL           1.04 -> 1.04 x2
[C.]  #122  perl5.42.0-Net-SSLeay             1.92 -> 1.92 x2
[C.]  #123  perl5.42.0-TermReadKey            2.38 -> 2.38 x2
[C.]  #124  perl5.42.0-Test-Fatal             0.017 x2 -> 0.017 x3
[C.]  #125  perl5.42.0-Test-Needs             0.002010 x2 -> 0.002010 x3
[C.]  #126  perl5.42.0-Test-RequiresInternet  0.05 x2 -> 0.05 x3
[C.]  #127  perl5.42.0-TimeDate               2.33 x2 -> 2.33 x3
[C.]  #128  perl5.42.0-Try-Tiny               0.31 x2 -> 0.31 x3
[C.]  #129  perl5.42.0-URI                    5.21 x2 -> 5.21 x3
[C.]  #130  perl5.42.0-WWW-RobotRules         6.02 x2 -> 6.02 x3
[C.]  #131  perl5.42.0-libnet                 3.15 -> 3.15 x2
[C.]  #132  perl5.42.0-libwww-perl            6.83 x2 -> 6.83 x3
[C*]  #133  plymouth                          26.134.222, 26.134.222_fish-completions -> 26.134.222 x2, 26.134.222_fish-completions
[C.]  #134  publicsuffix-list                 0-unstable-2026-06-24 x2 -> 0-unstable-2026-06-24 x3
[C.]  #135  python3                           3.14.6 x2, 3.14.6-env x4 -> 3.14.6 x3, 3.14.6-env x4
[U.]  #136  python3.14-gst-python             1.28.4 -> 1.28.5
[C.]  #137  readline                          8.3p3 x2 -> 8.3p3 x3
[U.]  #138  s2n-tls                           1.7.2 -> 1.7.6
[U.]  #139  spidermonkey                      140.11.0 -> 140.13.0
[C.]  #140  sqlite                            3.53.3 x2, 3.53.3-bin, 3.53.3-dev -> 3.53.3 x3, 3.53.3-bin, 3.53.3-dev
[U.]  #141  srt                               1.5.5 x2 -> 1.5.6 x2
[C*]  #142  systemd                           <none>, 261 x2, 261-dev, 261-man -> <none>, 261.1 x3, 261.1-dev, 261.1-man
[U.]  #143  systemd-minimal                   261 x2 -> 261.1 x2
[C.]  #144  systemd-minimal-libs              261 x2, 261-dev -> 261, 261.1 x2, 261.1-dev
[C.]  #145  tzdata                            2026b x2 -> 2026b, 2026c x2
[U.]  #146  unbound                           1.25.1-lib x2 -> 1.25.2-lib x2

_… diff truncated (172 lines total); see the `closure-diff-rhuidean` artifact for the full output._

</details>

<details><summary><b>tanchico</b></summary>

```
<<< result-old
>>> result-new
Version changes:
[C*]  #001  acl                               2.4.0 x2, 2.4.0-bin, 2.4.0-doc, 2.4.0-man -> 2.4.0 x3, 2.4.0-bin, 2.4.0-doc, 2.4.0-man
[C*]  #002  attr                              2.6.0 x2, 2.6.0-bin, 2.6.0-doc, 2.6.0-man -> 2.6.0 x3, 2.6.0-bin, 2.6.0-doc, 2.6.0-man
[C.]  #003  audit                             4.1.4-lib x2 -> 4.1.4-lib, 4.2-lib x2
[C.]  #004  bash                              5.3p15 x2 -> 5.3p15 x3
[C*]  #005  bash-interactive                  5.3p15 x3, 5.3p15-doc, 5.3p15-info, 5.3p15-man x2 -> 5.3p15 x4, 5.3p15-doc, 5.3p15-info, 5.3p15-man x2
[U*]  #006  bind                              9.20.24-host, 9.20.24-lib, 9.20.24-man -> 9.20.26-host, 9.20.26-lib, 9.20.26-man
[C.]  #007  brotli                            1.2.0, 1.2.0-dev, 1.2.0-lib x2 -> 1.2.0, 1.2.0-dev, 1.2.0-lib x3
[C*]  #008  bzip2                             1.0.8 x2, 1.0.8-bin, 1.0.8-dev, 1.0.8-man -> 1.0.8 x3, 1.0.8-bin, 1.0.8-dev, 1.0.8-man
[C.]  #009  coreutils                         9.11 x2 -> 9.11 x3
[U*]  #010  cpupower                          6.18.40, 6.18.40_fish-completions -> 6.18.41, 6.18.41_fish-completions
[C*]  #011  curl                              8.21.0 x3, 8.21.0-bin x3, 8.21.0-man x2 -> 8.21.0 x4, 8.21.0-bin x3, 8.21.0-man x2
[U.]  #012  dash                              0.5.13.4 -> 0.5.13.5
[C.]  #013  db                                4.8.30 x2, 5.3.28 -> 4.8.30 x3, 5.3.28
[C.]  #014  dns-root-data                     2025-04-14 x2 -> 2025-04-14 x3
[U.]  #015  electron                          41.9.1 -> 41.10.3
[U.]  #016  electron-unwrapped                41.9.1 -> 41.10.3
[U.]  #017  ethtool                           7.0 x2 -> 7.1 x2
[C.]  #018  expat                             2.8.2 x2, 2.8.2-dev -> 2.8.2 x3, 2.8.2-dev
[U*]  #019  findutils                         4.10.0, 4.10.0_fish-completions, 4.10.0-info -> 4.11.0, 4.11.0_fish-completions, 4.11.0-info
[U.]  #020  fluidsynth                        2.5.5 -> 2.5.6
[U*]  #021  fontconfig                        2.18.1 x2, 2.18.1-bin, 2.18.1-dev, 2.18.1_fish-completions, 2.18.1-lib x2 -> 2.18.2 x2, 2.18.2-bin, 2.18.2-dev, 2.18.2_fish-completions, 2.18.2-lib x2
[U.]  #022  fzf                               0.74.1, 0.74.1-fish-completions, 0.74.1-man -> 0.74.2, 0.74.2-fish-completions, 0.74.2-man
[C.]  #023  gcc                               15.3.0-lib x2, 15.3.0-libgcc x2 -> 15.3.0-lib x3, 15.3.0-libgcc x3
[C.]  #024  gdbm                              1.26-lib x2 -> 1.26-lib x3
[U*]  #025  geoclue                           2.7.2, 2.7.2_fish-completions -> 2.8.1, 2.8.1_fish-completions
[C.]  #026  gettext                           1.0 -> 1.0 x2
[U.]  #027  gh                                2.96.0, 2.96.0-fish-completions -> 2.97.0, 2.97.0-fish-completions
[C*]  #028  git                               2.55.0, 2.55.0-doc, 2.55.0-fish-completions x2 -> 2.55.0 x2, 2.55.0-doc x2, 2.55.0_fish-completions x2
[C*]  #029  glibc                             2.42-67 x2, 2.42-67-bin x2, 2.42-67-dev, 2.42-67-getent -> 2.42-67 x3, 2.42-67-bin x2, 2.42-67-dev, 2.42-67-getent
[C.]  #030  gmp-with-cxx                      6.3.0 x4, 6.3.0-dev -> 6.3.0 x5, 6.3.0-dev
[C*]  #031  gnugrep                           3.12 x2, 3.12_fish-completions, 3.12-info -> 3.12 x3, 3.12_fish-completions, 3.12-info
[C*]  #032  gnused                            4.10 x2, 4.10_fish-completions, 4.10-info -> 4.10 x3, 4.10_fish-completions, 4.10-info
[C*]  #033  gnutar                            1.35 x2, 1.35_fish-completions, 1.35-info -> 1.35, 1.35_fish-completions, 1.35-info
[U.]  #034  graphviz                          14.1.2 -> 15.1.0
[U.]  #035  gst-devtools                      1.28.4 -> 1.28.5
[U.]  #036  gst-editing-services              1.28.4 -> 1.28.5
[U.]  #037  gst-libav                         1.28.4 -> 1.28.5
[U.]  #038  gst-plugins-bad                   1.28.4 -> 1.28.5
[U.]  #039  gst-plugins-base                  1.28.4 x2 -> 1.28.5 x2
[U.]  #040  gst-plugins-good                  1.28.4 x2 -> 1.28.5 x2
[U.]  #041  gst-plugins-ugly                  1.28.4 -> 1.28.5
[U.]  #042  gst-rtsp-server                   1.28.4 -> 1.28.5
[U.]  #043  gstreamer                         1.28.4 x2, 1.28.4-bin -> 1.28.5 x2, 1.28.5-bin
[C*]  #044  gzip                              1.14, 1.14-info, 1.14-man -> 1.14 x2, 1.14-info, 1.14-man
[U.]  #045  headsetcontrol                    3.1.0, 3.1.0-fish-completions -> 4.0.0, 4.0.0-fish-completions
[U.]  #046  imagemagick                       7.1.2-27, 7.1.2-27-fish-completions -> 7.1.2-29, 7.1.2-29-fish-completions
[U.]  #047  initrd-linux                      6.18.40 -> 6.18.41
[C.]  #048  keyutils                          1.6.3-lib x2 -> 1.6.3-lib x3
[U.]  #049  kirigami-addons                   1.13.0 -> 1.13.1
[C.]  #050  krb5                              1.22.2, 1.22.2-lib x2 -> 1.22.2, 1.22.2-lib x3
[C.]  #051  ldns                              1.9.2 -> 1.9.2 x2
[U.]  #052  libapparmor                       5.0.1 x2 -> 5.0.2 x2
[C.]  #053  libcap-ng                         0.9.3 x2 -> 0.9.3 x3
[C.]  #054  libcbor                           0.14.0 x2 -> 0.14.0 x3
[C.]  #055  libedit                           20260508-3.1 x2 -> 20260508-3.1 x3
[C.]  #056  libffi                            3.7.0 x2, 3.7.0-dev -> 3.7.0, 3.7.1 x2, 3.7.1-dev
[C.]  #057  libfido2                          1.17.0 x2 -> 1.17.0 x3
[C.]  #058  libidn2                           2.3.8 x2 -> 2.3.8 x3
[U.]  #059  libmicrohttpd                     1.0.5 x2 -> 1.0.6 x2
[U.]  #060  libmysofa                         1.3.3 x2 -> 1.3.4 x2
[U.]  #061  libphonenumber                    9.0.35 -> 9.0.36
[C.]  #062  libpsl                            0.21.5 x2 -> 0.21.5 x3
[U.]  #063  libsodium                         1.0.22-unstable-2026-04-16 -> 1.0.22-unstable-2026-07-08
[U.]  #064  libssh                            0.12.0 x2 -> 0.12.1 x2
[C.]  #065  libssh2                           1.11.1 x2 -> 1.11.1 x3
[U.]  #066  libtiff                           4.7.1 x2, 4.7.1-bin, 4.7.1-dev, 4.7.1-man -> 4.7.2 x2, 4.7.2-bin, 4.7.2-dev, 4.7.2-man
[U.]  #067  libtool                           2.5.4-lib x2 -> 2.6.2-lib x2
[C.]  #068  libunistring                      1.4.2 x2 -> 1.4.2 x3
[C.]  #069  libxcrypt                         4.5.2 x2, 4.5.2-man -> 4.5.2 x3, 4.5.2-man
[U.]  #070  linux                             6.18.40, 6.18.40-modules x2 -> 6.18.41, 6.18.41-modules x2
[U.]  #071  linux-headers                     7.0 -> 7.1
[U.]  #072  linux-headers-static              7.0 -> 7.1
[C*]  #073  linux-pam                         1.7.2 x2, 1.7.2-doc, 1.7.2-man -> 1.7.2 x3, 1.7.2-doc, 1.7.2-man
[C.]  #074  mailcap                           2.1.54 x2 -> 2.1.54 x3
[U.]  #075  mbedtls                           3.6.6 x2 -> 3.6.7 x2
[U.]  #076  mesa                              26.1.5 x2 -> 26.1.6 x2
[C.]  #077  mpdecimal                         4.0.1 x2 -> 4.0.1 x3
[C*]  #078  ncurses                           6.6 x2, 6.6-man -> 6.6 x3, 6.6-man
[C.]  #079  nghttp2                           1.69.0-lib x2 -> 1.69.0-lib x3
[C.]  #080  nghttp3                           1.16.0 x2 -> 1.16.0 x3
[C.]  #081  ngtcp2                            1.23.0 x2, 1.24.0 -> 1.23.0 x3, 1.25.0
[U*]  #082  nh                                4.4.1, 4.4.1_fish-completions -> 4.4.2, 4.4.2_fish-completions
[U.]  #083  nh-unwrapped                      4.4.1 -> 4.4.2
[U*]  #084  nix-output-monitor                2.1.8, 2.1.8-fish-completions -> 2.2.0, 2.2.0-fish-completions
[U.]  #085  nixos-system-tanchico             26.11.20260726.624af66 -> 26.11.20260801.148bab9
[U.]  #086  nss-cacert                        3.125, 3.125-fish-completions, 3.125-p11kit -> 3.126, 3.126-fish-completions, 3.126-p11kit
[U.]  #087  openexr                           3.4.11 -> 3.4.13
[C*]  #088  openssh                           10.4p1, 10.4p1-man -> 10.4p1 x2, 10.4p1-man
[C.]  #089  openssl                           3.6.3 x2, 3.6.3-bin, 3.6.3-dev, 3.6.3-man -> 3.6.3 x3, 3.6.3-bin, 3.6.3-dev, 3.6.3-man
[U.]  #090  passt                             2025_09_19.623dbf6 -> 2026_07_16.090d739
[C.]  #091  pcre2                             10.47 x2, 10.47-bin, 10.47-dev -> 10.47 x3, 10.47-bin, 10.47-dev
[C*]  #092  pcsclite                          2.4.1, 2.4.1-doc, 2.4.1-lib x2, 2.4.1-man -> 2.4.1, 2.4.1-doc, 2.4.1-lib x3, 2.4.1-man
[C*]  #093  perl                              5.42.0 x2, 5.42.0-env x3, 5.42.0-man -> 5.42.0 x3, 5.42.0-env x3, 5.42.0-man
[C.]  #094  perl5.42.0-Authen-SASL            2.1900 -> 2.1900 x2
[C.]  #095  perl5.42.0-CGI                    4.59 -> 4.59 x2
[C.]  #096  perl5.42.0-CGI-Fast               2.16 -> 2.16 x2
[C.]  #097  perl5.42.0-Clone                  0.46 x2 -> 0.46 x3
[C.]  #098  perl5.42.0-Compress-Raw-Bzip2     2.218 x2 -> 2.218 x3
[C.]  #099  perl5.42.0-Compress-Raw-Zlib      2.222 x2 -> 2.222 x3
[C.]  #100  perl5.42.0-Crypt-URandom          0.55 -> 0.55 x2
[C.]  #101  perl5.42.0-Digest-HMAC            1.05 -> 1.05 x2
[C.]  #102  perl5.42.0-Encode-Locale          1.05 x2 -> 1.05 x3
[C.]  #103  perl5.42.0-FCGI                   0.82 -> 0.82 x2
[C.]  #104  perl5.42.0-FCGI-ProcManager       0.28 -> 0.28 x2
[C.]  #105  perl5.42.0-File-Listing           6.16 x2 -> 6.16 x3
[C.]  #106  perl5.42.0-HTML-Parser            3.85 x2 -> 3.85 x3
[C.]  #107  perl5.42.0-HTML-TagCloud          0.38 -> 0.38 x2
[C.]  #108  perl5.42.0-HTML-Tagset            3.20 x2 -> 3.20 x3
[C.]  #109  perl5.42.0-HTTP-CookieJar         0.014 x2 -> 0.014 x3
[C.]  #110  perl5.42.0-HTTP-Cookies           6.10 x2 -> 6.10 x3
[C.]  #111  perl5.42.0-HTTP-Daemon            6.17 x2 -> 6.17 x3
[C.]  #112  perl5.42.0-HTTP-Date              6.06 x2 -> 6.06 x3
[C.]  #113  perl5.42.0-HTTP-Message           7.02 x2 -> 7.02 x3
[C.]  #114  perl5.42.0-HTTP-Negotiate         6.01 x2 -> 6.01 x3
[C.]  #115  perl5.42.0-IO-Compress            2.221 x2 -> 2.221 x3
[C.]  #116  perl5.42.0-IO-HTML                1.004 x2 -> 1.004 x3
[C.]  #117  perl5.42.0-IO-Socket-SSL          2.083 -> 2.083 x2
[C.]  #118  perl5.42.0-LWP-MediaTypes         6.04 x2 -> 6.04 x3
[C.]  #119  perl5.42.0-Mozilla-CA             20230821 -> 20230821 x2
[C.]  #120  perl5.42.0-Net-HTTP               6.23 x2 -> 6.23 x3
[C.]  #121  perl5.42.0-Net-SMTP-SSL           1.04 -> 1.04 x2
[C.]  #122  perl5.42.0-Net-SSLeay             1.92 -> 1.92 x2
[C.]  #123  perl5.42.0-TermReadKey            2.38 -> 2.38 x2
[C.]  #124  perl5.42.0-Test-Fatal             0.017 x2 -> 0.017 x3
[C.]  #125  perl5.42.0-Test-Needs             0.002010 x2 -> 0.002010 x3
[C.]  #126  perl5.42.0-Test-RequiresInternet  0.05 x2 -> 0.05 x3
[C.]  #127  perl5.42.0-TimeDate               2.33 x2 -> 2.33 x3
[C.]  #128  perl5.42.0-Try-Tiny               0.31 x2 -> 0.31 x3
[C.]  #129  perl5.42.0-URI                    5.21 x2 -> 5.21 x3
[C.]  #130  perl5.42.0-WWW-RobotRules         6.02 x2 -> 6.02 x3
[C.]  #131  perl5.42.0-libnet                 3.15 -> 3.15 x2
[C.]  #132  perl5.42.0-libwww-perl            6.83 x2 -> 6.83 x3
[C*]  #133  plymouth                          26.134.222, 26.134.222_fish-completions -> 26.134.222 x2, 26.134.222_fish-completions
[C.]  #134  publicsuffix-list                 0-unstable-2026-06-24 x2 -> 0-unstable-2026-06-24 x3
[C.]  #135  python3                           3.14.6 x2, 3.14.6-env x4 -> 3.14.6 x3, 3.14.6-env x4
[U.]  #136  python3.14-gst-python             1.28.4 -> 1.28.5
[C.]  #137  readline                          8.3p3 x2 -> 8.3p3 x3
[U.]  #138  s2n-tls                           1.7.2 -> 1.7.6
[U.]  #139  spidermonkey                      140.11.0 -> 140.13.0
[C.]  #140  sqlite                            3.53.3 x2, 3.53.3-bin, 3.53.3-dev -> 3.53.3 x3, 3.53.3-bin, 3.53.3-dev
[U.]  #141  srt                               1.5.5 x2 -> 1.5.6 x2
[C*]  #142  systemd                           <none>, 261 x2, 261-dev, 261-man -> <none>, 261.1 x3, 261.1-dev, 261.1-man
[U.]  #143  systemd-minimal                   261 x2 -> 261.1 x2
[C.]  #144  systemd-minimal-libs              261 x2, 261-dev -> 261, 261.1 x2, 261.1-dev
[C.]  #145  tzdata                            2026b x2 -> 2026b, 2026c x2
[U.]  #146  unbound                           1.25.1-lib x2 -> 1.25.2-lib x2

_… diff truncated (172 lines total); see the `closure-diff-tanchico` artifact for the full output._

</details>

<details><summary><b>terangreal</b></summary>

```
<<< result-old
>>> result-new
Version changes:
[C.]  #001  abseil-cpp                        20260107.1 x3, 20260107.1-dev -> 20260107.1 x4, 20260107.1-dev
[C*]  #002  acl                               2.3.2 x2, 2.4.0 x2, 2.4.0-bin, 2.4.0-doc, 2.4.0-man -> 2.3.2 x2, 2.4.0 x3, 2.4.0-bin, 2.4.0-doc, 2.4.0-man
[C.]  #003  alsa-lib                          1.2.14, 1.2.16, 1.2.16.1 x2 -> 1.2.14, 1.2.16, 1.2.16.1 x3
[C.]  #004  alsa-topology-conf                1.2.5.1 x4 -> 1.2.5.1 x5
[C.]  #005  alsa-ucm-conf                     1.2.14, 1.2.16, 1.2.16.1 x2 -> 1.2.14, 1.2.16, 1.2.16.1 x3
[U.]  #006  aquamarine                        0.13.0, 0.13.0+date=2026-07-18_9b5f14d -> 0.14.0, 0.14.0+date=2026-07-29_fc39af0
[C*]  #007  attr                              2.5.2 x2, 2.6.0 x2, 2.6.0-bin, 2.6.0-doc, 2.6.0-man -> 2.5.2 x2, 2.6.0 x3, 2.6.0-bin, 2.6.0-doc, 2.6.0-man
[C.]  #008  audit                             4.1.4-lib x3 -> 4.1.4-lib x2, 4.2-lib x2
[C.]  #009  avahi                             0.8 x4 -> 0.8 x5
[C.]  #010  bash                              5.3p3, 5.3p9, 5.3p15 x2 -> 5.3p3, 5.3p9, 5.3p15 x3
[C*]  #011  bash-interactive                  5.3p9, 5.3p15, 5.3p15-doc, 5.3p15-info, 5.3p15-man -> 5.3p9, 5.3p15 x2, 5.3p15-doc, 5.3p15-info, 5.3p15-man
[U*]  #012  bind                              9.20.24-host, 9.20.24-lib, 9.20.24-man -> 9.20.26-host, 9.20.26-lib, 9.20.26-man
[C.]  #013  bluez                             5.86 x3 -> 5.86 x4
[C.]  #014  brotli                            1.1.0-lib, 1.2.0, 1.2.0-dev, 1.2.0-lib x3 -> 1.1.0-lib, 1.2.0, 1.2.0-dev, 1.2.0-lib x4
[C*]  #015  bzip2                             1.0.8 x4, 1.0.8-bin, 1.0.8-dev, 1.0.8-man -> 1.0.8 x5, 1.0.8-bin, 1.0.8-dev, 1.0.8-man
[C.]  #016  cairo                             1.18.4 x4, 1.18.4-dev -> 1.18.4 x5, 1.18.4-dev
[C.]  #017  cdparanoia-iii                    10.2 x3 -> 10.2 x4
[C.]  #018  cjson                             1.7.19 x3 -> 1.7.19 x4
[C.]  #019  clang                             21.1.8 x2, 21.1.8-lib x2 -> 21.1.8, 21.1.8-lib
[C.]  #020  coreutils                         9.7, 9.11 x3 -> 9.7, 9.11 x4
[U*]  #021  cpupower                          6.18.40, 6.18.40_fish-completions -> 6.18.41, 6.18.41_fish-completions
[C.]  #022  cracklib                          2.10.3 x3 -> 2.10.3 x4
[C*]  #023  cryptsetup                        2.8.6 x3, 2.8.6-bin, 2.8.6-man -> 2.8.6 x4, 2.8.6-bin, 2.8.6-man
[C*]  #024  curl                              8.21.0 x3, 8.21.0-bin, 8.21.0-dev, 8.21.0-man -> 8.21.0 x4, 8.21.0-bin, 8.21.0-man
[U.]  #025  dash                              0.5.13.4 -> 0.5.13.5
[C.]  #026  dav1d                             1.5.3 x3 -> 1.5.3 x4
[C.]  #027  db                                4.8.30 x3, 5.3.28 -> 4.8.30 x4, 5.3.28
[C*]  #028  dbus                              1, 1.14.10-lib, 1.16.2 x2, 1.16.2-dev x2, 1.16.2-doc, 1.16.2-lib x3, 1.16.2-man -> 1, 1.14.10-lib, 1.16.2 x2, 1.16.2-dev x2, 1.16.2-doc, 1.16.2-lib x4, 1.16.2-man
[C*]  #029  dconf                             0.40.0-lib, 0.49.0, 0.49.0_fish-completions, 0.49.0-lib x3 -> 0.40.0-lib, 0.49.0, 0.49.0_fish-completions, 0.49.0-lib x4
[C.]  #030  dejavu-fonts-minimal              2.37 x4 -> 2.37 x5
[C.]  #031  dns-root-data                     2025-04-14 x4 -> 2025-04-14 x5
[U.]  #032  electron                          41.9.1 -> 41.10.3
[U.]  #033  electron-unwrapped                41.9.1 -> 41.10.3
[C.]  #034  elfutils                          0.195 x3 -> 0.195 x4
[C.]  #035  ell                               0.83 x3 -> 0.83 x4
[U.]  #036  emacs-evil-ghostel                0.45.0 -> 0.48.0
[U.]  #037  emacs-ghostel                     0.45.0 -> 0.48.0
[U.]  #038  ethtool                           7.0 -> 7.1
[C.]  #039  expat                             2.7.1, 2.8.2 x3, 2.8.2-dev -> 2.7.1, 2.8.2 x4, 2.8.2-dev
[C.]  #040  fdk-aac                           2.0.3 x3 -> 2.0.3 x4
[C.]  #041  ffado                             2.4.9 x3 -> 2.4.9 x4
[C.]  #042  ffmpeg-headless                   8.1.2-data x3, 8.1.2-lib x3 -> 8.1.2-data x4, 8.1.2-lib x4
[C.]  #043  fftw-double                       3.3.11 x3 -> 3.3.11 x4
[C.]  #044  fftw-single                       3.3.11 x3 -> 3.3.11 x4
[C.]  #045  file                              5.45, 5.48 x3 -> 5.45, 5.48 x4
[U*]  #046  findutils                         4.10.0, 4.10.0_fish-completions, 4.10.0-info -> 4.11.0, 4.11.0_fish-completions, 4.11.0-info
[C.]  #047  flac                              1.5.0 x3 -> 1.5.0 x4
[U.]  #048  fluidsynth                        2.5.5 -> 2.5.6
[C*]  #049  fontconfig                        2.16.2, 2.16.2-lib, 2.18.1 x3, 2.18.1-bin, 2.18.1-dev, 2.18.1_fish-completions, 2.18.1-lib x3 -> 2.16.2, 2.16.2-lib, 2.18.1 x2, 2.18.1-lib x2, 2.18.2 x2, 2.18.2-bin, 2.18.2-dev, 2.18.2_fish-completions, 2.18.2-lib x2
[C.]  #050  freetype                          2.13.3, 2.14.3 x3, 2.14.3-dev -> 2.13.3, 2.14.3 x4, 2.14.3-dev
[C.]  #051  fribidi                           1.0.16 x4, 1.0.16-dev -> 1.0.16 x5, 1.0.16-dev
[U.]  #052  fzf                               0.74.1, 0.74.1-fish-completions, 0.74.1-man -> 0.74.2, 0.74.2-fish-completions, 0.74.2-man
[C*]  #053  gawk                              5.4.0, 5.4.1, 5.4.1-info, 5.4.1-man -> 5.4.1 x2, 5.4.1-info, 5.4.1-man
[C.]  #054  gcc                               14.3.0-lib, 14.3.0-libgcc, 15.2.0, 15.2.0-lib x2, 15.2.0-libgcc x2, 15.3.0, 15.3.0-lib x2, 15.3.0-libgcc x2, 16.1.0-lib x2, 16.1.0-libgcc x2 -> 14.3.0-lib, 14.3.0-libgcc, 15.2.0-lib, 15.2.0-libgcc, 15.3.0 x2, 15.3.0-lib x4, 15.3.0-libgcc x4, 16.1.0-lib x2, 16.1.0-libgcc x2
[C.]  #055  gdbm                              1.26-lib x3 -> 1.26-lib x4
[C.]  #056  gdk-pixbuf                        2.42.12, 2.44.6 x2, 2.44.6-dev -> 2.42.12, 2.44.6 x3, 2.44.6-dev
[U.]  #057  geoclue                           2.7.2 -> 2.8.1
[C.]  #058  gettext                           1.0 x2 -> 1.0 x3
[U.]  #059  gh                                2.96.0, 2.96.0-fish-completions -> 2.97.0, 2.97.0-fish-completions
[C.]  #060  giflib                            5.2.2, 6.1.3 x3 -> 5.2.2, 6.1.3 x4
[C*]  #061  git                               2.54.0, 2.54.0-doc, 2.55.0, 2.55.0-doc, 2.55.0_fish-completions x2 -> 2.54.0, 2.54.0-doc, 2.55.0 x2, 2.55.0-doc x2, 2.55.0_fish-completions x2
[C.]  #062  glib                              2.84.4, 2.88.1 x3, 2.88.1-bin x2, 2.88.1-dev, 2.88.1-fish-completions -> 2.84.4, 2.88.1 x4, 2.88.1-bin x3, 2.88.1-dev, 2.88.1-fish-completions
[C*]  #063  glibc                             2.40-66, 2.40-66-getent, 2.42-67 x3, 2.42-67-bin x2, 2.42-67-dev x2, 2.42-67-getent -> 2.40-66, 2.40-66-getent, 2.42-67 x4, 2.42-67-bin x3, 2.42-67-dev x2, 2.42-67-getent
[C.]  #064  glibmm                            2.66.8 x3, 2.88.0 -> 2.66.8 x4, 2.88.0
[C.]  #065  gmp-with-cxx                      6.3.0 x8, 6.3.0-dev -> 6.3.0 x10, 6.3.0-dev
[C*]  #066  gnugrep                           3.12 x2, 3.12_fish-completions, 3.12-info -> 3.12 x3, 3.12_fish-completions, 3.12-info
[C.]  #067  gnum4                             1.4.21 x3 -> 1.4.21 x4
[C*]  #068  gnused                            4.10 x2, 4.10_fish-completions, 4.10-info -> 4.10 x3, 4.10_fish-completions, 4.10-info
[C.]  #069  gnutls                            3.8.10, 3.8.13 x3 -> 3.8.10, 3.8.13 x4
[C.]  #070  graphene                          1.10.8 x3 -> 1.10.8 x4
[C.]  #071  graphite2                         1.3.14, 1.3.15 x3, 1.3.15-dev -> 1.3.14, 1.3.15 x4, 1.3.15-dev
[U.]  #072  graphviz                          14.1.2 -> 15.1.0
[U.]  #073  gst-libav                         1.28.4 -> 1.28.5
[U.]  #074  gst-plugins-bad                   1.28.4 -> 1.28.5
[C.]  #075  gst-plugins-base                  1.28.4 x3 -> 1.28.4 x2, 1.28.5 x2
[U.]  #076  gst-plugins-good                  1.28.4 -> 1.28.5
[C.]  #077  gstreamer                         1.28.4 x3 -> 1.28.4 x2, 1.28.5 x2
[C.]  #078  gtest                             1.17.0 x3, 1.17.0-dev -> 1.17.0 x4, 1.17.0-dev
[C*]  #079  gzip                              1.14 x2, 1.14-info, 1.14-man -> 1.14 x3, 1.14-info, 1.14-man
[C.]  #080  harfbuzz                          11.2.1, 13.2.1 x3, 13.2.1-dev -> 11.2.1, 13.2.1 x4, 13.2.1-dev
[U.]  #081  headsetcontrol                    3.1.0, 3.1.0-fish-completions -> 4.0.0, 4.0.0-fish-completions
[C.]  #082  hwdata                            0.408, 0.409 x2 -> 0.408, 0.409 x3
[U*]  #083  hyprland                          0.56.0, 0.56.0+date=2026-07-26_d8dc503, 0.56.0+date=2026-07-26_d8dc503-man -> 0.56.0+date=2026-08-01_88c6386, 0.56.0+date=2026-08-01_88c6386-man, 0.56.1
[U.]  #084  hyprland-guiutils                 0.2.1+date=2026-07-16_a6ccb6c -> 0.2.2+date=2026-07-20_a16ad89
[C.]  #085  hyprutils                         0.13.1, 0.14.0, 0.14.0+date=2026-07-17_5f03477, 0.14.0+date=2026-07-17_5f03477-dev -> 0.14.0 x2, 0.14.0+date=2026-07-19_83da5ee, 0.14.0+date=2026-07-19_83da5ee-dev
[C.]  #086  hyprwire                          0.3.1, 0.3.1+date=2026-05-10_85148a8 -> 0.3.1, 0.3.1+date=2026-07-19_7d935bb
[C.]  #087  icu4c                             76.1 x2, 77.1, 78.3 x2, 78.3-dev -> 76.1 x2, 77.1, 78.3 x3, 78.3-dev
[U.]  #088  imagemagick                       7.1.2-27, 7.1.2-27-fish-completions -> 7.1.2-29, 7.1.2-29-fish-completions
[U.]  #089  initrd-linux                      6.18.40 -> 6.18.41
[C.]  #090  iso-codes                         4.18.0, 4.20.1 x3 -> 4.18.0, 4.20.1 x4
[C.]  #091  json-c                            0.18 x3 -> 0.18 x4
[C*]  #092  kbd                               2.8.0-unstable-2025-08-12, 2.9.0 x3, 2.9.0-man -> 2.8.0-unstable-2025-08-12, 2.9.0 x4, 2.9.0-man
[C*]  #093  kexec-tools                       2.0.31, 2.0.32 x3, 2.0.32_fish-completions -> 2.0.31, 2.0.32 x4, 2.0.32_fish-completions
[C.]  #094  keyutils                          1.6.3-lib x3 -> 1.6.3-lib x4
[U.]  #095  kirigami-addons                   1.13.0 -> 1.13.1
[C*]  #096  kmod                              31 x4, 31-lib x4, 31-man -> 31 x5, 31-lib x5, 31-man
[C.]  #097  krb5                              1.22.2, 1.22.2-dev, 1.22.2-lib x3 -> 1.22.2-lib x4
[C.]  #098  lame                              3.100-lib x3 -> 3.100-lib x4
[C.]  #099  lcms2                             2.17, 2.19.1 x3 -> 2.17, 2.19.1 x4
[C.]  #100  ldacbt                            2.0.72 x3 -> 2.0.72 x4
[C.]  #101  ldns                              1.9.2 x2 -> 1.9.2 x3
[C.]  #102  lerc                              4.0.0, 4.1.0, 4.1.1 x2, 4.1.1-dev -> 4.0.0, 4.1.0, 4.1.1 x3, 4.1.1-dev
[C.]  #103  libao                             1.2.2 x3 -> 1.2.2 x4
[C.]  #104  libaom                            3.12.1 x3 -> 3.12.1 x4
[C.]  #105  libapparmor                       5.0.0, 5.0.1 x2 -> 5.0.0, 5.0.1, 5.0.2 x2
[C.]  #106  libarchive                        3.8.8-lib x3 -> 3.8.8-lib x4
[C.]  #107  libass                            0.17.4 x3 -> 0.17.4 x4
[C.]  #108  libavc1394                        0.5.4 x3 -> 0.5.4 x4
[C.]  #109  libbluray                         1.4.1 x3 -> 1.4.1 x4
[C.]  #110  libbpf                            1.7.0 x3 -> 1.7.0 x4
[C.]  #111  libbsd                            0.12.2 x2 -> 0.12.2 x3
[C.]  #112  libcamera                         0.7.0 x3 -> 0.7.0 x4
[C.]  #113  libcanberra                       0.30 x4 -> 0.30 x5
[C*]  #114  libcap                            2.76-lib, 2.78, 2.78-doc, 2.78-lib x3, 2.78-man -> 2.76-lib, 2.78, 2.78-doc, 2.78-lib x4, 2.78-man
[C.]  #115  libcap-ng                         0.9.3 x3 -> 0.9.3 x4
[C.]  #116  libcbor                           0.14.0 x3 -> 0.14.0 x4
[C.]  #117  libconfig                         1.8.2 x3 -> 1.8.2 x4
[C.]  #118  libdaemon                         0.14 x4 -> 0.14 x5
[C.]  #119  libdatrie                         2019-12-20, 2019-12-20-bin, 2019-12-20-dev, 2019-12-20-lib x4 -> 2019-12-20, 2019-12-20-bin, 2019-12-20-dev, 2019-12-20-lib x5
[C.]  #120  libdeflate                        1.24, 1.25 x3 -> 1.24, 1.25 x4
[C.]  #121  libdisplay-info                   0.3.0, 0.4.0 x2 -> 0.4.0 x3
[C.]  #122  libdrm                            2.4.134 x3, 2.4.134-bin x3, 2.4.134-dev x3 -> 2.4.134 x4, 2.4.134-bin x3, 2.4.134-dev x3
[C.]  #123  libebur128                        1.2.6 x3 -> 1.2.6 x4
[C.]  #124  libedit                           20260508-3.1 x2 -> 20260508-3.1 x3
[C.]  #125  libevent                          2.1.12 x2, 2.1.13 x2 -> 2.1.12 x2, 2.1.13 x3
[C.]  #126  libffi                            3.5.1, 3.5.2, 3.7.0 x2, 3.7.0-dev -> 3.5.1, 3.5.2, 3.7.0, 3.7.1 x2, 3.7.1-dev
[C.]  #127  libfido2                          1.17.0 x3 -> 1.17.0 x4
[C.]  #128  libfreeaptx                       0.2.2 x3 -> 0.2.2 x4
[C.]  #129  libgcrypt                         1.12.2-lib x3 -> 1.12.2-lib x4
[C.]  #130  libglvnd                          1.7.0 x4, 1.7.0-dev -> 1.7.0 x5, 1.7.0-dev
[C.]  #131  libgpg-error                      1.61 x3 -> 1.61 x4
[C.]  #132  libical                           3.0.20 x3 -> 3.0.20 x4
[C.]  #133  libidn2                           2.3.8 x4, 2.3.8-bin, 2.3.8-dev -> 2.3.8 x5
[C.]  #134  libiec61883                       1.2.0 x3 -> 1.2.0 x4
[C.]  #135  libjack2                          1.9.22 x3 -> 1.9.22 x4
[C.]  #136  libjpeg-turbo                     3.1.1, 3.1.4.1 x3, 3.1.4.1-bin, 3.1.4.1-dev -> 3.1.1, 3.1.4.1 x4, 3.1.4.1-bin, 3.1.4.1-dev
[C.]  #137  libjxl                            0.11.2, 0.12.0 -> 0.12.0 x2
[C.]  #138  liblc3                            1.1.3 x3 -> 1.1.3 x4
[C.]  #139  libmad                            0.15.1b x3 -> 0.15.1b x4
[C.]  #140  libmd                             1.2.0 x2 -> 1.2.0 x3
[C.]  #141  libmicrohttpd                     1.0.5 x3 -> 1.0.5 x2, 1.0.6 x2
[C.]  #142  libmpg123                         1.33.5, 1.33.6 x2 -> 1.33.5, 1.33.6 x3
[C.]  #143  libmysofa                         1.3.3 x3 -> 1.3.3 x2, 1.3.4 x2
[C.]  #144  libnotify                         0.8.8 x2, 0.8.8-fish-completions, 0.8.8-man -> 0.8.8 x3, 0.8.8-fish-completions, 0.8.8-man
[C.]  #145  libogg                            1.3.6 x3 -> 1.3.6 x4
[C.]  #146  libopenmpt                        0.8.7 x3 -> 0.8.7 x4

_… diff truncated (348 lines total); see the `closure-diff-terangreal` artifact for the full output._

</details>

<details><summary><b>tuathaan</b></summary>

```
<<< result-old
>>> result-new
Version changes:
[C.]  #001  abseil-cpp                        20260107.1 x3, 20260107.1-dev -> 20260107.1 x4, 20260107.1-dev
[C*]  #002  acl                               2.3.2 x2, 2.4.0 x2, 2.4.0-bin, 2.4.0-doc, 2.4.0-man -> 2.3.2 x2, 2.4.0 x3, 2.4.0-bin, 2.4.0-doc, 2.4.0-man
[C.]  #003  alsa-lib                          1.2.14, 1.2.16, 1.2.16.1 x2 -> 1.2.14, 1.2.16, 1.2.16.1 x3
[C.]  #004  alsa-topology-conf                1.2.5.1 x4 -> 1.2.5.1 x5
[C.]  #005  alsa-ucm-conf                     1.2.14, 1.2.16, 1.2.16.1 x2 -> 1.2.14, 1.2.16, 1.2.16.1 x3
[U.]  #006  aquamarine                        0.13.0, 0.13.0+date=2026-07-18_9b5f14d -> 0.14.0, 0.14.0+date=2026-07-29_fc39af0
[C*]  #007  attr                              2.5.2 x2, 2.6.0 x2, 2.6.0-bin, 2.6.0-doc, 2.6.0-man -> 2.5.2 x2, 2.6.0 x3, 2.6.0-bin, 2.6.0-doc, 2.6.0-man
[C.]  #008  audit                             4.1.4-lib x3 -> 4.1.4-lib x2, 4.2-lib x2
[C.]  #009  avahi                             0.8 x4 -> 0.8 x5
[C.]  #010  bash                              5.3p3, 5.3p9, 5.3p15 x2 -> 5.3p3, 5.3p9, 5.3p15 x3
[C*]  #011  bash-interactive                  5.3p9, 5.3p15, 5.3p15-doc, 5.3p15-info, 5.3p15-man -> 5.3p9, 5.3p15 x2, 5.3p15-doc, 5.3p15-info, 5.3p15-man
[U*]  #012  bind                              9.20.24-host, 9.20.24-lib, 9.20.24-man -> 9.20.26-host, 9.20.26-lib, 9.20.26-man
[C*]  #013  bluez                             5.86 x3, 5.86_fish-completions -> 5.86 x4, 5.86_fish-completions
[C.]  #014  brotli                            1.1.0-lib, 1.2.0, 1.2.0-dev, 1.2.0-lib x3 -> 1.1.0-lib, 1.2.0, 1.2.0-dev, 1.2.0-lib x4
[C*]  #015  bzip2                             1.0.8 x4, 1.0.8-bin, 1.0.8-dev, 1.0.8-man -> 1.0.8 x5, 1.0.8-bin, 1.0.8-dev, 1.0.8-man
[C.]  #016  cairo                             1.18.4 x4, 1.18.4-dev -> 1.18.4 x5, 1.18.4-dev
[C.]  #017  cdparanoia-iii                    10.2 x3 -> 10.2 x4
[C.]  #018  cjson                             1.7.19 x3 -> 1.7.19 x4
[C.]  #019  clang                             21.1.8 x2, 21.1.8-lib x2 -> 21.1.8, 21.1.8-lib
[C.]  #020  coreutils                         9.7, 9.11 x3 -> 9.7, 9.11 x4
[U*]  #021  cpupower                          6.18.40, 6.18.40_fish-completions -> 6.18.41, 6.18.41_fish-completions
[C.]  #022  cracklib                          2.10.3 x3 -> 2.10.3 x4
[C*]  #023  cryptsetup                        2.8.6 x3, 2.8.6-bin, 2.8.6-man -> 2.8.6 x4, 2.8.6-bin, 2.8.6-man
[C*]  #024  curl                              8.21.0 x3, 8.21.0-bin, 8.21.0-dev, 8.21.0-man -> 8.21.0 x4, 8.21.0-bin, 8.21.0-man
[U.]  #025  dash                              0.5.13.4 -> 0.5.13.5
[C.]  #026  dav1d                             1.5.3 x3 -> 1.5.3 x4


_… PR body truncated to stay under GitHub's size limit; see the closure-diff-* artifacts for full diffs._\n