### PR TITLE
Auto update 2026-08-09

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785330427,
-        "narHash": "sha256-RTKedehLwWxGblFY5Nop3T08EGKH1T+4zmDTddmZ8k4=",
+        "lastModified": 1785877886,
+        "narHash": "sha256-H2CrAlJD9FsUbSEIhPVK3IyVjnK0vSxPruBef17GcBs=",
         "owner": "hyprwm",
         "repo": "aquamarine",
-        "rev": "fc39af0ccec9171aec8185eaea8afb71a46eff90",
+        "rev": "1a10fe26a9f7d989c359e6a9ea61aa2e44d06c36",
         "type": "github"
       },
       "original": {
@@ -111,11 +111,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785563007,
-        "narHash": "sha256-00cOL/2oPEnSnmRK4yarCdUTBeFglwjhozeCC8MhJvY=",
+        "lastModified": 1786160519,
+        "narHash": "sha256-HxgpxNc0vZIOlCb4Cie0PN8Vk6PxS3I+56DoaQuxBFk=",
         "owner": "Gako358",
         "repo": "emacs-flake",
-        "rev": "b1fb553b01afaa7e5f6af10f7cc74ea8902b6635",
+        "rev": "5cd66cb3e7b832c13ad106501923576c2e26cc7f",
         "type": "github"
       },
       "original": {
@@ -225,11 +225,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1782949081,
-        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
+        "lastModified": 1785627969,
+        "narHash": "sha256-4dtXQk/NMePegK/nWp5NSeuZKLATItOq61lpEvmXqGw=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
+        "rev": "427bf4bd9435fdf21321c8cc628c24efc14c0f7a",
         "type": "github"
       },
       "original": {
@@ -392,11 +392,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785531816,
-        "narHash": "sha256-vkMnV0JIyw+g/NmcfoajlGaAO+9a0ezia+FZohQJrik=",
+        "lastModified": 1786031233,
+        "narHash": "sha256-TIDlLTLI1/pB7IqgjzcKQjpODQsZE2oII4XGG9B6KjI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "bf9ce9fec78f95f374e8dd3b503863a3ec128ebe",
+        "rev": "7834e82588860aaf780cec1366524456a70898d7",
         "type": "github"
       },
       "original": {
@@ -471,11 +471,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782566056,
-        "narHash": "sha256-haEZcHzYrePnjFOYSWTbxm/Nrla0aPslJfmvdCvqtVc=",
+        "lastModified": 1785855875,
+        "narHash": "sha256-dpW3UKG2NTboxxYGzOX4nZiH8YI++CpgosHmVaquOEI=",
         "owner": "hyprwm",
         "repo": "hyprgraphics",
-        "rev": "c6e7b9f673f4360bc813d3dc75028f75ee88d3f8",
+        "rev": "8699c38f0e4a1ca3bfc84f84ba020509ced1f133",
         "type": "github"
       },
       "original": {
@@ -536,11 +536,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1785600170,
-        "narHash": "sha256-FUYhESvUq9i4/VtGGr75w3nb3LA8qPKXG4Vs7+IjYD0=",
+        "lastModified": 1786227814,
+        "narHash": "sha256-FT4YNi3yr1lnuZPAj4CqBpxWYniUuPbvjIsLsttFjtI=",
         "owner": "hyprwm",
         "repo": "hyprland",
-        "rev": "88c6386994c960006e14c7bfa4ccfee873252882",
+        "rev": "5dee44a72476be67789f64e6c6bffae0df28c53a",
         "type": "github"
       },
       "original": {
@@ -633,11 +633,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785082040,
-        "narHash": "sha256-dLAwup4XzcAo4xo+BcVcNXNMXUnoHsY4X3HrZ17jgPs=",
+        "lastModified": 1786227627,
+        "narHash": "sha256-bc4jNVx0agB40xwxJ0r7hAAk5tk5Lm0uKtwP5rNyvZQ=",
         "owner": "hyprwm",
         "repo": "hyprland-plugins",
-        "rev": "81516add9b432b6ffc9f0906b92c9302c479c236",
+        "rev": "faf5ef1bd5916051ed3252463697dd2ae479f629",
         "type": "github"
       },
       "original": {
@@ -884,11 +884,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784458610,
-        "narHash": "sha256-A9Gb5wW2vMkYEec7DyCOBpEM6LwwpmQ/TIXEHhGgHUY=",
+        "lastModified": 1785843795,
+        "narHash": "sha256-DFc543bQN94Kt+RsD3Hiu7qCA1uKdqaFJKPMjzANKGU=",
         "owner": "hyprwm",
         "repo": "hyprutils",
-        "rev": "83da5ee98d806cef2d05a1072b8d8b832bf52891",
+        "rev": "5a7b8cf221914ce4714407950e4ffbdddcd8b66f",
         "type": "github"
       },
       "original": {
@@ -1061,11 +1061,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1785452604,
-        "narHash": "sha256-d0NKOOtI90kk8DAXNDkgYUZD8KK908bczz6zNLTC/zw=",
+        "lastModified": 1785749642,
+        "narHash": "sha256-5/wlGe3a4ucxvYq2cuAAsuSFWKcIttQ6En83MLlV2jY=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "c191775376b8734af02970153b4e5d86841dff19",
+        "rev": "f142433bdbeffd2af51231e0aff7162c2bfbf6ef",
         "type": "github"
       },
       "original": {
@@ -1155,11 +1155,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1782614948,
-        "narHash": "sha256-ePjCwr1sNm9NYUqywL7QfK3JnlS015msC+eBu2zKlp8=",
+        "lastModified": 1785031560,
+        "narHash": "sha256-OmshNvn2vupOFpYinLUu+1Dnpu4n7Q5N3ggGVNHpkUI=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "db3f255737b94216eb71cce308e2912cf6bc2d7c",
+        "rev": "0e79af5e3d4dcfcd676ab5ba3f95d2e3352e078c",
         "type": "github"
       },
       "original": {
@@ -1260,11 +1260,11 @@
     },
     "nixpkgs_10": {
       "locked": {
-        "lastModified": 1785571196,
-        "narHash": "sha256-KoTsyMQqnXQZq8deCEnu4QkyldkwH/bpMMhUcfMdGIw=",
+        "lastModified": 1786106723,
+        "narHash": "sha256-zDSUbpoeo/9ZmD2+wXnzxoo1+uhL8vxc0b8yuYMKYq0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "148bab9c1c3c53136ecb44a6ea356a0ed5b39b06",
+        "rev": "f13ff45afd1bb73e640eaa08a7066dbed07e3238",
         "type": "github"
       },
       "original": {
@@ -1305,11 +1305,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1785454630,
-        "narHash": "sha256-LQy14TZp77TwbQf40gg1V3jo8FwJG0jGDkAH+zRHqg8=",
+        "lastModified": 1786106723,
+        "narHash": "sha256-zDSUbpoeo/9ZmD2+wXnzxoo1+uhL8vxc0b8yuYMKYq0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1559d3daa3ecc813a650b79375ea61b6741b8746",
+        "rev": "f13ff45afd1bb73e640eaa08a7066dbed07e3238",
         "type": "github"
       },
       "original": {
@@ -1401,11 +1401,11 @@
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1785571196,
-        "narHash": "sha256-KoTsyMQqnXQZq8deCEnu4QkyldkwH/bpMMhUcfMdGIw=",
+        "lastModified": 1786106723,
+        "narHash": "sha256-zDSUbpoeo/9ZmD2+wXnzxoo1+uhL8vxc0b8yuYMKYq0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "148bab9c1c3c53136ecb44a6ea356a0ed5b39b06",
+        "rev": "f13ff45afd1bb73e640eaa08a7066dbed07e3238",
         "type": "github"
       },
       "original": {
@@ -1421,11 +1421,11 @@
         "nixpkgs": "nixpkgs_10"
       },
       "locked": {
-        "lastModified": 1785658849,
-        "narHash": "sha256-PgPkNVPZK8pl4h/FVAdqrWGsdYPrF0mYiA98myeAnfQ=",
+        "lastModified": 1786245143,
+        "narHash": "sha256-eLHhhkMP5kjmqqLcCO8jKaYNP1/ua/5kL6zTmQgWJVo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6755bdc2722c00441ce2c22ba57829310e199378",
+        "rev": "24c35502e7b26b3bc75365b5318399a6c451deab",
         "type": "github"
       },
       "original": {
@@ -1444,11 +1444,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783574839,
-        "narHash": "sha256-ICof1tV4/9XheBLBGf7dhMhfMq4dOs1zwTHrr7zGFlA=",
+        "lastModified": 1785762349,
+        "narHash": "sha256-jZhZkzAwc7f3exzcTDJWP2WCAchCv0iNC3UF/QsahdQ=",
         "owner": "nix-community",
         "repo": "plasma-manager",
-        "rev": "c551f0687658e4bb699cfff6015436ad7ee57a0d",
+        "rev": "a19a2a029fa180911bd89c554dca1616e10f4c1d",
         "type": "github"
       },
       "original": {
@@ -1727,11 +1727,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785359135,
-        "narHash": "sha256-sRAGZVUPgwxpx19uZwaSERa86g1AbsBUQ3SxhaRPgeg=",
+        "lastModified": 1786032767,
+        "narHash": "sha256-C5K27sF/jaQe1BgB1/575r01oTAvw6mrDWPS1qUl6X0=",
         "owner": "hyprwm",
         "repo": "xdg-desktop-portal-hyprland",
-        "rev": "cc8e5ef8fb2acef3db488b9a33b0c48c2a4ee204",
+        "rev": "688feb3d88404598f12440a668136e74044391de",
         "type": "github"
       },
       "original": {
@@ -1747,11 +1747,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785480078,
-        "narHash": "sha256-wWRW/Teo+58EMeTpVVEAqYid1qLzpB/PViQJCv7Xxvc=",
+        "lastModified": 1786164819,
+        "narHash": "sha256-tvBlGAYyzHYdLwn035bRCrB1mcMjvNNavcNZ293AIIA=",
         "owner": "youwen5",
         "repo": "zen-browser-flake",
-        "rev": "b7d4cc2778143a228675cd8bb7efdfa111638ac8",
+        "rev": "f9af5f7017cea1c159e17922288fb38ff94d28cd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automatic flake update on 2026-08-09.

Review the per-host package changes below before merging.

## Input changes

```
unpacking 'github:nix-community/disko/de5708739256238fb912c62f03988815db89ec9a' into the Git cache...
unpacking 'github:Gako358/emacs-flake/5cd66cb3e7b832c13ad106501923576c2e26cc7f' into the Git cache...
unpacking 'github:hercules-ci/flake-parts/427bf4bd9435fdf21321c8cc628c24efc14c0f7a' into the Git cache...
unpacking 'github:nixos/nixos-hardware/2e790b0a6be8ec2b76174ac0931b8ff11919ec98' into the Git cache...
unpacking 'github:nix-community/home-manager/7834e82588860aaf780cec1366524456a70898d7' into the Git cache...
unpacking 'github:hyprwm/hypridle/e5c01af0842bd66617f7004568df9406111d6e80' into the Git cache...
unpacking 'github:hyprwm/hyprland/5dee44a72476be67789f64e6c6bffae0df28c53a' into the Git cache...
unpacking 'github:hyprwm/contrib/3dcbce715ae8b93107fa8632db15bf976862a573' into the Git cache...
unpacking 'github:hyprwm/hyprland-plugins/faf5ef1bd5916051ed3252463697dd2ae479f629' into the Git cache...
unpacking 'github:hyprwm/hyprpaper/c011bd20886ea3301474e77d7fa4d22ab013ece0' into the Git cache...
unpacking 'github:nix-community/impermanence/7b1d382faf603b6d264f58627330f9faa5cba149' into the Git cache...
unpacking 'github:vic/import-tree/4ebb10ae17d5f1ad366e7aef5b92cb8eecf24f69' into the Git cache...
unpacking 'github:nix-community/lanzaboote/f142433bdbeffd2af51231e0aff7162c2bfbf6ef' into the Git cache...
unpacking 'github:misterio77/nix-colors/b01f024090d2c4fc3152cd0cf12027a7b8453ba1' into the Git cache...
unpacking 'github:nixos/nixpkgs/f13ff45afd1bb73e640eaa08a7066dbed07e3238' into the Git cache...
unpacking 'github:nix-community/NUR/24c35502e7b26b3bc75365b5318399a6c451deab' into the Git cache...
unpacking 'github:nix-community/plasma-manager/a19a2a029fa180911bd89c554dca1616e10f4c1d' into the Git cache...
unpacking 'github:cachix/pre-commit-hooks.nix/43b3c1ab9d40fb1dbb008f451988a91e375825e9' into the Git cache...
unpacking 'github:gako358/scram/c32556f403be2aa42aafd72087da28d8f477010e' into the Git cache...
unpacking 'github:Mic92/sops-nix/f1406619a3884cd5c47992a70b8b35c9c0fcb4c9' into the Git cache...
unpacking 'github:youwen5/zen-browser-flake/f9af5f7017cea1c159e17922288fb38ff94d28cd' into the Git cache...
warning: updating lock file "/home/runner/work/dotfiles/dotfiles/flake.lock":
• Updated input 'emacs-flake':
    'github:Gako358/emacs-flake/b1fb553b01afaa7e5f6af10f7cc74ea8902b6635?narHash=sha256-00cOL/2oPEnSnmRK4yarCdUTBeFglwjhozeCC8MhJvY%3D' (2026-08-01)
  → 'github:Gako358/emacs-flake/5cd66cb3e7b832c13ad106501923576c2e26cc7f?narHash=sha256-HxgpxNc0vZIOlCb4Cie0PN8Vk6PxS3I%2B56DoaQuxBFk%3D' (2026-08-08)
• Updated input 'emacs-flake/flake-parts':
    'github:hercules-ci/flake-parts/17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e?narHash=sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w%2B6NWK9yA%3D' (2026-07-01)
  → 'github:hercules-ci/flake-parts/427bf4bd9435fdf21321c8cc628c24efc14c0f7a?narHash=sha256-4dtXQk/NMePegK/nWp5NSeuZKLATItOq61lpEvmXqGw%3D' (2026-08-01)
• Updated input 'emacs-flake/flake-parts/nixpkgs-lib':
    'github:nix-community/nixpkgs.lib/db3f255737b94216eb71cce308e2912cf6bc2d7c?narHash=sha256-ePjCwr1sNm9NYUqywL7QfK3JnlS015msC%2BeBu2zKlp8%3D' (2026-06-28)
  → 'github:nix-community/nixpkgs.lib/0e79af5e3d4dcfcd676ab5ba3f95d2e3352e078c?narHash=sha256-OmshNvn2vupOFpYinLUu%2B1Dnpu4n7Q5N3ggGVNHpkUI%3D' (2026-07-26)
• Updated input 'home-manager':
    'github:nix-community/home-manager/bf9ce9fec78f95f374e8dd3b503863a3ec128ebe?narHash=sha256-vkMnV0JIyw%2Bg/NmcfoajlGaAO%2B9a0ezia%2BFZohQJrik%3D' (2026-07-31)
  → 'github:nix-community/home-manager/7834e82588860aaf780cec1366524456a70898d7?narHash=sha256-TIDlLTLI1/pB7IqgjzcKQjpODQsZE2oII4XGG9B6KjI%3D' (2026-08-06)
• Updated input 'hyprland':
    'github:hyprwm/hyprland/88c6386994c960006e14c7bfa4ccfee873252882?narHash=sha256-FUYhESvUq9i4/VtGGr75w3nb3LA8qPKXG4Vs7%2BIjYD0%3D' (2026-08-01)
  → 'github:hyprwm/hyprland/5dee44a72476be67789f64e6c6bffae0df28c53a?narHash=sha256-FT4YNi3yr1lnuZPAj4CqBpxWYniUuPbvjIsLsttFjtI%3D' (2026-08-08)
• Updated input 'hyprland/aquamarine':
    'github:hyprwm/aquamarine/fc39af0ccec9171aec8185eaea8afb71a46eff90?narHash=sha256-RTKedehLwWxGblFY5Nop3T08EGKH1T%2B4zmDTddmZ8k4%3D' (2026-07-29)
  → 'github:hyprwm/aquamarine/1a10fe26a9f7d989c359e6a9ea61aa2e44d06c36?narHash=sha256-H2CrAlJD9FsUbSEIhPVK3IyVjnK0vSxPruBef17GcBs%3D' (2026-08-04)
• Updated input 'hyprland/hyprgraphics':
    'github:hyprwm/hyprgraphics/c6e7b9f673f4360bc813d3dc75028f75ee88d3f8?narHash=sha256-haEZcHzYrePnjFOYSWTbxm/Nrla0aPslJfmvdCvqtVc%3D' (2026-06-27)
  → 'github:hyprwm/hyprgraphics/8699c38f0e4a1ca3bfc84f84ba020509ced1f133?narHash=sha256-dpW3UKG2NTboxxYGzOX4nZiH8YI%2B%2BCpgosHmVaquOEI%3D' (2026-08-04)
• Updated input 'hyprland/hyprutils':
    'github:hyprwm/hyprutils/83da5ee98d806cef2d05a1072b8d8b832bf52891?narHash=sha256-A9Gb5wW2vMkYEec7DyCOBpEM6LwwpmQ/TIXEHhGgHUY%3D' (2026-07-19)
  → 'github:hyprwm/hyprutils/5a7b8cf221914ce4714407950e4ffbdddcd8b66f?narHash=sha256-DFc543bQN94Kt%2BRsD3Hiu7qCA1uKdqaFJKPMjzANKGU%3D' (2026-08-04)
• Updated input 'hyprland/nixpkgs':
    'github:NixOS/nixpkgs/1559d3daa3ecc813a650b79375ea61b6741b8746?narHash=sha256-LQy14TZp77TwbQf40gg1V3jo8FwJG0jGDkAH%2BzRHqg8%3D' (2026-07-30)
  → 'github:NixOS/nixpkgs/f13ff45afd1bb73e640eaa08a7066dbed07e3238?narHash=sha256-zDSUbpoeo/9ZmD2%2BwXnzxoo1%2BuhL8vxc0b8yuYMKYq0%3D' (2026-08-07)
• Updated input 'hyprland/xdph':
    'github:hyprwm/xdg-desktop-portal-hyprland/cc8e5ef8fb2acef3db488b9a33b0c48c2a4ee204?narHash=sha256-sRAGZVUPgwxpx19uZwaSERa86g1AbsBUQ3SxhaRPgeg%3D' (2026-07-29)
  → 'github:hyprwm/xdg-desktop-portal-hyprland/688feb3d88404598f12440a668136e74044391de?narHash=sha256-C5K27sF/jaQe1BgB1/575r01oTAvw6mrDWPS1qUl6X0%3D' (2026-08-06)
• Updated input 'hyprland-plugins':
    'github:hyprwm/hyprland-plugins/81516add9b432b6ffc9f0906b92c9302c479c236?narHash=sha256-dLAwup4XzcAo4xo%2BBcVcNXNMXUnoHsY4X3HrZ17jgPs%3D' (2026-07-26)
  → 'github:hyprwm/hyprland-plugins/faf5ef1bd5916051ed3252463697dd2ae479f629?narHash=sha256-bc4jNVx0agB40xwxJ0r7hAAk5tk5Lm0uKtwP5rNyvZQ%3D' (2026-08-08)
• Updated input 'lanzaboote':
    'github:nix-community/lanzaboote/c191775376b8734af02970153b4e5d86841dff19?narHash=sha256-d0NKOOtI90kk8DAXNDkgYUZD8KK908bczz6zNLTC/zw%3D' (2026-07-30)
  → 'github:nix-community/lanzaboote/f142433bdbeffd2af51231e0aff7162c2bfbf6ef?narHash=sha256-5/wlGe3a4ucxvYq2cuAAsuSFWKcIttQ6En83MLlV2jY%3D' (2026-08-03)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/148bab9c1c3c53136ecb44a6ea356a0ed5b39b06?narHash=sha256-KoTsyMQqnXQZq8deCEnu4QkyldkwH/bpMMhUcfMdGIw%3D' (2026-08-01)
  → 'github:nixos/nixpkgs/f13ff45afd1bb73e640eaa08a7066dbed07e3238?narHash=sha256-zDSUbpoeo/9ZmD2%2BwXnzxoo1%2BuhL8vxc0b8yuYMKYq0%3D' (2026-08-07)
• Updated input 'nur':
    'github:nix-community/NUR/6755bdc2722c00441ce2c22ba57829310e199378?narHash=sha256-PgPkNVPZK8pl4h/FVAdqrWGsdYPrF0mYiA98myeAnfQ%3D' (2026-08-02)
  → 'github:nix-community/NUR/24c35502e7b26b3bc75365b5318399a6c451deab?narHash=sha256-eLHhhkMP5kjmqqLcCO8jKaYNP1/ua/5kL6zTmQgWJVo%3D' (2026-08-09)
• Updated input 'nur/nixpkgs':
    'github:nixos/nixpkgs/148bab9c1c3c53136ecb44a6ea356a0ed5b39b06?narHash=sha256-KoTsyMQqnXQZq8deCEnu4QkyldkwH/bpMMhUcfMdGIw%3D' (2026-08-01)
  → 'github:nixos/nixpkgs/f13ff45afd1bb73e640eaa08a7066dbed07e3238?narHash=sha256-zDSUbpoeo/9ZmD2%2BwXnzxoo1%2BuhL8vxc0b8yuYMKYq0%3D' (2026-08-07)
• Updated input 'plasma-manager':
    'github:nix-community/plasma-manager/c551f0687658e4bb699cfff6015436ad7ee57a0d?narHash=sha256-ICof1tV4/9XheBLBGf7dhMhfMq4dOs1zwTHrr7zGFlA%3D' (2026-07-09)
  → 'github:nix-community/plasma-manager/a19a2a029fa180911bd89c554dca1616e10f4c1d?narHash=sha256-jZhZkzAwc7f3exzcTDJWP2WCAchCv0iNC3UF/QsahdQ%3D' (2026-08-03)
• Updated input 'zen-browser':
    'github:youwen5/zen-browser-flake/b7d4cc2778143a228675cd8bb7efdfa111638ac8?narHash=sha256-wWRW/Teo%2B58EMeTpVVEAqYid1qLzpB/PViQJCv7Xxvc%3D' (2026-07-31)
  → 'github:youwen5/zen-browser-flake/f9af5f7017cea1c159e17922288fb38ff94d28cd?narHash=sha256-tvBlGAYyzHYdLwn035bRCrB1mcMjvNNavcNZ293AIIA%3D' (2026-08-08)
```

## Per-host package diff

<details><summary><b>aanallein</b></summary>

```
<<< result-old
>>> result-new
Version changes:
[U.]  #1  aardvark-dns            2.0.0 -> 2.1.0
[U*]  #2  cpupower                6.18.41, 6.18.41_fish-completions -> 6.18.43, 6.18.43_fish-completions
[U*]  #3  docker-compose          5.3.1 -> 5.4.0
[U.]  #4  initrd-linux            6.18.41 -> 6.18.43
[U.]  #5  linux                   6.18.41, 6.18.41-modules x2 -> 6.18.43, 6.18.43-modules x2
[U.]  #6  mesa                    26.1.6 x2 -> 26.2.0 x2
[U.]  #7  ncdu                    2.9.2, 2.9.2-fish-completions -> 2.10.0, 2.10.0-fish-completions
[U.]  #8  nixos-system-aanallein  26.11.20260801.148bab9 -> 26.11.20260807.f13ff45
[U.]  #9  python3.14-shtab        1.8.0 -> 1.9.2
Added packages:
[A.]  #1  unit-systemd-boot-random-seed.service  <none>
Closure size: 1889 -> 1890 (112 paths added, 111 paths removed, delta +1, disk usage +29.8MiB).
```

</details>

<details><summary><b>rhuidean</b></summary>

```
<<< result-old
>>> result-new
Version changes:
[U.]  #01  aardvark-dns               2.0.0 -> 2.1.0
[U.]  #02  breeze                     6.7.3 -> 6.7.4
[U*]  #03  cpupower                   6.18.41, 6.18.41_fish-completions -> 6.18.43, 6.18.43_fish-completions
[U.]  #04  discord                    1.0.146, 1.0.146-fish-completions -> 1.0.152, 1.0.152-fish-completions
[U*]  #05  docker-compose             5.3.1 -> 5.4.0
[U.]  #06  initrd-linux               6.18.41 -> 6.18.43
[U.]  #07  kdecoration                6.7.3 -> 6.7.4
[U.]  #08  linux                      6.18.41, 6.18.41-modules x2 -> 6.18.43, 6.18.43-modules x2
[U.]  #09  mesa                       26.1.6 x2 -> 26.2.0 x2
[U.]  #10  ncdu                       2.9.2, 2.9.2-fish-completions -> 2.10.0, 2.10.0-fish-completions
[U.]  #11  nixos-system-rhuidean      26.11.20260801.148bab9 -> 26.11.20260807.f13ff45
[U.]  #12  proton-ge-bin-GE-Proton11  1-steamcompattool -> 3-steamcompattool
[U.]  #13  python3.14-shtab           1.8.0 -> 1.9.2
[U*]  #14  upower                     1.91.1, 1.91.1_fish-completions -> 1.91.2, 1.91.2_fish-completions
[U.]  #15  vte                        0.84.0 x2 -> 0.84.1 x2
[U*]  #16  xdg-desktop-portal         1.20.4 -> 1.22.1
[U.]  #17  zen-browser                1.21.10b, 1.21.10b-fish-completions -> 1.21.12b, 1.21.12b-fish-completions
[U.]  #18  zen-browser-unwrapped      1.21.10b -> 1.21.12b
Added packages:
[A+]  #1  glycin-thumbnailer                     2.1.1
[A+]  #2  gst-thumbnailers                       1.0.0
[A.]  #3  unit-systemd-boot-random-seed.service  <none>
Closure size: 2717 -> 2720 (203 paths added, 200 paths removed, delta +3, disk usage +150.7MiB).
```

</details>

<details><summary><b>tanchico</b></summary>

```
<<< result-old
>>> result-new
Version changes:
[U.]  #01  aardvark-dns               2.0.0 -> 2.1.0
[U.]  #02  breeze                     6.7.3 -> 6.7.4
[U*]  #03  cpupower                   6.18.41, 6.18.41_fish-completions -> 6.18.43, 6.18.43_fish-completions
[U.]  #04  discord                    1.0.146, 1.0.146-fish-completions -> 1.0.152, 1.0.152-fish-completions
[U*]  #05  docker-compose             5.3.1 -> 5.4.0
[U.]  #06  initrd-linux               6.18.41 -> 6.18.43
[U.]  #07  kdecoration                6.7.3 -> 6.7.4
[U.]  #08  linux                      6.18.41, 6.18.41-modules x2 -> 6.18.43, 6.18.43-modules x2
[U.]  #09  mesa                       26.1.6 x2 -> 26.2.0 x2
[U.]  #10  ncdu                       2.9.2, 2.9.2-fish-completions -> 2.10.0, 2.10.0-fish-completions
[U.]  #11  nixos-system-tanchico      26.11.20260801.148bab9 -> 26.11.20260807.f13ff45
[U.]  #12  proton-ge-bin-GE-Proton11  1-steamcompattool -> 3-steamcompattool
[U.]  #13  python3.14-shtab           1.8.0 -> 1.9.2
[U*]  #14  upower                     1.91.1, 1.91.1_fish-completions -> 1.91.2, 1.91.2_fish-completions
[U.]  #15  vte                        0.84.0 x2 -> 0.84.1 x2
[U*]  #16  xdg-desktop-portal         1.20.4 -> 1.22.1
[U.]  #17  zen-browser                1.21.10b, 1.21.10b-fish-completions -> 1.21.12b, 1.21.12b-fish-completions
[U.]  #18  zen-browser-unwrapped      1.21.10b -> 1.21.12b
Added packages:
[A+]  #1  glycin-thumbnailer                     2.1.1
[A+]  #2  gst-thumbnailers                       1.0.0
[A.]  #3  unit-systemd-boot-random-seed.service  <none>
Closure size: 2714 -> 2717 (201 paths added, 198 paths removed, delta +3, disk usage +150.5MiB).
```

</details>

<details><summary><b>terangreal</b></summary>

```
<<< result-old
>>> result-new
Version changes:
[U.]  #001  aardvark-dns                  2.0.0 -> 2.1.0
[C.]  #002  abseil-cpp                    20260107.1 x4, 20260107.1-dev -> 20260107.1 x3, 20260107.1-dev
[C.]  #003  alsa-lib                      1.2.14, 1.2.16, 1.2.16.1 x3 -> 1.2.14, 1.2.16, 1.2.16.1 x2
[C.]  #004  alsa-topology-conf            1.2.5.1 x5 -> 1.2.5.1 x4
[C.]  #005  alsa-ucm-conf                 1.2.14, 1.2.16, 1.2.16.1 x3 -> 1.2.14, 1.2.16, 1.2.16.1 x2
[C.]  #006  aquamarine                    0.14.0, 0.14.0+date=2026-07-29_fc39af0 -> 0.14.0, 0.14.0+date=2026-08-04_1a10fe2
[C.]  #007  at-spi2-core                  2.56.2, 2.60.4 x2, 2.60.4-dev -> 2.56.2, 2.60.4, 2.60.4-dev
[C.]  #008  avahi                         0.8 x5 -> 0.8 x4
[C.]  #009  binutils                      2.46 x2, 2.46-lib x2 -> 2.46, 2.46-lib
[C.]  #010  binutils-wrapper              2.46 x2 -> 2.46
[C.]  #011  bluez                         5.86 x4 -> 5.86 x3
[U.]  #012  bottom                        0.14.6, 0.14.6-fish-completions -> 0.14.7, 0.14.7-fish-completions
[U.]  #013  breeze                        6.7.3 -> 6.7.4
[C.]  #014  cairo                         1.18.4 x5, 1.18.4-dev -> 1.18.4 x4, 1.18.4-dev
[C.]  #015  cdparanoia-iii                10.2 x4 -> 10.2 x3
[C.]  #016  cjson                         1.7.19 x4 -> 1.7.19 x3
[U*]  #017  cpupower                      6.18.41, 6.18.41_fish-completions -> 6.18.43, 6.18.43_fish-completions
[C.]  #018  cracklib                      2.10.3 x4 -> 2.10.3 x3
[C*]  #019  cryptsetup                    2.8.6 x4, 2.8.6-bin, 2.8.6-man -> 2.8.6 x3, 2.8.6-bin, 2.8.6-man
[C.]  #020  cups                          2.4.12-lib, 2.4.19, 2.4.19-dev, 2.4.19-lib x2 -> 2.4.12-lib, 2.4.19, 2.4.19-dev, 2.4.19-lib
[C.]  #021  dav1d                         1.5.3 x4 -> 1.5.3 x3
[C*]  #022  dbus                          1, 1.14.10-lib, 1.16.2 x2, 1.16.2-dev x2, 1.16.2-doc, 1.16.2-lib x4, 1.16.2-man -> 1, 1.14.10-lib, 1.16.2, 1.16.2-dev, 1.16.2-doc, 1.16.2-lib x3, 1.16.2-man
[C*]  #023  dconf                         0.40.0-lib, 0.49.0, 0.49.0_fish-completions, 0.49.0-lib x4 -> 0.40.0-lib, 0.49.0, 0.49.0_fish-completions, 0.49.0-lib x3
[C.]  #024  dejavu-fonts-minimal          2.37 x5 -> 2.37 x4
[U.]  #025  discord                       1.0.146, 1.0.146-fish-completions -> 1.0.152, 1.0.152-fish-completions
[U*]  #026  docker-compose                5.3.1 -> 5.4.0
[C.]  #027  double-conversion             3.4.0 x2, 3.4.0-dev -> 3.4.0, 3.4.0-dev
[C.]  #028  duktape                       2.7.0 x2 -> 2.7.0
[C.]  #029  elfutils                      0.195 x4 -> 0.195 x3
[C.]  #030  ell                           0.83 x4 -> 0.83 x3
[U.]  #031  emacs-evil-ghostel            0.48.0 -> 0.49.0
[U.]  #032  emacs-ghostel                 0.48.0 -> 0.49.0
[C.]  #033  expand-response-params        <none> x4 -> <none> x2
[C.]  #034  fdk-aac                       2.0.3 x4 -> 2.0.3 x3
[C.]  #035  ffado                         2.4.9 x4 -> 2.4.9 x3
[C.]  #036  ffmpeg-headless               8.1.2-data x4, 8.1.2-lib x4 -> 8.1.2-data x3, 8.1.2-lib x3
[C.]  #037  fftw-double                   3.3.11 x4 -> 3.3.11 x3
[C.]  #038  fftw-single                   3.3.11 x4 -> 3.3.11 x3
[C.]  #039  file                          5.45, 5.48 x4 -> 5.45, 5.48 x3
[C.]  #040  flac                          1.5.0 x4 -> 1.5.0 x3
[C*]  #041  fontconfig                    2.16.2, 2.16.2-lib, 2.18.1 x2, 2.18.1-lib x2, 2.18.2 x2, 2.18.2-bin, 2.18.2-dev, 2.18.2_fish-completions, 2.18.2-lib x2 -> 2.16.2, 2.16.2-lib, 2.18.1, 2.18.1-lib, 2.18.2 x2, 2.18.2-bin, 2.18.2-dev, 2.18.2_fish-completions, 2.18.2-lib x2
[C.]  #042  freetype                      2.13.3, 2.14.3 x4, 2.14.3-dev -> 2.13.3, 2.14.3 x3, 2.14.3-dev
[C.]  #043  fribidi                       1.0.16 x5, 1.0.16-dev -> 1.0.16 x4, 1.0.16-dev
[C*]  #044  gawk                          5.4.1 x2, 5.4.1-info, 5.4.1-man -> 5.4.1, 5.4.1-info, 5.4.1-man
[C.]  #045  gcc                           14.3.0-lib, 14.3.0-libgcc, 15.2.0-lib, 15.2.0-libgcc, 15.3.0 x2, 15.3.0-lib x4, 15.3.0-libgcc x4, 16.1.0-lib x2, 16.1.0-libgcc x2 -> 14.3.0-lib, 14.3.0-libgcc, 15.2.0-lib, 15.2.0-libgcc, 15.3.0 x2, 15.3.0-lib x4, 15.3.0-libgcc x4, 16.1.0-lib, 16.1.0-libgcc
[C.]  #046  gdk-pixbuf                    2.42.12, 2.44.6 x3, 2.44.6-dev -> 2.42.12, 2.44.6 x2, 2.44.6-dev
[C.]  #047  giflib                        5.2.2, 6.1.3 x4 -> 5.2.2, 6.1.3 x3
[C.]  #048  glib                          2.84.4, 2.88.1 x4, 2.88.1-bin x3, 2.88.1-dev, 2.88.1-fish-completions -> 2.84.4, 2.88.1 x3, 2.88.1-bin x2, 2.88.1-dev, 2.88.1-fish-completions
[C*]  #049  glibc                         2.40-66, 2.40-66-getent, 2.42-67 x4, 2.42-67-bin x3, 2.42-67-dev x2, 2.42-67-getent -> 2.40-66, 2.40-66-getent, 2.42-67 x4, 2.42-67-bin x2, 2.42-67-dev, 2.42-67-getent
[C.]  #050  glibmm                        2.66.8 x4, 2.88.0 -> 2.66.8 x3, 2.88.0
[C.]  #051  glslang                       16.3.0 x2 -> 16.3.0
[C.]  #052  gmp-with-cxx                  6.3.0 x10, 6.3.0-dev -> 6.3.0 x9, 6.3.0-dev
[C.]  #053  gnum4                         1.4.21 x4 -> 1.4.21 x3
[C.]  #054  gnutls                        3.8.10, 3.8.13 x4 -> 3.8.10, 3.8.13 x3
[C.]  #055  gobject-introspection         1.84.0, 1.86.0 x2, 1.86.0-dev -> 1.84.0, 1.86.0, 1.86.0-dev
[C.]  #056  graphene                      1.10.8 x4 -> 1.10.8 x3
[C.]  #057  graphite2                     1.3.14, 1.3.15 x4, 1.3.15-dev -> 1.3.14, 1.3.15 x3, 1.3.15-dev
[C.]  #058  grim                          1.5.0 x2 -> 1.5.0
[C.]  #059  gsettings-desktop-schemas     48.0, 50.1 x2 -> 48.0, 50.1
[C.]  #060  gst-plugins-base              1.28.4 x2, 1.28.5 x2 -> 1.28.4, 1.28.5 x2
[C.]  #061  gstreamer                     1.28.4 x2, 1.28.5 x2 -> 1.28.4, 1.28.5 x2
[C.]  #062  gtest                         1.17.0 x4, 1.17.0-dev -> 1.17.0 x3, 1.17.0-dev
[C.]  #063  gtk+3                         3.24.49, 3.24.52 x2, 3.24.52-dev -> 3.24.49, 3.24.52, 3.24.52-dev
[C.]  #064  harfbuzz                      11.2.1, 13.2.1 x4, 13.2.1-dev -> 11.2.1, 13.2.1 x3, 13.2.1-dev
[C.]  #065  hostname-debian               3.25 x2, 3.25-man x2 -> 3.25, 3.25-man
[C*]  #066  hostname-hostname-debian      3.25 x2, 3.25_fish-completions -> 3.25, 3.25_fish-completions
[C.]  #067  hwdata                        0.408, 0.409 x3 -> 0.408, 0.409 x2
[C.]  #068  hyprgraphics                  0.5.1, 0.5.1+date=2026-06-27_c6e7b9f -> 0.5.1, 0.5.1+date=2026-08-04_8699c38
[C*]  #069  hyprland                      0.56.0+date=2026-08-01_88c6386, 0.56.0+date=2026-08-01_88c6386-man, 0.56.1 -> 0.56.0+date=2026-08-08_5dee44a, 0.56.0+date=2026-08-08_5dee44a-man, 0.56.1
[C.]  #070  hyprutils                     0.14.0 x2, 0.14.0+date=2026-07-19_83da5ee, 0.14.0+date=2026-07-19_83da5ee-dev -> 0.14.0, 0.14.0+date=2026-08-04_5a7b8cf, 0.14.0+date=2026-08-04_5a7b8cf-dev
[C.]  #071  icu4c                         76.1 x2, 77.1, 78.3 x3, 78.3-dev -> 76.1 x2, 77.1, 78.3 x2, 78.3-dev
[C.]  #072  iniparser                     4.2.6 x2 -> 4.2.6
[U.]  #073  initrd-linux                  6.18.41 -> 6.18.43
[C.]  #074  iso-codes                     4.18.0, 4.20.1 x4 -> 4.18.0, 4.20.1 x3
[C.]  #075  jq                            1.8.2 x2, 1.8.2-bin x2, 1.8.2-fish-completions, 1.8.2-man -> 1.8.2, 1.8.2-bin, 1.8.2-fish-completions, 1.8.2-man
[C.]  #076  json-c                        0.18 x4 -> 0.18 x3
[C.]  #077  json-glib                     1.10.6, 1.10.8 x2 -> 1.10.6, 1.10.8
[C*]  #078  kbd                           2.8.0-unstable-2025-08-12, 2.9.0 x4, 2.9.0-man -> 2.8.0-unstable-2025-08-12, 2.9.0 x3, 2.9.0-man
[U.]  #079  kdecoration                   6.7.3 -> 6.7.4
[C*]  #080  kexec-tools                   2.0.31, 2.0.32 x4, 2.0.32_fish-completions -> 2.0.31, 2.0.32 x3, 2.0.32_fish-completions
[C*]  #081  kmod                          31 x5, 31-lib x5, 31-man -> 31 x4, 31-lib x4, 31-man
[C.]  #082  lame                          3.100-lib x4 -> 3.100-lib x3
[C.]  #083  lcms2                         2.17, 2.19.1 x4 -> 2.17, 2.19.1 x3
[C.]  #084  ldacbt                        2.0.72 x4 -> 2.0.72 x3
[C.]  #085  lerc                          4.0.0, 4.1.0, 4.1.1 x3, 4.1.1-dev -> 4.0.0, 4.1.0, 4.1.1 x2, 4.1.1-dev
[C.]  #086  libao                         1.2.2 x4 -> 1.2.2 x3
[C.]  #087  libaom                        3.12.1 x4 -> 3.12.1 x3
[C.]  #088  libapparmor                   5.0.0, 5.0.1, 5.0.2 x2 -> 5.0.0, 5.0.2 x2
[C.]  #089  libarchive                    3.8.8-lib x4 -> 3.8.8-lib x3
[C.]  #090  libass                        0.17.4 x4 -> 0.17.4 x3
[C.]  #091  libavc1394                    0.5.4 x4 -> 0.5.4 x3
[C.]  #092  libb2                         0.98.1 x2 -> 0.98.1
[C.]  #093  libbluray                     1.4.1 x4 -> 1.4.1 x3
[C.]  #094  libbpf                        1.7.0 x4 -> 1.7.0 x3
[C.]  #095  libbsd                        0.12.2 x3 -> 0.12.2 x2
[C.]  #096  libcamera                     0.7.0 x4 -> 0.7.0 x3
[C.]  #097  libcanberra                   0.30 x5 -> 0.30 x4
[C*]  #098  libcap                        2.76-lib, 2.78, 2.78-doc, 2.78-lib x4, 2.78-man -> 2.76-lib, 2.78, 2.78-doc, 2.78-lib x3, 2.78-man
[C.]  #099  libconfig                     1.8.2 x4 -> 1.8.2 x3
[C.]  #100  libdaemon                     0.14 x5 -> 0.14 x4
[C.]  #101  libdatrie                     2019-12-20, 2019-12-20-bin, 2019-12-20-dev, 2019-12-20-lib x5 -> 2019-12-20, 2019-12-20-bin, 2019-12-20-dev, 2019-12-20-lib x4
[C.]  #102  libde265                      1.1.1 x2 -> 1.1.1
[C.]  #103  libdeflate                    1.24, 1.25 x4 -> 1.24, 1.25 x3
[C.]  #104  libdisplay-info               0.4.0 x3 -> 0.4.0 x2
[C.]  #105  libdrm                        2.4.134 x4, 2.4.134-bin x3, 2.4.134-dev x3 -> 2.4.134 x3, 2.4.134-bin x2, 2.4.134-dev x2
[C.]  #106  libebur128                    1.2.6 x4 -> 1.2.6 x3
[C.]  #107  libei                         1.6.0 x2 -> 1.6.0
[C.]  #108  libepoxy                      1.5.10 x3, 1.5.10-dev -> 1.5.10 x2, 1.5.10-dev
[C.]  #109  libevdev                      1.13.6 x2 -> 1.13.6
[C.]  #110  libevent                      2.1.12 x2, 2.1.13 x3 -> 2.1.12 x2, 2.1.13 x2
[C.]  #111  libfreeaptx                   0.2.2 x4 -> 0.2.2 x3
[C.]  #112  libgcrypt                     1.12.2-lib x4 -> 1.12.2-lib x3
[C.]  #113  libglvnd                      1.7.0 x5, 1.7.0-dev -> 1.7.0 x4, 1.7.0-dev
[C.]  #114  libgpg-error                  1.61 x4 -> 1.61 x3
[C.]  #115  libgudev                      238 x2 -> 238
[C.]  #116  libheif                       1.23.1-lib x2 -> 1.23.1-lib
[C.]  #117  libical                       3.0.20 x4 -> 3.0.20 x3
[C.]  #118  libice                        1.1.2 x2, 1.1.2-dev -> 1.1.2, 1.1.2-dev
[C.]  #119  libiec61883                   1.2.0 x4 -> 1.2.0 x3
[C.]  #120  libinput                      1.31.3 x2, 1.31.3-bin, 1.31.3-dev -> 1.31.3, 1.31.3-bin, 1.31.3-dev
[C.]  #121  libjack2                      1.9.22 x4 -> 1.9.22 x3
[C.]  #122  libjpeg-turbo                 3.1.1, 3.1.4.1 x4, 3.1.4.1-bin, 3.1.4.1-dev -> 3.1.1, 3.1.4.1 x3, 3.1.4.1-bin, 3.1.4.1-dev
[C.]  #123  libjxl                        0.12.0 x2 -> 0.12.0
[C.]  #124  liblc3                        1.1.3 x4 -> 1.1.3 x3
[C.]  #125  libmad                        0.15.1b x4 -> 0.15.1b x3
[C.]  #126  libmd                         1.2.0 x3 -> 1.2.0 x2
[C.]  #127  libmicrohttpd                 1.0.5 x2, 1.0.6 x2 -> 1.0.5, 1.0.6 x2
[C.]  #128  libmpg123                     1.33.5, 1.33.6 x3 -> 1.33.5, 1.33.6 x2
[C.]  #129  libmysofa                     1.3.3 x2, 1.3.4 x2 -> 1.3.3, 1.3.4 x2
[C.]  #130  libnotify                     0.8.8 x3, 0.8.8-fish-completions, 0.8.8-man -> 0.8.8 x2, 0.8.8-fish-completions, 0.8.8-man
[C.]  #131  libogg                        1.3.6 x4 -> 1.3.6 x3
[C.]  #132  libopenmpt                    0.8.7 x4 -> 0.8.7 x3
[C.]  #133  libopus                       1.6.1 x4 -> 1.6.1 x3
[C.]  #134  libpciaccess                  0.19 x4 -> 0.19 x3
[C.]  #135  libpng-apng                   1.6.49, 1.6.58 x4, 1.6.58-dev -> 1.6.49, 1.6.58 x3, 1.6.58-dev
[C.]  #136  libpq                         18.4 x2 -> 18.4
[C.]  #137  libproxy                      0.5.12 x2, 0.5.12-dev -> 0.5.12, 0.5.12-dev
[C.]  #138  libpulseaudio                 17.0 x4 -> 17.0 x3
[C.]  #139  libpwquality                  1.4.5-lib x4 -> 1.4.5-lib x3
[C.]  #140  libraw1394                    2.1.2 x4 -> 2.1.2 x3
[C.]  #141  librist                       0.2.11 x4 -> 0.2.11 x3
[C.]  #142  librsvg                       2.62.3 x2 -> 2.62.3
[C.]  #143  libsamplerate                 0.2.2 x4 -> 0.2.2 x3
[C.]  #144  libseccomp                    2.6.0-lib x2, 2.6.1-lib x3 -> 2.6.0-lib x2, 2.6.1-lib x2
[C.]  #145  libselinux                    3.8.1, 3.10 x4, 3.10-bin, 3.10-dev -> 3.8.1, 3.10 x3, 3.10-bin, 3.10-dev
[C.]  #146  libsigc++                     2.12.1 x4, 3.8.1 -> 2.12.1 x3, 3.8.1

_… diff truncated (313 lines total); see the `closure-diff-terangreal` artifact for the full output._

</details>

<details><summary><b>tuathaan</b></summary>

```
<<< result-old
>>> result-new
Version changes:
[U.]  #001  aardvark-dns                  2.0.0 -> 2.1.0
[C.]  #002  abseil-cpp                    20260107.1 x4, 20260107.1-dev -> 20260107.1 x3, 20260107.1-dev
[C.]  #003  alsa-lib                      1.2.14, 1.2.16, 1.2.16.1 x3 -> 1.2.14, 1.2.16, 1.2.16.1 x2
[C.]  #004  alsa-topology-conf            1.2.5.1 x5 -> 1.2.5.1 x4
[C.]  #005  alsa-ucm-conf                 1.2.14, 1.2.16, 1.2.16.1 x3 -> 1.2.14, 1.2.16, 1.2.16.1 x2
[C.]  #006  aquamarine                    0.14.0, 0.14.0+date=2026-07-29_fc39af0 -> 0.14.0, 0.14.0+date=2026-08-04_1a10fe2
[C.]  #007  at-spi2-core                  2.56.2, 2.60.4 x2, 2.60.4-dev -> 2.56.2, 2.60.4, 2.60.4-dev
[C.]  #008  avahi                         0.8 x5 -> 0.8 x4
[C.]  #009  binutils                      2.46 x2, 2.46-lib x2 -> 2.46, 2.46-lib
[C.]  #010  binutils-wrapper              2.46 x2 -> 2.46
[C*]  #011  bluez                         5.86 x4, 5.86_fish-completions -> 5.86 x3, 5.86_fish-completions
[U.]  #012  bottom                        0.14.6, 0.14.6-fish-completions -> 0.14.7, 0.14.7-fish-completions
[U.]  #013  breeze                        6.7.3 -> 6.7.4
[C.]  #014  cairo                         1.18.4 x5, 1.18.4-dev -> 1.18.4 x4, 1.18.4-dev
[C.]  #015  cdparanoia-iii                10.2 x4 -> 10.2 x3
[C.]  #016  cjson                         1.7.19 x4 -> 1.7.19 x3
[U*]  #017  cpupower                      6.18.41, 6.18.41_fish-completions -> 6.18.43, 6.18.43_fish-completions
[C.]  #018  cracklib                      2.10.3 x4 -> 2.10.3 x3
[C*]  #019  cryptsetup                    2.8.6 x4, 2.8.6-bin, 2.8.6-man -> 2.8.6 x3, 2.8.6-bin, 2.8.6-man
[C.]  #020  cups                          2.4.12-lib, 2.4.19, 2.4.19-dev, 2.4.19-lib x2 -> 2.4.12-lib, 2.4.19, 2.4.19-dev, 2.4.19-lib
[C.]  #021  dav1d                         1.5.3 x4 -> 1.5.3 x3
[C*]  #022  dbus                          1, 1.14.10-lib, 1.16.2 x2, 1.16.2-dev x2, 1.16.2-doc, 1.16.2-lib x4, 1.16.2-man -> 1, 1.14.10-lib, 1.16.2, 1.16.2-dev, 1.16.2-doc, 1.16.2-lib x3, 1.16.2-man
[C*]  #023  dconf                         0.40.0-lib, 0.49.0, 0.49.0_fish-completions, 0.49.0-lib x4 -> 0.40.0-lib, 0.49.0, 0.49.0_fish-completions, 0.49.0-lib x3
[C.]  #024  dejavu-fonts-minimal          2.37 x5 -> 2.37 x4
[U.]  #025  discord                       1.0.146, 1.0.146-fish-completions -> 1.0.152, 1.0.152-fish-completions
[U*]  #026  docker-compose                5.3.1 -> 5.4.0
[C.]  #027  double-conversion             3.4.0 x2, 3.4.0-dev -> 3.4.0, 3.4.0-dev
[C.]  #028  duktape                       2.7.0 x2 -> 2.7.0
[C.]  #029  elfutils                      0.195 x4 -> 0.195 x3
[C.]  #030  ell                           0.83 x4 -> 0.83 x3
[U.]  #031  emacs-evil-ghostel            0.48.0 -> 0.49.0
[U.]  #032  emacs-ghostel                 0.48.0 -> 0.49.0
[C.]  #033  expand-response-params        <none> x4 -> <none> x2
[C.]  #034  fdk-aac                       2.0.3 x4 -> 2.0.3 x3
[C.]  #035  ffado                         2.4.9 x4 -> 2.4.9 x3
[C.]  #036  ffmpeg-headless               8.1.2-data x4, 8.1.2-lib x4 -> 8.1.2-data x3, 8.1.2-lib x3
[C.]  #037  fftw-double                   3.3.11 x4 -> 3.3.11 x3
[C.]  #038  fftw-single                   3.3.11 x4 -> 3.3.11 x3
[C.]  #039  file                          5.45, 5.48 x4 -> 5.45, 5.48 x3
[C.]  #040  flac                          1.5.0 x4 -> 1.5.0 x3
[C*]  #041  fontconfig                    2.16.2, 2.16.2-lib, 2.18.1 x2, 2.18.1-lib x2, 2.18.2 x2, 2.18.2-bin, 2.18.2-dev, 2.18.2_fish-completions, 2.18.2-lib x2 -> 2.16.2, 2.16.2-lib, 2.18.1, 2.18.1-lib, 2.18.2 x2, 2.18.2-bin, 2.18.2-dev, 2.18.2_fish-completions, 2.18.2-lib x2
[C.]  #042  freetype                      2.13.3, 2.14.3 x4, 2.14.3-dev -> 2.13.3, 2.14.3 x3, 2.14.3-dev
[C.]  #043  fribidi                       1.0.16 x5, 1.0.16-dev -> 1.0.16 x4, 1.0.16-dev
[C*]  #044  gawk                          5.4.1 x2, 5.4.1-info, 5.4.1-man -> 5.4.1, 5.4.1-info, 5.4.1-man
[C.]  #045  gcc                           14.3.0-lib, 14.3.0-libgcc, 15.2.0-lib, 15.2.0-libgcc, 15.3.0 x2, 15.3.0-lib x4, 15.3.0-libgcc x4, 16.1.0-lib x2, 16.1.0-libgcc x2 -> 14.3.0-lib, 14.3.0-libgcc, 15.2.0-lib, 15.2.0-libgcc, 15.3.0 x2, 15.3.0-lib x4, 15.3.0-libgcc x4, 16.1.0-lib, 16.1.0-libgcc
[C.]  #046  gdk-pixbuf                    2.42.12, 2.44.6 x3, 2.44.6-dev -> 2.42.12, 2.44.6 x2, 2.44.6-dev
[C.]  #047  giflib                        5.2.2, 6.1.3 x4 -> 5.2.2, 6.1.3 x3
[C.]  #048  glib                          2.84.4, 2.88.1 x4, 2.88.1-bin x3, 2.88.1-dev, 2.88.1-fish-completions -> 2.84.4, 2.88.1 x3, 2.88.1-bin x2, 2.88.1-dev, 2.88.1-fish-completions
[C*]  #049  glibc                         2.40-66, 2.40-66-getent, 2.42-67 x4, 2.42-67-bin x3, 2.42-67-dev x2, 2.42-67-getent -> 2.40-66, 2.40-66-getent, 2.42-67 x4, 2.42-67-bin x2, 2.42-67-dev, 2.42-67-getent
[C.]  #050  glibmm                        2.66.8 x4, 2.88.0 -> 2.66.8 x3, 2.88.0
[C.]  #051  glslang                       16.3.0 x2 -> 16.3.0
[C.]  #052  gmp-with-cxx                  6.3.0 x10, 6.3.0-dev -> 6.3.0 x9, 6.3.0-dev
[C.]  #053  gnum4                         1.4.21 x4 -> 1.4.21 x3
[C.]  #054  gnutls                        3.8.10, 3.8.13 x4 -> 3.8.10, 3.8.13 x3
[C.]  #055  gobject-introspection         1.84.0, 1.86.0 x2, 1.86.0-dev -> 1.84.0, 1.86.0, 1.86.0-dev
[C.]  #056  graphene                      1.10.8 x4 -> 1.10.8 x3
[C.]  #057  graphite2                     1.3.14, 1.3.15 x4, 1.3.15-dev -> 1.3.14, 1.3.15 x3, 1.3.15-dev
[C.]  #058  grim                          1.5.0 x2 -> 1.5.0
[C.]  #059  gsettings-desktop-schemas     48.0, 50.1 x2 -> 48.0, 50.1
[C.]  #060  gst-plugins-base              1.28.4 x2, 1.28.5 x2 -> 1.28.4, 1.28.5 x2
[C.]  #061  gstreamer                     1.28.4 x2, 1.28.5 x2 -> 1.28.4, 1.28.5 x2
[C.]  #062  gtest                         1.17.0 x4, 1.17.0-dev -> 1.17.0 x3, 1.17.0-dev
[C.]  #063  gtk+3                         3.24.49, 3.24.52 x2, 3.24.52-dev -> 3.24.49, 3.24.52, 3.24.52-dev
[C.]  #064  harfbuzz                      11.2.1, 13.2.1 x4, 13.2.1-dev -> 11.2.1, 13.2.1 x3, 13.2.1-dev
[C.]  #065  hostname-debian               3.25 x2, 3.25-man x2 -> 3.25, 3.25-man
[C*]  #066  hostname-hostname-debian      3.25 x2, 3.25_fish-completions -> 3.25, 3.25_fish-completions
[C.]  #067  hwdata                        0.408, 0.409 x3 -> 0.408, 0.409 x2
[C.]  #068  hyprgraphics                  0.5.1, 0.5.1+date=2026-06-27_c6e7b9f -> 0.5.1, 0.5.1+date=2026-08-04_8699c38
[C*]  #069  hyprland                      0.56.0+date=2026-08-01_88c6386, 0.56.0+date=2026-08-01_88c6386-man, 0.56.1 -> 0.56.0+date=2026-08-08_5dee44a, 0.56.0+date=2026-08-08_5dee44a-man, 0.56.1
[C.]  #070  hyprutils                     0.14.0 x2, 0.14.0+date=2026-07-19_83da5ee, 0.14.0+date=2026-07-19_83da5ee-dev -> 0.14.0, 0.14.0+date=2026-08-04_5a7b8cf, 0.14.0+date=2026-08-04_5a7b8cf-dev
[C.]  #071  icu4c                         76.1 x2, 77.1, 78.3 x3, 78.3-dev -> 76.1 x2, 77.1, 78.3 x2, 78.3-dev
[C.]  #072  iniparser                     4.2.6 x2 -> 4.2.6
[U.]  #073  initrd-linux                  6.18.41 -> 6.18.43
[C.]  #074  iso-codes                     4.18.0, 4.20.1 x4 -> 4.18.0, 4.20.1 x3
[C.]  #075  jq                            1.8.2 x2, 1.8.2-bin x2, 1.8.2-fish-completions, 1.8.2-man -> 1.8.2, 1.8.2-bin, 1.8.2-fish-completions, 1.8.2-man
[C.]  #076  json-c                        0.18 x4 -> 0.18 x3
[C.]  #077  json-glib                     1.10.6, 1.10.8 x2 -> 1.10.6, 1.10.8
[C*]  #078  kbd                           2.8.0-unstable-2025-08-12, 2.9.0 x4, 2.9.0-man -> 2.8.0-unstable-2025-08-12, 2.9.0 x3, 2.9.0-man
[U.]  #079  kdecoration                   6.7.3 -> 6.7.4
[C*]  #080  kexec-tools                   2.0.31, 2.0.32 x4, 2.0.32_fish-completions -> 2.0.31, 2.0.32 x3, 2.0.32_fish-completions
[C*]  #081  kmod                          31 x5, 31-lib x5, 31-man -> 31 x4, 31-lib x4, 31-man
[C.]  #082  lame                          3.100-lib x4 -> 3.100-lib x3
[C.]  #083  lcms2                         2.17, 2.19.1 x4 -> 2.17, 2.19.1 x3
[C.]  #084  ldacbt                        2.0.72 x4 -> 2.0.72 x3
[C.]  #085  lerc                          4.0.0, 4.1.0, 4.1.1 x3, 4.1.1-dev -> 4.0.0, 4.1.0, 4.1.1 x2, 4.1.1-dev
[C.]  #086  libao                         1.2.2 x4 -> 1.2.2 x3
[C.]  #087  libaom                        3.12.1 x4 -> 3.12.1 x3
[C.]  #088  libapparmor                   5.0.0, 5.0.1, 5.0.2 x2 -> 5.0.0, 5.0.2 x2
[C.]  #089  libarchive                    3.8.8-lib x4 -> 3.8.8-lib x3
[C.]  #090  libass                        0.17.4 x4 -> 0.17.4 x3
[C.]  #091  libavc1394                    0.5.4 x4 -> 0.5.4 x3
[C.]  #092  libb2                         0.98.1 x2 -> 0.98.1
[C.]  #093  libbluray                     1.4.1 x4 -> 1.4.1 x3
[C.]  #094  libbpf                        1.7.0 x4 -> 1.7.0 x3
[C.]  #095  libbsd                        0.12.2 x3 -> 0.12.2 x2
[C.]  #096  libcamera                     0.7.0 x4 -> 0.7.0 x3
[C.]  #097  libcanberra                   0.30 x5 -> 0.30 x4
[C*]  #098  libcap                        2.76-lib, 2.78, 2.78-doc, 2.78-lib x4, 2.78-man -> 2.76-lib, 2.78, 2.78-doc, 2.78-lib x3, 2.78-man
[C.]  #099  libconfig                     1.8.2 x4 -> 1.8.2 x3
[C.]  #100  libdaemon                     0.14 x5 -> 0.14 x4
[C.]  #101  libdatrie                     2019-12-20, 2019-12-20-bin, 2019-12-20-dev, 2019-12-20-lib x5 -> 2019-12-20, 2019-12-20-bin, 2019-12-20-dev, 2019-12-20-lib x4
[C.]  #102  libde265                      1.1.1 x2 -> 1.1.1
[C.]  #103  libdeflate                    1.24, 1.25 x4 -> 1.24, 1.25 x3
[C.]  #104  libdisplay-info               0.4.0 x3 -> 0.4.0 x2
[C.]  #105  libdrm                        2.4.134 x4, 2.4.134-bin x3, 2.4.134-dev x3 -> 2.4.134 x3, 2.4.134-bin x2, 2.4.134-dev x2
[C.]  #106  libebur128                    1.2.6 x4 -> 1.2.6 x3
[C.]  #107  libei                         1.6.0 x2 -> 1.6.0
[C.]  #108  libepoxy                      1.5.10 x3, 1.5.10-dev -> 1.5.10 x2, 1.5.10-dev
[C.]  #109  libevdev                      1.13.6 x2 -> 1.13.6
[C.]  #110  libevent                      2.1.12 x2, 2.1.13 x3 -> 2.1.12 x2, 2.1.13 x2
[C.]  #111  libfreeaptx                   0.2.2 x4 -> 0.2.2 x3
[C.]  #112  libgcrypt                     1.12.2-lib x4 -> 1.12.2-lib x3
[C.]  #113  libglvnd                      1.7.0 x5, 1.7.0-dev -> 1.7.0 x4, 1.7.0-dev
[C.]  #114  libgpg-error                  1.61 x4 -> 1.61 x3
[C.]  #115  libgudev                      238 x2 -> 238
[C.]  #116  libheif                       1.23.1-lib x2 -> 1.23.1-lib
[C.]  #117  libical                       3.0.20 x4 -> 3.0.20 x3
[C.]  #118  libice                        1.1.2 x2, 1.1.2-dev -> 1.1.2, 1.1.2-dev
[C.]  #119  libiec61883                   1.2.0 x4 -> 1.2.0 x3
[C*]  #120  libinput                      1.31.3 x2, 1.31.3-bin, 1.31.3-dev, 1.31.3_fish-completions -> 1.31.3, 1.31.3-bin, 1.31.3-dev, 1.31.3_fish-completions
[C.]  #121  libjack2                      1.9.22 x4 -> 1.9.22 x3
[C.]  #122  libjpeg-turbo                 3.1.1, 3.1.4.1 x4, 3.1.4.1-bin, 3.1.4.1-dev -> 3.1.1, 3.1.4.1 x3, 3.1.4.1-bin, 3.1.4.1-dev
[C.]  #123  libjxl                        0.12.0 x2 -> 0.12.0
[C.]  #124  liblc3                        1.1.3 x4 -> 1.1.3 x3
[C.]  #125  libmad                        0.15.1b x4 -> 0.15.1b x3
[C.]  #126  libmd                         1.2.0 x3 -> 1.2.0 x2
[C.]  #127  libmicrohttpd                 1.0.5 x2, 1.0.6 x2 -> 1.0.5, 1.0.6 x2
[C.]  #128  libmpg123                     1.33.5, 1.33.6 x3 -> 1.33.5, 1.33.6 x2
[C.]  #129  libmysofa                     1.3.3 x2, 1.3.4 x2 -> 1.3.3, 1.3.4 x2
[C.]  #130  libnotify                     0.8.8 x3, 0.8.8-fish-completions, 0.8.8-man -> 0.8.8 x2, 0.8.8-fish-completions, 0.8.8-man
[C.]  #131  libogg                        1.3.6 x4 -> 1.3.6 x3
[C.]  #132  libopenmpt                    0.8.7 x4 -> 0.8.7 x3
[C.]  #133  libopus                       1.6.1 x4 -> 1.6.1 x3
[C.]  #134  libpciaccess                  0.19 x4 -> 0.19 x3
[C.]  #135  libpng-apng                   1.6.49, 1.6.58 x4, 1.6.58-dev -> 1.6.49, 1.6.58 x3, 1.6.58-dev
[C.]  #136  libpq                         18.4 x2 -> 18.4
[C.]  #137  libproxy                      0.5.12 x2, 0.5.12-dev -> 0.5.12, 0.5.12-dev
[C.]  #138  libpulseaudio                 17.0 x4 -> 17.0 x3
[C.]  #139  libpwquality                  1.4.5-lib x4 -> 1.4.5-lib x3
[C.]  #140  libraw1394                    2.1.2 x4 -> 2.1.2 x3
[C.]  #141  librist                       0.2.11 x4 -> 0.2.11 x3
[C.]  #142  librsvg                       2.62.3 x2 -> 2.62.3
[C.]  #143  libsamplerate                 0.2.2 x4 -> 0.2.2 x3
[C.]  #144  libseccomp                    2.6.0-lib x2, 2.6.1-lib x3 -> 2.6.0-lib x2, 2.6.1-lib x2
[C.]  #145  libselinux                    3.8.1, 3.10 x4, 3.10-bin, 3.10-dev -> 3.8.1, 3.10 x3, 3.10-bin, 3.10-dev
[C.]  #146  libsigc++                     2.12.1 x4, 3.8.1 -> 2.12.1 x3, 3.8.1

_… diff truncated (310 lines total); see the `closure-diff-tuathaan` artifact for the full output._

</details>

