### PR TITLE
Auto update 2026-08-16

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785877886,
-        "narHash": "sha256-H2CrAlJD9FsUbSEIhPVK3IyVjnK0vSxPruBef17GcBs=",
+        "lastModified": 1786464219,
+        "narHash": "sha256-WKqWL8r7CyTDYueTr2ffJ9ya50dellv6IR1JX5PghDY=",
         "owner": "hyprwm",
         "repo": "aquamarine",
-        "rev": "1a10fe26a9f7d989c359e6a9ea61aa2e44d06c36",
+        "rev": "f3d1804205e8158c15595cdda1b566f93349ffae",
         "type": "github"
       },
       "original": {
@@ -67,11 +67,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1784564969,
-        "narHash": "sha256-TkTWNhJV/8Wk3czlbz4bwHZkFCaCHPsOy+oJe4PUiXg=",
+        "lastModified": 1785782307,
+        "narHash": "sha256-MPaRdVkf6zZP5fCPxYCi8Dr4pZzgmXzg8T9nVEbp3Mw=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "7930f6c291de6f83c257839d434592aa085f290a",
+        "rev": "2c71e194474d13de031d729b729c968ddbe3507f",
         "type": "github"
       },
       "original": {
@@ -111,11 +111,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786636664,
-        "narHash": "sha256-8M3Ks1N27iFxM2WCBUPG849OJ9ku3OE6vz9uIcspv44=",
+        "lastModified": 1786763306,
+        "narHash": "sha256-Xrt51iEPulDngzrlXlwzzuVnASIMelYdzobxWbmkcdE=",
         "owner": "Gako358",
         "repo": "emacs-flake",
-        "rev": "150dce3d3eba7dcbb9257a201a7acb7d8963f745",
+        "rev": "7093c0105887495cf3c34fc13fa73862a68a2d9a",
         "type": "github"
       },
       "original": {
@@ -372,11 +372,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1785232496,
-        "narHash": "sha256-65EQYIRRpTdpH8lUiB6Mvo5uBkG60aBIzAJuALfx+O0=",
+        "lastModified": 1786717298,
+        "narHash": "sha256-asdPlqtM0AweQ5YNLad6eY4tSYW55YNr1uyayf7mOMQ=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "2e790b0a6be8ec2b76174ac0931b8ff11919ec98",
+        "rev": "2dda192987ab6815e44df0130f03d6c907b79134",
         "type": "github"
       },
       "original": {
@@ -392,11 +392,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786031233,
-        "narHash": "sha256-TIDlLTLI1/pB7IqgjzcKQjpODQsZE2oII4XGG9B6KjI=",
+        "lastModified": 1786826571,
+        "narHash": "sha256-nNqmXIFmESRnU91KARtiekSox0+o+E3AS0d1TuUQ/9o=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7834e82588860aaf780cec1366524456a70898d7",
+        "rev": "c8058ecc1329a71a3c99c4d0353dba4009a66152",
         "type": "github"
       },
       "original": {
@@ -442,11 +442,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776511930,
-        "narHash": "sha256-fCpwFiTW0rT7oKJqr3cqHMnkwypSwQKpbtUEtxdkgrM=",
+        "lastModified": 1786464181,
+        "narHash": "sha256-2alOMkLjXANh7unkZnYnCF2K2rApZaOLMoQ3o+VX2CY=",
         "owner": "hyprwm",
         "repo": "hyprcursor",
-        "rev": "39435900785d0c560c6ae8777d29f28617d031ef",
+        "rev": "e4ed7c08123df5af460a0a70961380cbfb872f76",
         "type": "github"
       },
       "original": {
@@ -471,11 +471,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785855875,
-        "narHash": "sha256-dpW3UKG2NTboxxYGzOX4nZiH8YI++CpgosHmVaquOEI=",
+        "lastModified": 1786464367,
+        "narHash": "sha256-k58p4wbzIXWyRWrW84pP8tD+iaZSSYiiM+fr0Auk4oU=",
         "owner": "hyprwm",
         "repo": "hyprgraphics",
-        "rev": "8699c38f0e4a1ca3bfc84f84ba020509ced1f133",
+        "rev": "7c895c44e3ca6d28ed68ddd80ec02b02b925e7fc",
         "type": "github"
       },
       "original": {
@@ -506,11 +506,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785077099,
-        "narHash": "sha256-Wi8kgoWStgYopfjEmHZWsAG7Gkghr9RGFjYLVmxSKpQ=",
+        "lastModified": 1786465315,
+        "narHash": "sha256-+qflH9Z86YZqL69GMC8fAc6Crw0pAbMqgCUibo+iL3A=",
         "owner": "hyprwm",
         "repo": "hypridle",
-        "rev": "e5c01af0842bd66617f7004568df9406111d6e80",
+        "rev": "aa958ed7ad4863860b93ecd7189419e193bfae2c",
         "type": "github"
       },
       "original": {
@@ -536,11 +536,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1786227814,
-        "narHash": "sha256-FT4YNi3yr1lnuZPAj4CqBpxWYniUuPbvjIsLsttFjtI=",
+        "lastModified": 1786807079,
+        "narHash": "sha256-8Pyv0ORHhzsUElqqESECxSr3xr+SFibDZTizTF48k9I=",
         "owner": "hyprwm",
         "repo": "hyprland",
-        "rev": "5dee44a72476be67789f64e6c6bffae0df28c53a",
+        "rev": "a1b9dc0e8cdfeca3e2d96a24b10b3d85e14fbd50",
         "type": "github"
       },
       "original": {
@@ -603,11 +603,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784533903,
-        "narHash": "sha256-Ee78BRFi+MrmgHmmW+2dZUEI1R3cssEzza0ar3fsNX8=",
+        "lastModified": 1786464504,
+        "narHash": "sha256-7sHwM86KILQyHDHDuE2SDBlQ2jvZ0EW3hY7sW009/cg=",
         "owner": "hyprwm",
         "repo": "hyprland-guiutils",
-        "rev": "a16ad89ed5fb4192c966018a80c652de8d96f748",
+        "rev": "4c30cf3097ea963c0e250749ee0c59f8b08816d6",
         "type": "github"
       },
       "original": {
@@ -712,11 +712,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777320127,
-        "narHash": "sha256-Qu+Wf2Bp5qUjyn2YpZNq8a7JyzTGowhT1knrwE38a9U=",
+        "lastModified": 1786464129,
+        "narHash": "sha256-339AkTlpMYSIvFuG0rnR+8Yg4/AZKeJalshJavlnKfg=",
         "owner": "hyprwm",
         "repo": "hyprlang",
-        "rev": "090117506ddc3d7f26e650ff344d378c2ec329cc",
+        "rev": "9508458be316a0d70d37ebed1ab725ccd10411ff",
         "type": "github"
       },
       "original": {
@@ -762,11 +762,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779722845,
-        "narHash": "sha256-vnAw7lsqr4xGsr36WiL/qTlq47CtsldhnD2TnZzvz30=",
+        "lastModified": 1786644848,
+        "narHash": "sha256-31/Mc3h5BtNi1Vh0+/W13RMjHCOhQlSOXqdseMAlV2Y=",
         "owner": "hyprwm",
         "repo": "hyprpaper",
-        "rev": "c011bd20886ea3301474e77d7fa4d22ab013ece0",
+        "rev": "39029bdfda857a5ea60340a427681893d12d4892",
         "type": "github"
       },
       "original": {
@@ -814,11 +814,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782554491,
-        "narHash": "sha256-+p3MlyN/nqRefcf2IckPlGRUn9+hielqpS9XClbLleM=",
+        "lastModified": 1785930473,
+        "narHash": "sha256-DitTu625BhEYpZjtjxtGpjrEJwPwW+X/+jJvhSZNSJM=",
         "owner": "hyprwm",
         "repo": "hyprtoolkit",
-        "rev": "bdba25ced39ea39ab004a8f31593ba0b0ff1ca35",
+        "rev": "af515b69dfbe366dc7873aa1475cb2f4db3ebad7",
         "type": "github"
       },
       "original": {
@@ -859,11 +859,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772462885,
-        "narHash": "sha256-5pHXrQK9zasMnIo6yME6EOXmWGFMSnCITcfKshhKJ9I=",
+        "lastModified": 1786464731,
+        "narHash": "sha256-USQr9G+TZbHbBHXRwgqTNQ/rQZjDCVByngD/7HuZhmY=",
         "owner": "hyprwm",
         "repo": "hyprtoolkit",
-        "rev": "9af245a69fa6b286b88ddfc340afd288e00a6998",
+        "rev": "be487c470a1a10011fb8dccf9fc0f12f1e006cac",
         "type": "github"
       },
       "original": {
@@ -884,11 +884,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785843795,
-        "narHash": "sha256-DFc543bQN94Kt+RsD3Hiu7qCA1uKdqaFJKPMjzANKGU=",
+        "lastModified": 1786464080,
+        "narHash": "sha256-W1hxvumEM57yV+QwsZ4QdAHEqOkr7e4S8VAkLX60qDE=",
         "owner": "hyprwm",
         "repo": "hyprutils",
-        "rev": "5a7b8cf221914ce4714407950e4ffbdddcd8b66f",
+        "rev": "c157fe1e3092b980cc69315a6631f89aff09dcce",
         "type": "github"
       },
       "original": {
@@ -909,11 +909,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772459835,
-        "narHash": "sha256-978jRz/y/9TKmZb/qD4lEYHCQGHpEXGqy+8X2lFZsak=",
+        "lastModified": 1786464033,
+        "narHash": "sha256-QM8Qe4/L8lpdVN4bgwahmi+jyyc4fisseDMe4afcDxA=",
         "owner": "hyprwm",
         "repo": "hyprwayland-scanner",
-        "rev": "0a692d4a645165eebd65f109146b8861e3a925e7",
+        "rev": "62e62c1ca23da17612c6890d4ad2064f575643db",
         "type": "github"
       },
       "original": {
@@ -934,11 +934,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777159683,
-        "narHash": "sha256-Jxixw6wZphUp+nHYxOKUYSckL17QMBx2d5Zp0rJHr1g=",
+        "lastModified": 1786464033,
+        "narHash": "sha256-QM8Qe4/L8lpdVN4bgwahmi+jyyc4fisseDMe4afcDxA=",
         "owner": "hyprwm",
         "repo": "hyprwayland-scanner",
-        "rev": "b8632713a6beaf28b56f2a7b0ab2fb7088dbb404",
+        "rev": "62e62c1ca23da17612c6890d4ad2064f575643db",
         "type": "github"
       },
       "original": {
@@ -963,11 +963,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784465130,
-        "narHash": "sha256-ak5fWEmWZyax8trkV4aphdvjrbUiSyl6qS+y5GwBS7Y=",
+        "lastModified": 1786464294,
+        "narHash": "sha256-ZQsZ2WvBdkboCIyh8LStDPdAIARmxzn0XMNxxoOhjPE=",
         "owner": "hyprwm",
         "repo": "hyprwire",
-        "rev": "7d935bb54674aa0fbd327d2a6888bd0630079ed0",
+        "rev": "4ce7cd6b6128c1ac41caf23c58a30a26b327f9dd",
         "type": "github"
       },
       "original": {
@@ -1061,11 +1061,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1785749642,
-        "narHash": "sha256-5/wlGe3a4ucxvYq2cuAAsuSFWKcIttQ6En83MLlV2jY=",
+        "lastModified": 1786473774,
+        "narHash": "sha256-BDedo9F6NJOw+Ii+luFZh0MVIheKqiYgiVzMWc6WB24=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "f142433bdbeffd2af51231e0aff7162c2bfbf6ef",
+        "rev": "4a773989235545c56f408d168cb63bc41d468832",
         "type": "github"
       },
       "original": {
@@ -1260,11 +1260,11 @@
     },
     "nixpkgs_10": {
       "locked": {
-        "lastModified": 1786106723,
-        "narHash": "sha256-zDSUbpoeo/9ZmD2+wXnzxoo1+uhL8vxc0b8yuYMKYq0=",
+        "lastModified": 1786599213,
+        "narHash": "sha256-yNJd40f11EzXBjSByCB7IPpeFFAdeoSKKM67dGkfFoU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f13ff45afd1bb73e640eaa08a7066dbed07e3238",
+        "rev": "0e251e24a4f24e036a084b6b4b2d2491af4167f4",
         "type": "github"
       },
       "original": {
@@ -1305,11 +1305,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1786106723,
-        "narHash": "sha256-zDSUbpoeo/9ZmD2+wXnzxoo1+uhL8vxc0b8yuYMKYq0=",
+        "lastModified": 1786247143,
+        "narHash": "sha256-8S3Kcxs7D4UtxJxSJZz0m14CGhuW0MxfrIwJxeGWGnQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f13ff45afd1bb73e640eaa08a7066dbed07e3238",
+        "rev": "279b4a8275f032c566576b3f181fa0f27197f588",
         "type": "github"
       },
       "original": {
@@ -1401,11 +1401,11 @@
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1786106723,
-        "narHash": "sha256-zDSUbpoeo/9ZmD2+wXnzxoo1+uhL8vxc0b8yuYMKYq0=",
+        "lastModified": 1786599213,
+        "narHash": "sha256-yNJd40f11EzXBjSByCB7IPpeFFAdeoSKKM67dGkfFoU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f13ff45afd1bb73e640eaa08a7066dbed07e3238",
+        "rev": "0e251e24a4f24e036a084b6b4b2d2491af4167f4",
         "type": "github"
       },
       "original": {
@@ -1421,11 +1421,11 @@
         "nixpkgs": "nixpkgs_10"
       },
       "locked": {
-        "lastModified": 1786245143,
-        "narHash": "sha256-eLHhhkMP5kjmqqLcCO8jKaYNP1/ua/5kL6zTmQgWJVo=",
+        "lastModified": 1786847921,
+        "narHash": "sha256-3BjmH0+2Vmj+NznuGuBU8hhOOy1yKO5zRyu3XJZs/Gg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "24c35502e7b26b3bc75365b5318399a6c451deab",
+        "rev": "e0bbd1b1afc716fd7c591ae609e6b5a98f832584",
         "type": "github"
       },
       "original": {
@@ -1616,11 +1616,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785044261,
-        "narHash": "sha256-ehF/c4fLdgmNu7YXEClnmwhoBYddhYIVoSQpsZoorC4=",
+        "lastModified": 1786420161,
+        "narHash": "sha256-PU4CY4GUCDFOoS67dGrc/fS6Y+d1cYZSh6nbgYqAAwE=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "fe2124391e739e7b3e8720cd8a73f06edd0aceba",
+        "rev": "3a646bd5daa3af78a78a1cb32329cb72d18fcae0",
         "type": "github"
       },
       "original": {
@@ -1656,11 +1656,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783174389,
-        "narHash": "sha256-aCWC8ngycU7OdJrU2+Je3qf+1a2ykuBvpPhZT/9tXMc=",
+        "lastModified": 1786629091,
+        "narHash": "sha256-gkig4nPi1CWc4Z50GBsjE4ygSE7hMpl/TwID2an2Cck=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "f1406619a3884cd5c47992a70b8b35c9c0fcb4c9",
+        "rev": "a8627b21b9107c5711c96b84f32a9a4b3d45295f",
         "type": "github"
       },
       "original": {
@@ -1727,11 +1727,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786032767,
-        "narHash": "sha256-C5K27sF/jaQe1BgB1/575r01oTAvw6mrDWPS1qUl6X0=",
+        "lastModified": 1786464334,
+        "narHash": "sha256-/TBQT5rhBB2Dm4HoZzhGDaCwYmRTs3W3DPhMXFWc/BU=",
         "owner": "hyprwm",
         "repo": "xdg-desktop-portal-hyprland",
-        "rev": "688feb3d88404598f12440a668136e74044391de",
+        "rev": "9f0e9ff02739cd538d39bd706422dc50e9ca60dd",
         "type": "github"
       },
       "original": {
@@ -1747,11 +1747,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786164819,
-        "narHash": "sha256-tvBlGAYyzHYdLwn035bRCrB1mcMjvNNavcNZ293AIIA=",
+        "lastModified": 1786685380,
+        "narHash": "sha256-3ZuubfWk7CHPF/60w5BVrVkzdO7Oed1MgZ+ugLsgww8=",
         "owner": "youwen5",
         "repo": "zen-browser-flake",
-        "rev": "f9af5f7017cea1c159e17922288fb38ff94d28cd",
+        "rev": "e1e4aa6433a352f07059aeb8483ae42deb61f9b2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automatic flake update on 2026-08-16.

Review the per-host package changes below before merging.

## Input changes

```
unpacking 'github:nix-community/disko/de5708739256238fb912c62f03988815db89ec9a' into the Git cache...
unpacking 'github:Gako358/emacs-flake/7093c0105887495cf3c34fc13fa73862a68a2d9a' into the Git cache...
unpacking 'github:hercules-ci/flake-parts/427bf4bd9435fdf21321c8cc628c24efc14c0f7a' into the Git cache...
unpacking 'github:nixos/nixos-hardware/2dda192987ab6815e44df0130f03d6c907b79134' into the Git cache...
unpacking 'github:nix-community/home-manager/c8058ecc1329a71a3c99c4d0353dba4009a66152' into the Git cache...
unpacking 'github:hyprwm/hypridle/aa958ed7ad4863860b93ecd7189419e193bfae2c' into the Git cache...
unpacking 'github:hyprwm/hyprland/a1b9dc0e8cdfeca3e2d96a24b10b3d85e14fbd50' into the Git cache...
unpacking 'github:hyprwm/contrib/3dcbce715ae8b93107fa8632db15bf976862a573' into the Git cache...
unpacking 'github:hyprwm/hyprland-plugins/faf5ef1bd5916051ed3252463697dd2ae479f629' into the Git cache...
unpacking 'github:hyprwm/hyprpaper/39029bdfda857a5ea60340a427681893d12d4892' into the Git cache...
unpacking 'github:nix-community/impermanence/7b1d382faf603b6d264f58627330f9faa5cba149' into the Git cache...
unpacking 'github:vic/import-tree/4ebb10ae17d5f1ad366e7aef5b92cb8eecf24f69' into the Git cache...
unpacking 'github:nix-community/lanzaboote/4a773989235545c56f408d168cb63bc41d468832' into the Git cache...
unpacking 'github:misterio77/nix-colors/b01f024090d2c4fc3152cd0cf12027a7b8453ba1' into the Git cache...
unpacking 'github:nixos/nixpkgs/0e251e24a4f24e036a084b6b4b2d2491af4167f4' into the Git cache...
unpacking 'github:nix-community/NUR/e0bbd1b1afc716fd7c591ae609e6b5a98f832584' into the Git cache...
unpacking 'github:nix-community/plasma-manager/a19a2a029fa180911bd89c554dca1616e10f4c1d' into the Git cache...
unpacking 'github:cachix/pre-commit-hooks.nix/43b3c1ab9d40fb1dbb008f451988a91e375825e9' into the Git cache...
unpacking 'github:gako358/scram/c32556f403be2aa42aafd72087da28d8f477010e' into the Git cache...
unpacking 'github:Mic92/sops-nix/a8627b21b9107c5711c96b84f32a9a4b3d45295f' into the Git cache...
unpacking 'github:youwen5/zen-browser-flake/e1e4aa6433a352f07059aeb8483ae42deb61f9b2' into the Git cache...
warning: updating lock file "/home/runner/work/dotfiles/dotfiles/flake.lock":
• Updated input 'emacs-flake':
    'github:Gako358/emacs-flake/150dce3d3eba7dcbb9257a201a7acb7d8963f745?narHash=sha256-8M3Ks1N27iFxM2WCBUPG849OJ9ku3OE6vz9uIcspv44%3D' (2026-08-13)
  → 'github:Gako358/emacs-flake/7093c0105887495cf3c34fc13fa73862a68a2d9a?narHash=sha256-Xrt51iEPulDngzrlXlwzzuVnASIMelYdzobxWbmkcdE%3D' (2026-08-15)
• Updated input 'hardware':
    'github:nixos/nixos-hardware/2e790b0a6be8ec2b76174ac0931b8ff11919ec98?narHash=sha256-65EQYIRRpTdpH8lUiB6Mvo5uBkG60aBIzAJuALfx%2BO0%3D' (2026-07-28)
  → 'github:nixos/nixos-hardware/2dda192987ab6815e44df0130f03d6c907b79134?narHash=sha256-asdPlqtM0AweQ5YNLad6eY4tSYW55YNr1uyayf7mOMQ%3D' (2026-08-14)
• Updated input 'home-manager':
    'github:nix-community/home-manager/7834e82588860aaf780cec1366524456a70898d7?narHash=sha256-TIDlLTLI1/pB7IqgjzcKQjpODQsZE2oII4XGG9B6KjI%3D' (2026-08-06)
  → 'github:nix-community/home-manager/c8058ecc1329a71a3c99c4d0353dba4009a66152?narHash=sha256-nNqmXIFmESRnU91KARtiekSox0%2Bo%2BE3AS0d1TuUQ/9o%3D' (2026-08-15)
• Updated input 'hypridle':
    'github:hyprwm/hypridle/e5c01af0842bd66617f7004568df9406111d6e80?narHash=sha256-Wi8kgoWStgYopfjEmHZWsAG7Gkghr9RGFjYLVmxSKpQ%3D' (2026-07-26)
  → 'github:hyprwm/hypridle/aa958ed7ad4863860b93ecd7189419e193bfae2c?narHash=sha256-%2BqflH9Z86YZqL69GMC8fAc6Crw0pAbMqgCUibo%2BiL3A%3D' (2026-08-11)
• Updated input 'hypridle/hyprwayland-scanner':
    'github:hyprwm/hyprwayland-scanner/0a692d4a645165eebd65f109146b8861e3a925e7?narHash=sha256-978jRz/y/9TKmZb/qD4lEYHCQGHpEXGqy%2B8X2lFZsak%3D' (2026-03-02)
  → 'github:hyprwm/hyprwayland-scanner/62e62c1ca23da17612c6890d4ad2064f575643db?narHash=sha256-QM8Qe4/L8lpdVN4bgwahmi%2Bjyyc4fisseDMe4afcDxA%3D' (2026-08-11)
• Updated input 'hyprland':
    'github:hyprwm/hyprland/5dee44a72476be67789f64e6c6bffae0df28c53a?narHash=sha256-FT4YNi3yr1lnuZPAj4CqBpxWYniUuPbvjIsLsttFjtI%3D' (2026-08-08)
  → 'github:hyprwm/hyprland/a1b9dc0e8cdfeca3e2d96a24b10b3d85e14fbd50?narHash=sha256-8Pyv0ORHhzsUElqqESECxSr3xr%2BSFibDZTizTF48k9I%3D' (2026-08-15)
• Updated input 'hyprland/aquamarine':
    'github:hyprwm/aquamarine/1a10fe26a9f7d989c359e6a9ea61aa2e44d06c36?narHash=sha256-H2CrAlJD9FsUbSEIhPVK3IyVjnK0vSxPruBef17GcBs%3D' (2026-08-04)
  → 'github:hyprwm/aquamarine/f3d1804205e8158c15595cdda1b566f93349ffae?narHash=sha256-WKqWL8r7CyTDYueTr2ffJ9ya50dellv6IR1JX5PghDY%3D' (2026-08-11)
• Updated input 'hyprland/hyprcursor':
    'github:hyprwm/hyprcursor/39435900785d0c560c6ae8777d29f28617d031ef?narHash=sha256-fCpwFiTW0rT7oKJqr3cqHMnkwypSwQKpbtUEtxdkgrM%3D' (2026-04-18)
  → 'github:hyprwm/hyprcursor/e4ed7c08123df5af460a0a70961380cbfb872f76?narHash=sha256-2alOMkLjXANh7unkZnYnCF2K2rApZaOLMoQ3o%2BVX2CY%3D' (2026-08-11)
• Updated input 'hyprland/hyprgraphics':
    'github:hyprwm/hyprgraphics/8699c38f0e4a1ca3bfc84f84ba020509ced1f133?narHash=sha256-dpW3UKG2NTboxxYGzOX4nZiH8YI%2B%2BCpgosHmVaquOEI%3D' (2026-08-04)
  → 'github:hyprwm/hyprgraphics/7c895c44e3ca6d28ed68ddd80ec02b02b925e7fc?narHash=sha256-k58p4wbzIXWyRWrW84pP8tD%2BiaZSSYiiM%2Bfr0Auk4oU%3D' (2026-08-11)
• Updated input 'hyprland/hyprland-guiutils':
    'github:hyprwm/hyprland-guiutils/a16ad89ed5fb4192c966018a80c652de8d96f748?narHash=sha256-Ee78BRFi%2BMrmgHmmW%2B2dZUEI1R3cssEzza0ar3fsNX8%3D' (2026-07-20)
  → 'github:hyprwm/hyprland-guiutils/4c30cf3097ea963c0e250749ee0c59f8b08816d6?narHash=sha256-7sHwM86KILQyHDHDuE2SDBlQ2jvZ0EW3hY7sW009/cg%3D' (2026-08-11)
• Updated input 'hyprland/hyprland-guiutils/hyprtoolkit':
    'github:hyprwm/hyprtoolkit/bdba25ced39ea39ab004a8f31593ba0b0ff1ca35?narHash=sha256-%2Bp3MlyN/nqRefcf2IckPlGRUn9%2BhielqpS9XClbLleM%3D' (2026-06-27)
  → 'github:hyprwm/hyprtoolkit/af515b69dfbe366dc7873aa1475cb2f4db3ebad7?narHash=sha256-DitTu625BhEYpZjtjxtGpjrEJwPwW%2BX/%2BjJvhSZNSJM%3D' (2026-08-05)
• Updated input 'hyprland/hyprlang':
    'github:hyprwm/hyprlang/090117506ddc3d7f26e650ff344d378c2ec329cc?narHash=sha256-Qu%2BWf2Bp5qUjyn2YpZNq8a7JyzTGowhT1knrwE38a9U%3D' (2026-04-27)
  → 'github:hyprwm/hyprlang/9508458be316a0d70d37ebed1ab725ccd10411ff?narHash=sha256-339AkTlpMYSIvFuG0rnR%2B8Yg4/AZKeJalshJavlnKfg%3D' (2026-08-11)
• Updated input 'hyprland/hyprutils':
    'github:hyprwm/hyprutils/5a7b8cf221914ce4714407950e4ffbdddcd8b66f?narHash=sha256-DFc543bQN94Kt%2BRsD3Hiu7qCA1uKdqaFJKPMjzANKGU%3D' (2026-08-04)
  → 'github:hyprwm/hyprutils/c157fe1e3092b980cc69315a6631f89aff09dcce?narHash=sha256-W1hxvumEM57yV%2BQwsZ4QdAHEqOkr7e4S8VAkLX60qDE%3D' (2026-08-11)
• Updated input 'hyprland/hyprwayland-scanner':
    'github:hyprwm/hyprwayland-scanner/b8632713a6beaf28b56f2a7b0ab2fb7088dbb404?narHash=sha256-Jxixw6wZphUp%2BnHYxOKUYSckL17QMBx2d5Zp0rJHr1g%3D' (2026-04-25)
  → 'github:hyprwm/hyprwayland-scanner/62e62c1ca23da17612c6890d4ad2064f575643db?narHash=sha256-QM8Qe4/L8lpdVN4bgwahmi%2Bjyyc4fisseDMe4afcDxA%3D' (2026-08-11)
• Updated input 'hyprland/hyprwire':
    'github:hyprwm/hyprwire/7d935bb54674aa0fbd327d2a6888bd0630079ed0?narHash=sha256-ak5fWEmWZyax8trkV4aphdvjrbUiSyl6qS%2By5GwBS7Y%3D' (2026-07-19)
  → 'github:hyprwm/hyprwire/4ce7cd6b6128c1ac41caf23c58a30a26b327f9dd?narHash=sha256-ZQsZ2WvBdkboCIyh8LStDPdAIARmxzn0XMNxxoOhjPE%3D' (2026-08-11)
• Updated input 'hyprland/nixpkgs':
    'github:NixOS/nixpkgs/f13ff45afd1bb73e640eaa08a7066dbed07e3238?narHash=sha256-zDSUbpoeo/9ZmD2%2BwXnzxoo1%2BuhL8vxc0b8yuYMKYq0%3D' (2026-08-07)
  → 'github:NixOS/nixpkgs/279b4a8275f032c566576b3f181fa0f27197f588?narHash=sha256-8S3Kcxs7D4UtxJxSJZz0m14CGhuW0MxfrIwJxeGWGnQ%3D' (2026-08-09)
• Updated input 'hyprland/xdph':
    'github:hyprwm/xdg-desktop-portal-hyprland/688feb3d88404598f12440a668136e74044391de?narHash=sha256-C5K27sF/jaQe1BgB1/575r01oTAvw6mrDWPS1qUl6X0%3D' (2026-08-06)
  → 'github:hyprwm/xdg-desktop-portal-hyprland/9f0e9ff02739cd538d39bd706422dc50e9ca60dd?narHash=sha256-/TBQT5rhBB2Dm4HoZzhGDaCwYmRTs3W3DPhMXFWc/BU%3D' (2026-08-11)
• Updated input 'hyprpaper':
    'github:hyprwm/hyprpaper/c011bd20886ea3301474e77d7fa4d22ab013ece0?narHash=sha256-vnAw7lsqr4xGsr36WiL/qTlq47CtsldhnD2TnZzvz30%3D' (2026-05-25)
  → 'github:hyprwm/hyprpaper/39029bdfda857a5ea60340a427681893d12d4892?narHash=sha256-31/Mc3h5BtNi1Vh0%2B/W13RMjHCOhQlSOXqdseMAlV2Y%3D' (2026-08-13)
• Updated input 'hyprpaper/hyprtoolkit':
    'github:hyprwm/hyprtoolkit/9af245a69fa6b286b88ddfc340afd288e00a6998?narHash=sha256-5pHXrQK9zasMnIo6yME6EOXmWGFMSnCITcfKshhKJ9I%3D' (2026-03-02)
  → 'github:hyprwm/hyprtoolkit/be487c470a1a10011fb8dccf9fc0f12f1e006cac?narHash=sha256-USQr9G%2BTZbHbBHXRwgqTNQ/rQZjDCVByngD/7HuZhmY%3D' (2026-08-11)
• Updated input 'lanzaboote':
    'github:nix-community/lanzaboote/f142433bdbeffd2af51231e0aff7162c2bfbf6ef?narHash=sha256-5/wlGe3a4ucxvYq2cuAAsuSFWKcIttQ6En83MLlV2jY%3D' (2026-08-03)
  → 'github:nix-community/lanzaboote/4a773989235545c56f408d168cb63bc41d468832?narHash=sha256-BDedo9F6NJOw%2BIi%2BluFZh0MVIheKqiYgiVzMWc6WB24%3D' (2026-08-11)
• Updated input 'lanzaboote/crane':
    'github:ipetkov/crane/7930f6c291de6f83c257839d434592aa085f290a?narHash=sha256-TkTWNhJV/8Wk3czlbz4bwHZkFCaCHPsOy%2BoJe4PUiXg%3D' (2026-07-20)
  → 'github:ipetkov/crane/2c71e194474d13de031d729b729c968ddbe3507f?narHash=sha256-MPaRdVkf6zZP5fCPxYCi8Dr4pZzgmXzg8T9nVEbp3Mw%3D' (2026-08-03)
• Updated input 'lanzaboote/rust-overlay':
    'github:oxalica/rust-overlay/fe2124391e739e7b3e8720cd8a73f06edd0aceba?narHash=sha256-ehF/c4fLdgmNu7YXEClnmwhoBYddhYIVoSQpsZoorC4%3D' (2026-07-26)
  → 'github:oxalica/rust-overlay/3a646bd5daa3af78a78a1cb32329cb72d18fcae0?narHash=sha256-PU4CY4GUCDFOoS67dGrc/fS6Y%2Bd1cYZSh6nbgYqAAwE%3D' (2026-08-11)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/f13ff45afd1bb73e640eaa08a7066dbed07e3238?narHash=sha256-zDSUbpoeo/9ZmD2%2BwXnzxoo1%2BuhL8vxc0b8yuYMKYq0%3D' (2026-08-07)
  → 'github:nixos/nixpkgs/0e251e24a4f24e036a084b6b4b2d2491af4167f4?narHash=sha256-yNJd40f11EzXBjSByCB7IPpeFFAdeoSKKM67dGkfFoU%3D' (2026-08-13)
• Updated input 'nur':
    'github:nix-community/NUR/24c35502e7b26b3bc75365b5318399a6c451deab?narHash=sha256-eLHhhkMP5kjmqqLcCO8jKaYNP1/ua/5kL6zTmQgWJVo%3D' (2026-08-09)
  → 'github:nix-community/NUR/e0bbd1b1afc716fd7c591ae609e6b5a98f832584?narHash=sha256-3BjmH0%2B2Vmj%2BNznuGuBU8hhOOy1yKO5zRyu3XJZs/Gg%3D' (2026-08-16)
• Updated input 'nur/nixpkgs':
    'github:nixos/nixpkgs/f13ff45afd1bb73e640eaa08a7066dbed07e3238?narHash=sha256-zDSUbpoeo/9ZmD2%2BwXnzxoo1%2BuhL8vxc0b8yuYMKYq0%3D' (2026-08-07)
  → 'github:nixos/nixpkgs/0e251e24a4f24e036a084b6b4b2d2491af4167f4?narHash=sha256-yNJd40f11EzXBjSByCB7IPpeFFAdeoSKKM67dGkfFoU%3D' (2026-08-13)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/f1406619a3884cd5c47992a70b8b35c9c0fcb4c9?narHash=sha256-aCWC8ngycU7OdJrU2%2BJe3qf%2B1a2ykuBvpPhZT/9tXMc%3D' (2026-07-04)
  → 'github:Mic92/sops-nix/a8627b21b9107c5711c96b84f32a9a4b3d45295f?narHash=sha256-gkig4nPi1CWc4Z50GBsjE4ygSE7hMpl/TwID2an2Cck%3D' (2026-08-13)
• Updated input 'zen-browser':
    'github:youwen5/zen-browser-flake/f9af5f7017cea1c159e17922288fb38ff94d28cd?narHash=sha256-tvBlGAYyzHYdLwn035bRCrB1mcMjvNNavcNZ293AIIA%3D' (2026-08-08)
  → 'github:youwen5/zen-browser-flake/e1e4aa6433a352f07059aeb8483ae42deb61f9b2?narHash=sha256-3ZuubfWk7CHPF/60w5BVrVkzdO7Oed1MgZ%2BugLsgww8%3D' (2026-08-14)
```

## Per-host package diff

<details><summary><b>aanallein</b></summary>

```
<<< result-old
>>> result-new
Version changes:
[U.]  #01  at-spi2-core                 2.60.4, 2.60.4-dev -> 2.60.6, 2.60.6-dev
[C.]  #02  audit                        4.1.4-lib, 4.2-lib x2 -> 4.1.4-lib, 4.2.1-lib x2
[U.]  #03  bcachefs-tools               1.38.8 -> 1.39.1
[U.]  #04  bluez                        5.86 x2 -> 5.87 x2
[U*]  #05  cpupower                     6.18.43, 6.18.43_fish-completions -> 6.18.44, 6.18.44_fish-completions
[U*]  #06  docker                       29.6.2 -> 29.7.2
[U.]  #07  docker-containerd            29.6.2 -> 29.7.2
[U.]  #08  docker-runc                  29.6.2 -> 29.7.2
[U.]  #09  docker-tini                  29.6.2 -> 29.7.2
[U.]  #10  ffmpeg-headless              8.1.2-data x2, 8.1.2-lib x2 -> 9.0-data x2, 9.0-lib x2
[U.]  #11  gdk-pixbuf                   2.44.6, 2.44.6-dev -> 2.44.7, 2.44.7-dev
[U.]  #12  glib                         2.88.1 x2, 2.88.1-bin, 2.88.1-dev -> 2.88.3 x2, 2.88.3-bin, 2.88.3-dev
[C.]  #13  glibmm                       2.66.8 x2, 2.88.0 -> 2.66.8 x2, 2.88.1
[U.]  #14  gnuplot                      6.0.4 -> 6.0.5
[U.]  #15  hwdata                       0.409 x2 -> 0.410 x2
[U.]  #16  initrd-linux                 6.18.43 -> 6.18.44
[U.]  #17  lerc                         4.1.1 x2, 4.1.1-dev -> 4.2.0 x2, 4.2.0-dev
[U.]  #18  libmpg123                    1.33.6 x2 -> 1.33.7 x2
[U.]  #19  libraqm                      0.10.5 -> 0.11.0
[U.]  #20  libssh                       0.12.1 x2 -> 0.12.2 x2
[U.]  #21  libva                        2.24.0 -> 2.24.1
[U.]  #22  libva-minimal                2.24.0 x2 -> 2.24.1 x2
[U.]  #23  linux                        6.18.43, 6.18.43-modules x2 -> 6.18.44, 6.18.44-modules x2
[U.]  #24  linux-firmware               20260622-zstd -> 20260810-zstd
[U.]  #25  llhttp                       9.4.2 -> 9.4.3
[U.]  #26  moby                         29.6.2 -> 29.7.2
[U.]  #27  mpg123                       1.33.6 x2 -> 1.33.7 x2
[U.]  #28  ncdu                         2.10.0, 2.10.0-fish-completions -> 2.11.0, 2.11.0-fish-completions
[U.]  #29  nerd-fonts-dejavu-sans-mono  3.4.0+2.37 -> 3.5.0+2.37
[U.]  #30  nerd-fonts-fira-code         3.4.0+6.2 -> 3.5.0+6.2
[U.]  #31  nerd-fonts-fira-mono         3.4.0+3.206 -> 3.5.0+3.206
[U.]  #32  nerd-fonts-hack              3.4.0+3.003 -> 3.5.0+3.003
[U.]  #33  nerd-fonts-iosevka           3.4.0+33.2.1 -> 3.5.0+34.8.0
[U.]  #34  nerd-fonts-jetbrains-mono    3.4.0+2.304 -> 3.5.0+2.304
[U.]  #35  nerd-fonts-liberation        3.4.0+2.1.5 -> 3.5.0+2.1.5
[U.]  #36  nerd-fonts-noto              3.4.0 -> 3.5.0
[U.]  #37  nerd-fonts-roboto-mono       3.4.0+3.0 -> 3.5.0+3.0
[U.]  #38  nerd-fonts-ubuntu-mono       3.4.0+0.80 -> 3.5.0+0.80
[U*]  #39  networkmanager               1.56.0, 1.56.0-doc, 1.56.0-man -> 1.58.0, 1.58.0-doc, 1.58.0-man
[U.]  #40  nix-direnv                   3.1.2 -> 3.2.0
[U.]  #41  nixos-system-aanallein       26.11.20260807.f13ff45 -> 26.11.20260813.0e251e2
[U.]  #42  noto-fonts                   2026.07.01 -> 2026.08.01
[C.]  #43  pangomm                      2.46.4, 2.56.1 -> 2.46.4, 2.56.2
[C*]  #44  perl                         5.42.0 x2, 5.42.0-env x3, 5.42.0-man -> 5.42.0 x2, 5.42.0-env x4, 5.42.0-man
[C.]  #45  publicsuffix-list            0-unstable-2026-06-24 x3 -> 0-unstable-2026-06-24, 0-unstable-2026-07-25 x2
[C.]  #46  python3                      3.14.6 x3, 3.14.6-env x2 -> 3.14.6, 3.14.7 x2, 3.14.7-env x2
[U*]  #47  shadow                       4.19.4, 4.19.4-man, 4.19.4-su -> 4.20.0, 4.20.0-man, 4.20.0-su
[C*]  #48  systemd                      <none>, 261.1 x3, 261.1-dev, 261.1-man -> <none>, 261.1 x2, 261.1-dev, 261.1-man
[U.]  #49  tpm2-tss                     4.1.3 x2 -> 4.2.0 x2
[C.]  #50  unifont                      17.0.05 -> 17.0.05, 17.0.05-bin
[U.]  #51  vulkan-headers               1.4.350.0 -> 1.4.357.0
[U.]  #52  vulkan-loader                1.4.350.0 x2, 1.4.350.0-dev -> 1.4.357.0 x2, 1.4.357.0-dev
[U.]  #53  wildmidi                     0.4.6 -> 0.5.0
[U.]  #54  zxing-cpp                    3.0.2 -> 3.1.1
Added packages:
[A.]  #1  perl5.42.0-GD  2.86
Removed packages:
[R.]  #1  tremor-unstable  2018-03-16 x2
Closure size: 1890 -> 1890 (1758 paths added, 1758 paths removed, delta +0, disk usage +122.4MiB).
```

</details>

<details><summary><b>rhuidean</b></summary>

```
<<< result-old
>>> result-new
Version changes:
[C.]  #01  abseil-cpp                   20260107.1 x2, 20260107.1-dev -> 20260107.1 x3, 20260107.1-dev
[U*]  #02  at-spi2-core                 2.60.4 x2, 2.60.4-dev -> 2.60.6 x2, 2.60.6-dev
[C.]  #03  audit                        4.1.4-lib, 4.2-lib x2 -> 4.1.4-lib, 4.2.1-lib x2
[U.]  #04  bcachefs-tools               1.38.8 -> 1.39.1
[U*]  #05  bluez                        5.86 x2, 5.86_fish-completions -> 5.87 x2, 5.87_fish-completions
[U*]  #06  cpupower                     6.18.43, 6.18.43_fish-completions -> 6.18.44, 6.18.44_fish-completions
[U.]  #07  discord                      1.0.152, 1.0.152-fish-completions -> 1.0.153, 1.0.153-bwrap, 1.0.153-fhsenv-profile, 1.0.153-fhsenv-rootfs, 1.0.153-fish-completions, 1.0.153-init
[U*]  #08  docker                       29.6.2 -> 29.7.2
[U.]  #09  docker-containerd            29.6.2 -> 29.7.2
[U.]  #10  docker-runc                  29.6.2 -> 29.7.2
[U.]  #11  docker-tini                  29.6.2 -> 29.7.2
[C.]  #12  ffmpeg                       4.4.8-data, 4.4.8-lib, 7.1.5-data, 7.1.5-lib, 8.1.2-data, 8.1.2-lib -> 4.4.8-data, 4.4.8-lib, 7.1.5-data, 7.1.5-lib, 9.0-data, 9.0-lib
[C.]  #13  ffmpeg-headless              8.1.2-data x2, 8.1.2-lib x2 -> 8.1.2-data, 8.1.2-lib, 9.0-data x2, 9.0-lib x2
[U.]  #14  fmt                          12.1.0 x2 -> 12.2.0 x2
[C.]  #15  gcc                          15.3.0-lib x3, 15.3.0-libgcc x3 -> 15.3.0, 15.3.0-lib x3, 15.3.0-libgcc x3, 15.3.0-man
[U.]  #16  gdk-pixbuf                   2.44.6 x2, 2.44.6-dev, 2.44.6-man -> 2.44.7 x2, 2.44.7-dev, 2.44.7-man
[C*]  #17  gdm                          <none>, 50.1 -> <none>, 50.2
[C.]  #18  gexiv2                       0.14.6, 0.16.0 -> 0.14.6, 0.16.2
[U*]  #19  gjs                          1.88.0 -> 1.88.1
[U*]  #20  glib                         2.88.1 x2, 2.88.1-bin x2, 2.88.1-dev, 2.88.1_fish-completions -> 2.88.3 x2, 2.88.3-bin x2, 2.88.3-dev, 2.88.3_fish-completions
[C.]  #21  glibmm                       2.66.8 x2, 2.88.0 -> 2.66.8 x2, 2.88.1
[U.]  #22  glycin-loaders               2.1.1 -> 2.1.5
[U*]  #23  glycin-thumbnailer           2.1.1 -> 2.1.5
[U*]  #24  gnome-control-center         50.3 -> 50.4
[C*]  #25  gnome-initial-setup          <none>, 50.0 -> <none>, 50.1
[U*]  #26  gnome-maps                   50.2 -> 50.3
[U*]  #27  gnome-remote-desktop         50.1, 50.1_fish-completions -> 50.2, 50.2_fish-completions
[U*]  #28  gnome-shell                  50.2, 50.2_fish-completions -> 50.4, 50.4_fish-completions
[U*]  #29  gnome-user-docs              50.2 -> 50.4
[U.]  #30  gnuplot                      6.0.4 -> 6.0.5
[U*]  #31  gvfs                         1.60.1 x2 -> 1.60.2 x2
[U.]  #32  hwdata                       0.409 x2 -> 0.410 x2
[U.]  #33  initrd-linux                 6.18.43 -> 6.18.44
[C*]  #34  iputils                      20250605 x2, 20250605-man -> 20250605, 20250605-man
[U.]  #35  lerc                         4.1.1 x2, 4.1.1-dev -> 4.2.0 x2, 4.2.0-dev
[C.]  #36  libXNVCtrl                   390.157, 595.84 -> 390.157, 595.91.07
[U.]  #37  libadwaita                   1.9.2 -> 1.9.3
[U.]  #38  libglycin                    2.1.1 -> 2.1.5
[U.]  #39  libglycin-gtk4               2.1.1 -> 2.1.5
[C.]  #40  libmpc                       1.4.1 -> 1.4.1 x2
[U.]  #41  libmpg123                    1.33.6 x2, 1.33.6-man -> 1.33.7 x2, 1.33.7-man
[C.]  #42  libnotify                    0.8.8 -> 0.8.8, 0.8.8-man
[U.]  #43  libraqm                      0.10.5 -> 0.11.0
[U.]  #44  libshumate                   1.6.2 -> 1.6.3
[U.]  #45  libssh                       0.12.1 x2 -> 0.12.2 x2
[U.]  #46  libva                        2.24.0 x2 -> 2.24.1 x2
[U.]  #47  libva-minimal                2.24.0 x2 -> 2.24.1 x2
[U.]  #48  libxfont_2                   2.0.8 -> 2.0.9
[U.]  #49  libxmp                       4.7.1 -> 4.7.2
[U.]  #50  linux                        6.18.43, 6.18.43-modules x2 -> 6.18.44, 6.18.44-modules x2
[U.]  #51  linux-firmware               20260622-zstd -> 20260810-zstd
[U.]  #52  llhttp                       9.4.2 -> 9.4.3
[U.]  #53  moby                         29.6.2 -> 29.7.2
[C.]  #54  mpfr                         4.2.2 -> 4.2.2 x2
[U.]  #55  mpg123                       1.33.6 x2 -> 1.33.7 x2
[U.]  #56  mutter                       50.2 -> 50.4
[U.]  #57  ncdu                         2.10.0, 2.10.0-fish-completions -> 2.11.0, 2.11.0-fish-completions
[U.]  #58  nerd-fonts-dejavu-sans-mono  3.4.0+2.37 -> 3.5.0+2.37
[U.]  #59  nerd-fonts-fira-code         3.4.0+6.2 -> 3.5.0+6.2
[U.]  #60  nerd-fonts-fira-mono         3.4.0+3.206 -> 3.5.0+3.206
[U.]  #61  nerd-fonts-hack              3.4.0+3.003 -> 3.5.0+3.003
[U.]  #62  nerd-fonts-iosevka           3.4.0+33.2.1 -> 3.5.0+34.8.0
[U.]  #63  nerd-fonts-jetbrains-mono    3.4.0+2.304 -> 3.5.0+2.304
[U.]  #64  nerd-fonts-liberation        3.4.0+2.1.5 -> 3.5.0+2.1.5
[U.]  #65  nerd-fonts-noto              3.4.0 -> 3.5.0
[U.]  #66  nerd-fonts-roboto-mono       3.4.0+3.0 -> 3.5.0+3.0
[U.]  #67  nerd-fonts-ubuntu-mono       3.4.0+0.80 -> 3.5.0+0.80
[U*]  #68  networkmanager               1.56.0 x2, 1.56.0-doc, 1.56.0-man -> 1.58.0 x2, 1.58.0-doc, 1.58.0-man
[U.]  #69  nix-direnv                   3.1.2 -> 3.2.0
[U.]  #70  nixos-system-rhuidean        26.11.20260807.f13ff45 -> 26.11.20260813.0e251e2
[U.]  #71  noto-fonts                   2026.07.01 -> 2026.08.01
[C.]  #72  pangomm                      2.46.4, 2.56.1 -> 2.46.4, 2.56.2
[C*]  #73  perl                         5.42.0 x3, 5.42.0-env x3, 5.42.0-man -> 5.42.0 x3, 5.42.0-env x4, 5.42.0-man
[C*]  #74  plymouth                     26.134.222 x2, 26.134.222_fish-completions -> 26.134.222, 26.134.222_fish-completions
[C.]  #75  publicsuffix-list            0-unstable-2026-06-24 x3 -> 0-unstable-2026-06-24, 0-unstable-2026-07-25 x2
[C.]  #76  python3                      3.14.6 x3, 3.14.6-env x4 -> 3.14.6, 3.14.7 x2, 3.14.7-env x4
[U.]  #77  samba                        4.23.8 -> 4.23.10
[U*]  #78  shadow                       4.19.4, 4.19.4-man, 4.19.4-su -> 4.20.0, 4.20.0-man, 4.20.0-su
[C*]  #79  systemd                      <none>, 261.1 x3, 261.1-dev, 261.1-man -> <none>, 261.1 x2, 261.1-dev, 261.1-man
[U.]  #80  tpm2-tss                     4.1.3 x2 -> 4.2.0 x2
[U*]  #81  udisks                       2.11.1, 2.11.1-man -> 2.11.2, 2.11.2-man
[C.]  #82  unifont                      17.0.05 -> 17.0.05, 17.0.05-bin, 17.0.05-man
[U*]  #83  upower                       1.91.2, 1.91.2_fish-completions -> 1.91.3, 1.91.3_fish-completions
[U.]  #84  vulkan-headers               1.4.350.0 -> 1.4.357.0
[U.]  #85  vulkan-loader                1.4.350.0 x2, 1.4.350.0-dev -> 1.4.357.0 x2, 1.4.357.0-dev
[U.]  #86  vulkan-tools                 1.4.350.0 -> 1.4.357.0
[U.]  #87  wildmidi                     0.4.6 -> 0.5.0
[U.]  #88  zen-browser                  1.21.12b, 1.21.12b-fish-completions -> 1.21.14b, 1.21.14b-fish-completions
[U.]  #89  zen-browser-unwrapped        1.21.12b -> 1.21.14b
[U.]  #90  zxing-cpp                    3.0.2 -> 3.1.1
Added packages:
[A.]  #1  discord-unwrapped  1.0.153
[A.]  #2  gmp                6.3.0
[A.]  #3  isl                0.20
[A.]  #4  perl5.42.0-GD      2.86
Removed packages:
[R.]  #1  hm_.configautostartdiscord.desktop  <none>
[R.]  #2  libgnomekbd                         3.28.1
[R.]  #3  libxklavier                         5.4
[R.]  #4  tremor-unstable                     2018-03-16 x2
Closure size: 2720 -> 2731 (2594 paths added, 2583 paths removed, delta +11, disk usage +426.1MiB).
```

</details>

<details><summary><b>tanchico</b></summary>

```
<<< result-old
>>> result-new
Version changes:
[C.]  #01  abseil-cpp                   20260107.1 x2, 20260107.1-dev -> 20260107.1 x3, 20260107.1-dev
[U*]  #02  at-spi2-core                 2.60.4 x2, 2.60.4-dev -> 2.60.6 x2, 2.60.6-dev
[C.]  #03  audit                        4.1.4-lib, 4.2-lib x2 -> 4.1.4-lib, 4.2.1-lib x2
[U.]  #04  bcachefs-tools               1.38.8 -> 1.39.1
[U*]  #05  bluez                        5.86 x2, 5.86_fish-completions -> 5.87 x2, 5.87_fish-completions
[U*]  #06  cpupower                     6.18.43, 6.18.43_fish-completions -> 6.18.44, 6.18.44_fish-completions
[U.]  #07  discord                      1.0.152, 1.0.152-fish-completions -> 1.0.153, 1.0.153-bwrap, 1.0.153-fhsenv-profile, 1.0.153-fhsenv-rootfs, 1.0.153-fish-completions, 1.0.153-init
[U*]  #08  docker                       29.6.2 -> 29.7.2
[U.]  #09  docker-containerd            29.6.2 -> 29.7.2
[U.]  #10  docker-runc                  29.6.2 -> 29.7.2
[U.]  #11  docker-tini                  29.6.2 -> 29.7.2
[C.]  #12  ffmpeg                       4.4.8-data, 4.4.8-lib, 7.1.5-data, 7.1.5-lib, 8.1.2-data, 8.1.2-lib -> 4.4.8-data, 4.4.8-lib, 7.1.5-data, 7.1.5-lib, 9.0-data, 9.0-lib
[C.]  #13  ffmpeg-headless              8.1.2-data x2, 8.1.2-lib x2 -> 8.1.2-data, 8.1.2-lib, 9.0-data x2, 9.0-lib x2
[U.]  #14  fmt                          12.1.0 x2 -> 12.2.0 x2
[C.]  #15  gcc                          15.3.0-lib x3, 15.3.0-libgcc x3 -> 15.3.0, 15.3.0-lib x3, 15.3.0-libgcc x3, 15.3.0-man
[U.]  #16  gdk-pixbuf                   2.44.6 x2, 2.44.6-dev, 2.44.6-man -> 2.44.7 x2, 2.44.7-dev, 2.44.7-man
[C*]  #17  gdm                          <none>, 50.1 -> <none>, 50.2
[C.]  #18  gexiv2                       0.14.6, 0.16.0 -> 0.14.6, 0.16.2
[U*]  #19  gjs                          1.88.0 -> 1.88.1
[U*]  #20  glib                         2.88.1 x2, 2.88.1-bin x2, 2.88.1-dev, 2.88.1_fish-completions -> 2.88.3 x2, 2.88.3-bin x2, 2.88.3-dev, 2.88.3_fish-completions
[C.]  #21  glibmm                       2.66.8 x2, 2.88.0 -> 2.66.8 x2, 2.88.1
[U.]  #22  glycin-loaders               2.1.1 -> 2.1.5
[U*]  #23  glycin-thumbnailer           2.1.1 -> 2.1.5
[U*]  #24  gnome-control-center         50.3 -> 50.4
[C*]  #25  gnome-initial-setup          <none>, 50.0 -> <none>, 50.1
[U*]  #26  gnome-maps                   50.2 -> 50.3
[U*]  #27  gnome-remote-desktop         50.1, 50.1_fish-completions -> 50.2, 50.2_fish-completions
[U*]  #28  gnome-shell                  50.2, 50.2_fish-completions -> 50.4, 50.4_fish-completions
[U*]  #29  gnome-user-docs              50.2 -> 50.4
[U.]  #30  gnuplot                      6.0.4 -> 6.0.5
[U*]  #31  gvfs                         1.60.1 x2 -> 1.60.2 x2
[U.]  #32  hwdata                       0.409 x2 -> 0.410 x2
[U.]  #33  initrd-linux                 6.18.43 -> 6.18.44
[C*]  #34  iputils                      20250605 x2, 20250605-man -> 20250605, 20250605-man
[U.]  #35  lerc                         4.1.1 x2, 4.1.1-dev -> 4.2.0 x2, 4.2.0-dev
[C.]  #36  libXNVCtrl                   390.157, 595.84 -> 390.157, 595.91.07
[U.]  #37  libadwaita                   1.9.2 -> 1.9.3
[U.]  #38  libglycin                    2.1.1 -> 2.1.5
[U.]  #39  libglycin-gtk4               2.1.1 -> 2.1.5
[C.]  #40  libmpc                       1.4.1 -> 1.4.1 x2
[U.]  #41  libmpg123                    1.33.6 x2, 1.33.6-man -> 1.33.7 x2, 1.33.7-man
[C.]  #42  libnotify                    0.8.8 -> 0.8.8, 0.8.8-man
[U.]  #43  libraqm                      0.10.5 -> 0.11.0
[U.]  #44  libshumate                   1.6.2 -> 1.6.3
[U.]  #45  libssh                       0.12.1 x2 -> 0.12.2 x2
[U.]  #46  libva                        2.24.0 x2 -> 2.24.1 x2
[U.]  #47  libva-minimal                2.24.0 x2 -> 2.24.1 x2
[U.]  #48  libxfont_2                   2.0.8 -> 2.0.9
[U.]  #49  libxmp                       4.7.1 -> 4.7.2
[U.]  #50  linux                        6.18.43, 6.18.43-modules x2 -> 6.18.44, 6.18.44-modules x2
[U.]  #51  linux-firmware               20260622-zstd -> 20260810-zstd
[U.]  #52  llhttp                       9.4.2 -> 9.4.3
[U.]  #53  moby                         29.6.2 -> 29.7.2
[C.]  #54  mpfr                         4.2.2 -> 4.2.2 x2
[U.]  #55  mpg123                       1.33.6 x2 -> 1.33.7 x2
[U.]  #56  mutter                       50.2 -> 50.4
[U.]  #57  ncdu                         2.10.0, 2.10.0-fish-completions -> 2.11.0, 2.11.0-fish-completions
[U.]  #58  nerd-fonts-dejavu-sans-mono  3.4.0+2.37 -> 3.5.0+2.37
[U.]  #59  nerd-fonts-fira-code         3.4.0+6.2 -> 3.5.0+6.2
[U.]  #60  nerd-fonts-fira-mono         3.4.0+3.206 -> 3.5.0+3.206
[U.]  #61  nerd-fonts-hack              3.4.0+3.003 -> 3.5.0+3.003
[U.]  #62  nerd-fonts-iosevka           3.4.0+33.2.1 -> 3.5.0+34.8.0
[U.]  #63  nerd-fonts-jetbrains-mono    3.4.0+2.304 -> 3.5.0+2.304
[U.]  #64  nerd-fonts-liberation        3.4.0+2.1.5 -> 3.5.0+2.1.5
[U.]  #65  nerd-fonts-noto              3.4.0 -> 3.5.0
[U.]  #66  nerd-fonts-roboto-mono       3.4.0+3.0 -> 3.5.0+3.0
[U.]  #67  nerd-fonts-ubuntu-mono       3.4.0+0.80 -> 3.5.0+0.80
[U*]  #68  networkmanager               1.56.0 x2, 1.56.0-doc, 1.56.0-man -> 1.58.0 x2, 1.58.0-doc, 1.58.0-man
[U.]  #69  nix-direnv                   3.1.2 -> 3.2.0
[U.]  #70  nixos-system-tanchico        26.11.20260807.f13ff45 -> 26.11.20260813.0e251e2
[U.]  #71  noto-fonts                   2026.07.01 -> 2026.08.01
[C.]  #72  pangomm                      2.46.4, 2.56.1 -> 2.46.4, 2.56.2
[C*]  #73  perl                         5.42.0 x3, 5.42.0-env x3, 5.42.0-man -> 5.42.0 x3, 5.42.0-env x4, 5.42.0-man
[C*]  #74  plymouth                     26.134.222 x2, 26.134.222_fish-completions -> 26.134.222, 26.134.222_fish-completions
[C.]  #75  publicsuffix-list            0-unstable-2026-06-24 x3 -> 0-unstable-2026-06-24, 0-unstable-2026-07-25 x2
[C.]  #76  python3                      3.14.6 x3, 3.14.6-env x4 -> 3.14.6, 3.14.7 x2, 3.14.7-env x4
[U.]  #77  samba                        4.23.8 -> 4.23.10
[U*]  #78  shadow                       4.19.4, 4.19.4-man, 4.19.4-su -> 4.20.0, 4.20.0-man, 4.20.0-su
[C*]  #79  systemd                      <none>, 261.1 x3, 261.1-dev, 261.1-man -> <none>, 261.1 x2, 261.1-dev, 261.1-man
[U.]  #80  tpm2-tss                     4.1.3 x2 -> 4.2.0 x2
[U*]  #81  udisks                       2.11.1, 2.11.1-man -> 2.11.2, 2.11.2-man
[C.]  #82  unifont                      17.0.05 -> 17.0.05, 17.0.05-bin, 17.0.05-man
[U*]  #83  upower                       1.91.2, 1.91.2_fish-completions -> 1.91.3, 1.91.3_fish-completions
[U.]  #84  vulkan-headers               1.4.350.0 -> 1.4.357.0
[U.]  #85  vulkan-loader                1.4.350.0 x2, 1.4.350.0-dev -> 1.4.357.0 x2, 1.4.357.0-dev
[U.]  #86  vulkan-tools                 1.4.350.0 -> 1.4.357.0
[U.]  #87  wildmidi                     0.4.6 -> 0.5.0
[U.]  #88  zen-browser                  1.21.12b, 1.21.12b-fish-completions -> 1.21.14b, 1.21.14b-fish-completions
[U.]  #89  zen-browser-unwrapped        1.21.12b -> 1.21.14b
[U.]  #90  zxing-cpp                    3.0.2 -> 3.1.1
Added packages:
[A.]  #1  discord-unwrapped  1.0.153
[A.]  #2  gmp                6.3.0
[A.]  #3  isl                0.20
[A.]  #4  perl5.42.0-GD      2.86
Removed packages:
[R.]  #1  hm_.configautostartdiscord.desktop  <none>
[R.]  #2  libgnomekbd                         3.28.1
[R.]  #3  libxklavier                         5.4
[R.]  #4  tremor-unstable                     2018-03-16 x2
Closure size: 2717 -> 2728 (2591 paths added, 2580 paths removed, delta +11, disk usage +426.2MiB).
```

</details>

<details><summary><b>terangreal</b></summary>

```
<<< result-old
>>> result-new
Version changes:
[C.]  #001  abseil-cpp                        20260107.1 x3, 20260107.1-dev -> 20260107.1 x5, 20260107.1-dev
[C*]  #002  acl                               2.3.2 x2, 2.4.0 x3, 2.4.0-bin, 2.4.0-doc, 2.4.0-man -> 2.3.2 x2, 2.4.0 x4, 2.4.0-bin, 2.4.0-doc, 2.4.0-man
[C.]  #003  alsa-lib                          1.2.14, 1.2.16, 1.2.16.1 x2 -> 1.2.14, 1.2.16, 1.2.16.1 x3
[C.]  #004  alsa-topology-conf                1.2.5.1 x4 -> 1.2.5.1 x5
[C.]  #005  alsa-ucm-conf                     1.2.14, 1.2.16, 1.2.16.1 x2 -> 1.2.14, 1.2.16, 1.2.16.1 x3
[C.]  #006  aquamarine                        0.14.0, 0.14.0+date=2026-08-04_1a10fe2 -> 0.14.0, 0.14.0+date=2026-08-11_f3d1804
[C.]  #007  at-spi2-core                      2.56.2, 2.60.4, 2.60.4-dev -> 2.56.2, 2.60.4, 2.60.6, 2.60.6-dev
[C*]  #008  attr                              2.5.2 x2, 2.6.0 x3, 2.6.0-bin, 2.6.0-doc, 2.6.0-man -> 2.5.2 x2, 2.6.0 x4, 2.6.0-bin, 2.6.0-doc, 2.6.0-man
[C.]  #009  audit                             4.1.4-lib x2, 4.2-lib x2 -> 4.1.4-lib x2, 4.2-lib, 4.2.1-lib x2
[C.]  #010  avahi                             0.8 x4 -> 0.8 x5
[C.]  #011  bash                              5.3p3, 5.3p9, 5.3p15 x3 -> 5.3p3, 5.3p9, 5.3p15 x4
[C*]  #012  bash-interactive                  5.3p9, 5.3p15 x2, 5.3p15-doc, 5.3p15-info, 5.3p15-man -> 5.3p9, 5.3p15 x4, 5.3p15-doc, 5.3p15-info, 5.3p15-man x2
[U.]  #013  bcachefs-tools                    1.38.8 -> 1.39.1
[C.]  #014  binutils                          2.46, 2.46-lib -> 2.46 x2, 2.46-lib x2
[C.]  #015  binutils-wrapper                  2.46 -> 2.46 x2
[C.]  #016  bluez                             5.86 x3 -> 5.86 x2, 5.87 x2
[C.]  #017  brotli                            1.1.0-lib, 1.2.0, 1.2.0-dev, 1.2.0-lib x4 -> 1.1.0-lib, 1.2.0 x2, 1.2.0-dev x2, 1.2.0-lib x5
[C*]  #018  bzip2                             1.0.8 x5, 1.0.8-bin, 1.0.8-dev, 1.0.8-man -> 1.0.8 x6, 1.0.8-bin x2, 1.0.8-dev x2, 1.0.8-man
[C.]  #019  cairo                             1.18.4 x4, 1.18.4-dev -> 1.18.4 x5, 1.18.4-dev x2
[C.]  #020  cdparanoia-iii                    10.2 x3 -> 10.2 x4
[C.]  #021  cjson                             1.7.19 x3 -> 1.7.19 x4
[C.]  #022  coreutils                         9.7, 9.11 x4 -> 9.7, 9.11 x5
[U*]  #023  cpupower                          6.18.43, 6.18.43_fish-completions -> 6.18.44, 6.18.44_fish-completions
[C.]  #024  cracklib                          2.10.3 x3 -> 2.10.3 x4
[C*]  #025  cryptsetup                        2.8.6 x3, 2.8.6-bin, 2.8.6-man -> 2.8.6 x4, 2.8.6-bin, 2.8.6-man
[C.]  #026  cups                              2.4.12-lib, 2.4.19, 2.4.19-dev, 2.4.19-lib -> 2.4.12-lib, 2.4.19, 2.4.19-dev, 2.4.19-lib x2, 2.4.19-man
[C*]  #027  curl                              8.21.0 x4, 8.21.0-bin, 8.21.0-man -> 8.21.0 x5, 8.21.0-bin, 8.21.0-man
[C.]  #028  dav1d                             1.5.3 x3 -> 1.5.3 x4
[C.]  #029  db                                4.8.30 x4, 5.3.28 -> 4.8.30 x5, 5.3.28
[C*]  #030  dbus                              1, 1.14.10-lib, 1.16.2, 1.16.2-dev, 1.16.2-doc, 1.16.2-lib x3, 1.16.2-man -> 1, 1.14.10-lib, 1.16.2 x2, 1.16.2-dev x2, 1.16.2-doc, 1.16.2-lib x4, 1.16.2-man
[C*]  #031  dconf                             0.40.0-lib, 0.49.0, 0.49.0_fish-completions, 0.49.0-lib x3 -> 0.40.0-lib, 0.49.0, 0.49.0_fish-completions, 0.49.0-lib x4
[C.]  #032  dejavu-fonts-minimal              2.37 x4 -> 2.37 x5
[U.]  #033  discord                           1.0.152, 1.0.152-fish-completions -> 1.0.153, 1.0.153-bwrap, 1.0.153-fhsenv-profile, 1.0.153-fhsenv-rootfs, 1.0.153-fish-completions, 1.0.153-init
[C.]  #034  dns-root-data                     2025-04-14 x5 -> 2025-04-14 x6
[U*]  #035  docker                            29.6.2 -> 29.7.2
[U.]  #036  docker-containerd                 29.6.2 -> 29.7.2
[U.]  #037  docker-runc                       29.6.2 -> 29.7.2
[U.]  #038  docker-tini                       29.6.2 -> 29.7.2
[C.]  #039  double-conversion                 3.4.0, 3.4.0-dev -> 3.4.0 x2, 3.4.0-dev
[C.]  #040  duktape                           2.7.0 -> 2.7.0 x2
[C.]  #041  elfutils                          0.195 x3 -> 0.195 x4
[C.]  #042  ell                               0.83 x3 -> 0.83 x4
[U.]  #043  emacs-apheleia                    20260619.1935 -> 20260803.1927
[U.]  #044  emacs-cape                        20260519.1021 -> 20260804.2303
[U.]  #045  emacs-consult                     20260716.1105 -> 20260805.1130
[U.]  #046  emacs-consult-gh                  20260625.257 -> 20260801.1654
[U.]  #047  emacs-consult-gh-embark           20260623.1820 -> 20260801.1654
[U.]  #048  emacs-consult-gh-forge            20250906.1805 -> 20260801.1654
[C.]  #049  emacs-copilot-chat                20260401.836 x2 -> 20260401.836
[U.]  #050  emacs-corfu                       20260719.2241 -> 20260802.2028
[U.]  #051  emacs-diff-hl                     20260627.208 -> 20260723.238
[U.]  #052  emacs-dirvish                     20260716.729 -> 20260725.1520
[U.]  #053  emacs-eca                         20260716.1447 -> 20260805.1842
[U.]  #054  emacs-evil                        20260603.654 -> 20260728.1438
[U.]  #055  emacs-evil-collection             20260719.2207 -> 20260729.1654
[U.]  #056  emacs-forge                       20260701.1425 -> 20260731.2255
[U.]  #057  emacs-ghub                        20260701.1318 -> 20260731.2254
[U.]  #058  emacs-magit                       20260719.948 -> 20260808.323
[U.]  #059  emacs-magit-section               20260709.950 -> 20260731.2248
[U.]  #060  emacs-marginalia                  20260519.1044 -> 20260724.810
[U.]  #061  emacs-markdown-mode               20260425.954 -> 20260722.40
[U.]  #062  emacs-mu4e                        1.14.2 -> 1.14.3
[U.]  #063  emacs-nerd-icons                  20260710.1627 -> 20260805.635
[C.]  #064  emacs-org                         9.8.7, 9.8.8 -> 9.8.8
[U.]  #065  emacs-org-modern                  20260707.1016 x2 -> 20260722.1411
[C.]  #066  emacs-org-roam                    20260425.1623 x2 -> 20260425.1623
[U.]  #067  emacs-projectile                  20260720.549 -> 20260807.1455
[U.]  #068  emacs-s                           20220902.1511 -> 20260522.135
[U.]  #069  emacs-shell-maker                 20260713.844 -> 20260806.844
[U.]  #070  emacs-tramp                       2.8.2 -> 2.8.2.1
[U.]  #071  emacs-transient                   20260701.1255 -> 20260806.1211
[U.]  #072  emacs-vertico                     20260709.1303 -> 20260805.1129
[U.]  #073  emacs-with-editor                 20260701.1252 -> 20260731.2234
[C.]  #074  expand-response-params            <none> x2 -> <none> x4
[C.]  #075  expat                             2.7.1, 2.8.2 x4, 2.8.2-dev -> 2.7.1, 2.8.2 x5, 2.8.2-dev x2
[C.]  #076  fdk-aac                           2.0.3 x3 -> 2.0.3 x4
[C.]  #077  ffado                             2.4.9 x3 -> 2.4.9 x4
[C.]  #078  ffmpeg                            7.1.5-data, 7.1.5-lib, 8.1.2-data x2, 8.1.2-lib x2 -> 7.1.5-data, 7.1.5-lib, 8.1.2-data, 8.1.2-lib, 9.0-data, 9.0-lib
[C.]  #079  ffmpeg-headless                   8.1.2-data x3, 8.1.2-lib x3 -> 8.1.2-data x3, 8.1.2-lib x3, 9.0-data x2, 9.0-lib x2
[C.]  #080  fftw-double                       3.3.11 x3 -> 3.3.11 x4
[C.]  #081  fftw-single                       3.3.11 x3 -> 3.3.11 x4
[C.]  #082  file                              5.45, 5.48 x3 -> 5.45, 5.48 x4
[C.]  #083  flac                              1.5.0 x3 -> 1.5.0 x4
[C*]  #084  fontconfig                        2.16.2, 2.16.2-lib, 2.18.1, 2.18.1-lib, 2.18.2 x2, 2.18.2-bin, 2.18.2-dev, 2.18.2_fish-completions, 2.18.2-lib x2 -> 2.16.2, 2.16.2-lib, 2.18.1, 2.18.1-lib, 2.18.2 x3, 2.18.2-bin x2, 2.18.2-dev x2, 2.18.2_fish-completions, 2.18.2-lib x3
[C.]  #085  freetype                          2.13.3, 2.14.3 x3, 2.14.3-dev -> 2.13.3, 2.14.3 x4, 2.14.3-dev x2
[C.]  #086  fribidi                           1.0.16 x4, 1.0.16-dev -> 1.0.16 x5, 1.0.16-dev
[C*]  #087  gawk                              5.4.1, 5.4.1-info, 5.4.1-man -> 5.4.1 x2, 5.4.1-info, 5.4.1-man
[C.]  #088  gcc                               14.3.0-lib, 14.3.0-libgcc, 15.2.0-lib, 15.2.0-libgcc, 15.3.0 x2, 15.3.0-lib x4, 15.3.0-libgcc x4, 16.1.0-lib, 16.1.0-libgcc -> 14.3.0-lib, 14.3.0-libgcc, 15.2.0-lib, 15.2.0-libgcc, 15.3.0, 15.3.0-lib x4, 15.3.0-libgcc x4, 15.3.0-man, 16.2.0, 16.2.0-lib x2, 16.2.0-libgcc x2
[C.]  #089  gdbm                              1.26-lib x4 -> 1.26-lib x5
[C.]  #090  gdk-pixbuf                        2.42.12, 2.44.6 x2, 2.44.6-dev -> 2.42.12, 2.44.6 x2, 2.44.7, 2.44.7-dev, 2.44.7-man
[C.]  #091  gettext                           1.0 x3 -> 1.0 x4
[C.]  #092  giflib                            5.2.2, 6.1.3 x3 -> 5.2.2, 6.1.3 x4
[U.]  #093  gjs                               1.88.0 -> 1.88.1
[C.]  #094  glib                              2.84.4, 2.88.1 x3, 2.88.1-bin x2, 2.88.1-dev, 2.88.1-fish-completions -> 2.84.4, 2.88.1 x2, 2.88.1-bin x2, 2.88.1-dev, 2.88.3 x2, 2.88.3-bin, 2.88.3-dev, 2.88.3-fish-completions
[C*]  #095  glibc                             2.40-66, 2.40-66-getent, 2.42-67 x4, 2.42-67-bin x2, 2.42-67-dev, 2.42-67-getent -> 2.40-66, 2.40-66-getent, 2.42-67 x5, 2.42-67-bin x3, 2.42-67-dev x2, 2.42-67-getent
[C.]  #096  glibc-iconv                       2.42 -> 2.42 x2
[C*]  #097  glibc-locales                     2.42-67 -> 2.42-67 x2
[C.]  #098  glibmm                            2.66.8 x3, 2.88.0 -> 2.66.8 x4, 2.88.1
[C.]  #099  glslang                           16.3.0 -> 16.3.0, 16.4.0
[C.]  #100  gmp-with-cxx                      6.3.0 x9, 6.3.0-dev -> 6.3.0 x11, 6.3.0-dev
[C*]  #101  gnugrep                           3.12 x3, 3.12_fish-completions, 3.12-info -> 3.12 x4, 3.12_fish-completions, 3.12-info
[C.]  #102  gnum4                             1.4.21 x3 -> 1.4.21 x4
[U.]  #103  gnuplot                           6.0.4 -> 6.0.5
[C*]  #104  gnused                            4.10 x3, 4.10_fish-completions, 4.10-info -> 4.10 x4, 4.10_fish-completions, 4.10-info
[C.]  #105  gnutls                            3.8.10, 3.8.13 x3 -> 3.8.10, 3.8.13 x4
[C.]  #106  gobject-introspection             1.84.0, 1.86.0, 1.86.0-dev -> 1.84.0, 1.86.0 x2, 1.86.0-dev
[C.]  #107  graphene                          1.10.8 x3 -> 1.10.8 x4
[C.]  #108  graphite2                         1.3.14, 1.3.15 x3, 1.3.15-dev -> 1.3.14, 1.3.15 x4, 1.3.15-dev x2
[C.]  #109  grim                              1.5.0 -> 1.5.0 x2
[U.]  #110  grpc                              1.82.1 -> 1.83.0
[C.]  #111  gsettings-desktop-schemas         48.0, 50.1 -> 48.0, 50.1 x2
[C.]  #112  gst-plugins-base                  1.28.4, 1.28.5 x2 -> 1.28.4, 1.28.5 x3
[C.]  #113  gstreamer                         1.28.4, 1.28.5 x2 -> 1.28.4, 1.28.5 x3
[C.]  #114  gtest                             1.17.0 x3, 1.17.0-dev -> 1.17.0 x4, 1.17.0-dev
[C.]  #115  gtk+3                             3.24.49, 3.24.52, 3.24.52-dev -> 3.24.49, 3.24.52 x2, 3.24.52-dev
[U*]  #116  gvfs                              1.60.1 x2 -> 1.60.2 x2
[C.]  #117  harfbuzz                          11.2.1, 13.2.1 x3, 13.2.1-dev -> 11.2.1, 13.2.1 x4, 13.2.1-dev x2
[C.]  #118  hostname-debian                   3.25, 3.25-man -> 3.25 x2, 3.25-man x2
[C*]  #119  hostname-hostname-debian          3.25, 3.25_fish-completions -> 3.25 x2, 3.25_fish-completions
[C.]  #120  hwdata                            0.408, 0.409 x2 -> 0.408, 0.409, 0.410 x2
[C.]  #121  hyprcursor                        0.1.13+date=2026-04-18_3943590-lib, 0.1.13-lib -> 0.1.13+date=2026-08-11_e4ed7c0-lib, 0.1.13-lib
[C.]  #122  hyprgraphics                      0.5.1, 0.5.1+date=2026-08-04_8699c38 -> 0.5.1, 0.5.1+date=2026-08-11_7c895c4, 0.5.1+date=2026-08-11_7c895c4-dev
[U.]  #123  hypridle                          0.1.8+date=2026-07-26_e5c01af -> 0.1.8+date=2026-08-11_aa958ed
[C*]  #124  hyprland                          0.56.0+date=2026-08-08_5dee44a, 0.56.0+date=2026-08-08_5dee44a-man, 0.56.1 -> 0.56.0+date=2026-08-15_a1b9dc0, 0.56.0+date=2026-08-15_a1b9dc0-man, 0.56.2
[U.]  #125  hyprland-guiutils                 0.2.2+date=2026-07-20_a16ad89 -> 0.2.2+date=2026-08-11_4c30cf3
[C.]  #126  hyprlang                          0.6.8, 0.6.8+date=2026-04-27_0901175, 0.6.8+date=2026-04-27_0901175-dev -> 0.6.8, 0.6.8+date=2026-08-11_9508458, 0.6.8+date=2026-08-11_9508458-dev
[U.]  #127  hyprpaper                         0.8.4+date=2026-05-25_c011bd2 -> 0.8.4+date=2026-08-13_39029bd
[C.]  #128  hyprtoolkit                       0.5.3+date=2026-03-02_9af245a, 0.5.4 -> 0.5.4, 0.5.4+date=2026-08-11_be487c4
[C.]  #129  hyprutils                         0.14.0, 0.14.0+date=2026-08-04_5a7b8cf, 0.14.0+date=2026-08-04_5a7b8cf-dev -> 0.14.0 x2, 0.14.0+date=2026-08-11_c157fe1, 0.14.0+date=2026-08-11_c157fe1-dev
[C.]  #130  hyprwire                          0.3.1, 0.3.1+date=2026-07-19_7d935bb -> 0.3.1, 0.3.1+date=2026-08-11_4ce7cd6
[C.]  #131  icu4c                             76.1 x2, 77.1, 78.3 x2, 78.3-dev -> 76.1 x2, 77.1, 78.3 x3, 78.3-dev
[C.]  #132  iniparser                         4.2.6 -> 4.2.6 x2
[U.]  #133  initrd-linux                      6.18.43 -> 6.18.44
[C.]  #134  iso-codes                         4.18.0, 4.20.1 x3 -> 4.18.0, 4.20.1 x4
[C.]  #135  jq                                1.8.2, 1.8.2-bin, 1.8.2-fish-completions, 1.8.2-man -> 1.8.2 x2, 1.8.2-bin x2, 1.8.2-fish-completions, 1.8.2-man
[C.]  #136  json-c                            0.18 x3 -> 0.18 x4
[C.]  #137  json-glib                         1.10.6, 1.10.8 -> 1.10.6, 1.10.8 x2
[C*]  #138  kbd                               2.8.0-unstable-2025-08-12, 2.9.0 x3, 2.9.0-man -> 2.8.0-unstable-2025-08-12, 2.9.0 x4, 2.9.0-man
[C*]  #139  kexec-tools                       2.0.31, 2.0.32 x3, 2.0.32_fish-completions -> 2.0.31, 2.0.32 x4, 2.0.32_fish-completions
[C.]  #140  keyutils                          1.6.3-lib x4 -> 1.6.3-lib x5
[C*]  #141  kmod                              31 x4, 31-lib x4, 31-man -> 31 x5, 31-lib x5, 31-man
[C.]  #142  krb5                              1.22.2-lib x4 -> 1.22.2-lib x5
[C.]  #143  lame                              3.100-lib x3 -> 3.100-lib x4
[C.]  #144  lcms2                             2.17, 2.19.1 x3 -> 2.17, 2.19.1 x4
[C.]  #145  ldacbt                            2.0.72 x3 -> 2.0.72 x4
[C.]  #146  lerc                              4.0.0, 4.1.0, 4.1.1 x2, 4.1.1-dev -> 4.0.0, 4.1.0, 4.1.1, 4.2.0 x2, 4.2.0-dev

_… diff truncated (461 lines total); see the `closure-diff-terangreal` artifact for the full output._

</details>

<details><summary><b>tuathaan</b></summary>

```
<<< result-old
>>> result-new
Version changes:
[C.]  #001  abseil-cpp                        20260107.1 x3, 20260107.1-dev -> 20260107.1 x5, 20260107.1-dev
[C*]  #002  acl                               2.3.2 x2, 2.4.0 x3, 2.4.0-bin, 2.4.0-doc, 2.4.0-man -> 2.3.2 x2, 2.4.0 x4, 2.4.0-bin, 2.4.0-doc, 2.4.0-man
[C.]  #003  alsa-lib                          1.2.14, 1.2.16, 1.2.16.1 x2 -> 1.2.14, 1.2.16, 1.2.16.1 x3
[C.]  #004  alsa-topology-conf                1.2.5.1 x4 -> 1.2.5.1 x5
[C.]  #005  alsa-ucm-conf                     1.2.14, 1.2.16, 1.2.16.1 x2 -> 1.2.14, 1.2.16, 1.2.16.1 x3
[C.]  #006  aquamarine                        0.14.0, 0.14.0+date=2026-08-04_1a10fe2 -> 0.14.0, 0.14.0+date=2026-08-11_f3d1804
[C.]  #007  at-spi2-core                      2.56.2, 2.60.4, 2.60.4-dev -> 2.56.2, 2.60.4, 2.60.6, 2.60.6-dev
[C*]  #008  attr                              2.5.2 x2, 2.6.0 x3, 2.6.0-bin, 2.6.0-doc, 2.6.0-man -> 2.5.2 x2, 2.6.0 x4, 2.6.0-bin, 2.6.0-doc, 2.6.0-man
[C.]  #009  audit                             4.1.4-lib x2, 4.2-lib x2 -> 4.1.4-lib x2, 4.2-lib, 4.2.1-lib x2
[C.]  #010  avahi                             0.8 x4 -> 0.8 x5
[C.]  #011  bash                              5.3p3, 5.3p9, 5.3p15 x3 -> 5.3p3, 5.3p9, 5.3p15 x4
[C*]  #012  bash-interactive                  5.3p9, 5.3p15 x2, 5.3p15-doc, 5.3p15-info, 5.3p15-man -> 5.3p9, 5.3p15 x4, 5.3p15-doc, 5.3p15-info, 5.3p15-man x2
[U.]  #013  bcachefs-tools                    1.38.8 -> 1.39.1
[C.]  #014  binutils                          2.46, 2.46-lib -> 2.46 x2, 2.46-lib x2
[C.]  #015  binutils-wrapper                  2.46 -> 2.46 x2
[C*]  #016  bluez                             5.86 x3, 5.86_fish-completions -> 5.86 x2, 5.87 x2, 5.87_fish-completions
[C.]  #017  brotli                            1.1.0-lib, 1.2.0, 1.2.0-dev, 1.2.0-lib x4 -> 1.1.0-lib, 1.2.0 x2, 1.2.0-dev x2, 1.2.0-lib x5
[C*]  #018  bzip2                             1.0.8 x5, 1.0.8-bin, 1.0.8-dev, 1.0.8-man -> 1.0.8 x6, 1.0.8-bin x2, 1.0.8-dev x2, 1.0.8-man
[C.]  #019  cairo                             1.18.4 x4, 1.18.4-dev -> 1.18.4 x5, 1.18.4-dev x2
[C.]  #020  cdparanoia-iii                    10.2 x3 -> 10.2 x4
[C.]  #021  cjson                             1.7.19 x3 -> 1.7.19 x4
[C.]  #022  coreutils                         9.7, 9.11 x4 -> 9.7, 9.11 x5
[U*]  #023  cpupower                          6.18.43, 6.18.43_fish-completions -> 6.18.44, 6.18.44_fish-completions
[C.]  #024  cracklib                          2.10.3 x3 -> 2.10.3 x4
[C*]  #025  cryptsetup                        2.8.6 x3, 2.8.6-bin, 2.8.6-man -> 2.8.6 x4, 2.8.6-bin, 2.8.6-man
[C.]  #026  cups                              2.4.12-lib, 2.4.19, 2.4.19-dev, 2.4.19-lib -> 2.4.12-lib, 2.4.19, 2.4.19-dev, 2.4.19-lib x2, 2.4.19-man
[C*]  #027  curl                              8.21.0 x4, 8.21.0-bin, 8.21.0-man -> 8.21.0 x5, 8.21.0-bin, 8.21.0-man
[C.]  #028  dav1d                             1.5.3 x3 -> 1.5.3 x4
[C.]  #029  db                                4.8.30 x4, 5.3.28 -> 4.8.30 x5, 5.3.28
[C*]  #030  dbus                              1, 1.14.10-lib, 1.16.2, 1.16.2-dev, 1.16.2-doc, 1.16.2-lib x3, 1.16.2-man -> 1, 1.14.10-lib, 1.16.2 x2, 1.16.2-dev x2, 1.16.2-doc, 1.16.2-lib x4, 1.16.2-man
[C*]  #031  dconf                             0.40.0-lib, 0.49.0, 0.49.0_fish-completions, 0.49.0-lib x3 -> 0.40.0-lib, 0.49.0, 0.49.0_fish-completions, 0.49.0-lib x4
[C.]  #032  dejavu-fonts-minimal              2.37 x4 -> 2.37 x5
[U.]  #033  discord                           1.0.152, 1.0.152-fish-completions -> 1.0.153, 1.0.153-bwrap, 1.0.153-fhsenv-profile, 1.0.153-fhsenv-rootfs, 1.0.153-fish-completions, 1.0.153-init
[C.]  #034  dns-root-data                     2025-04-14 x5 -> 2025-04-14 x6
[U*]  #035  docker                            29.6.2 -> 29.7.2
[U.]  #036  docker-containerd                 29.6.2 -> 29.7.2
[U.]  #037  docker-runc                       29.6.2 -> 29.7.2
[U.]  #038  docker-tini                       29.6.2 -> 29.7.2
[C.]  #039  double-conversion                 3.4.0, 3.4.0-dev -> 3.4.0 x2, 3.4.0-dev
[C.]  #040  duktape                           2.7.0 -> 2.7.0 x2
[C.]  #041  elfutils                          0.195 x3 -> 0.195 x4
[C.]  #042  ell                               0.83 x3 -> 0.83 x4
[U.]  #043  emacs-apheleia                    20260619.1935 -> 20260803.1927
[U.]  #044  emacs-cape                        20260519.1021 -> 20260804.2303
[U.]  #045  emacs-consult                     20260716.1105 -> 20260805.1130
[U.]  #046  emacs-consult-gh                  20260625.257 -> 20260801.1654
[U.]  #047  emacs-consult-gh-embark           20260623.1820 -> 20260801.1654
[U.]  #048  emacs-consult-gh-forge            20250906.1805 -> 20260801.1654
[C.]  #049  emacs-copilot-chat                20260401.836 x2 -> 20260401.836
[U.]  #050  emacs-corfu                       20260719.2241 -> 20260802.2028
[U.]  #051  emacs-diff-hl                     20260627.208 -> 20260723.238
[U.]  #052  emacs-dirvish                     20260716.729 -> 20260725.1520
[U.]  #053  emacs-eca                         20260716.1447 -> 20260805.1842
[U.]  #054  emacs-evil                        20260603.654 -> 20260728.1438
[U.]  #055  emacs-evil-collection             20260719.2207 -> 20260729.1654
[U.]  #056  emacs-forge                       20260701.1425 -> 20260731.2255
[U.]  #057  emacs-ghub                        20260701.1318 -> 20260731.2254
[U.]  #058  emacs-magit                       20260719.948 -> 20260808.323
[U.]  #059  emacs-magit-section               20260709.950 -> 20260731.2248
[U.]  #060  emacs-marginalia                  20260519.1044 -> 20260724.810
[U.]  #061  emacs-markdown-mode               20260425.954 -> 20260722.40
[U.]  #062  emacs-mu4e                        1.14.2 -> 1.14.3
[U.]  #063  emacs-nerd-icons                  20260710.1627 -> 20260805.635
[C.]  #064  emacs-org                         9.8.7, 9.8.8 -> 9.8.8
[U.]  #065  emacs-org-modern                  20260707.1016 x2 -> 20260722.1411
[C.]  #066  emacs-org-roam                    20260425.1623 x2 -> 20260425.1623
[U.]  #067  emacs-projectile                  20260720.549 -> 20260807.1455
[U.]  #068  emacs-s                           20220902.1511 -> 20260522.135
[U.]  #069  emacs-shell-maker                 20260713.844 -> 20260806.844
[U.]  #070  emacs-tramp                       2.8.2 -> 2.8.2.1
[U.]  #071  emacs-transient                   20260701.1255 -> 20260806.1211
[U.]  #072  emacs-vertico                     20260709.1303 -> 20260805.1129
[U.]  #073  emacs-with-editor                 20260701.1252 -> 20260731.2234
[C.]  #074  expand-response-params            <none> x2 -> <none> x4
[C.]  #075  expat                             2.7.1, 2.8.2 x4, 2.8.2-dev -> 2.7.1, 2.8.2 x5, 2.8.2-dev x2
[C.]  #076  fdk-aac                           2.0.3 x3 -> 2.0.3 x4
[C.]  #077  ffado                             2.4.9 x3 -> 2.4.9 x4
[C.]  #078  ffmpeg                            7.1.5-data, 7.1.5-lib, 8.1.2-data x2, 8.1.2-lib x2 -> 7.1.5-data, 7.1.5-lib, 8.1.2-data, 8.1.2-lib, 9.0-data, 9.0-lib
[C.]  #079  ffmpeg-headless                   8.1.2-data x3, 8.1.2-lib x3 -> 8.1.2-data x3, 8.1.2-lib x3, 9.0-data x2, 9.0-lib x2
[C.]  #080  fftw-double                       3.3.11 x3 -> 3.3.11 x4
[C.]  #081  fftw-single                       3.3.11 x3 -> 3.3.11 x4
[C.]  #082  file                              5.45, 5.48 x3 -> 5.45, 5.48 x4
[C.]  #083  flac                              1.5.0 x3 -> 1.5.0 x4
[C*]  #084  fontconfig                        2.16.2, 2.16.2-lib, 2.18.1, 2.18.1-lib, 2.18.2 x2, 2.18.2-bin, 2.18.2-dev, 2.18.2_fish-completions, 2.18.2-lib x2 -> 2.16.2, 2.16.2-lib, 2.18.1, 2.18.1-lib, 2.18.2 x3, 2.18.2-bin x2, 2.18.2-dev x2, 2.18.2_fish-completions, 2.18.2-lib x3
[C.]  #085  freetype                          2.13.3, 2.14.3 x3, 2.14.3-dev -> 2.13.3, 2.14.3 x4, 2.14.3-dev x2
[C.]  #086  fribidi                           1.0.16 x4, 1.0.16-dev -> 1.0.16 x5, 1.0.16-dev
[C*]  #087  gawk                              5.4.1, 5.4.1-info, 5.4.1-man -> 5.4.1 x2, 5.4.1-info, 5.4.1-man
[C.]  #088  gcc                               14.3.0-lib, 14.3.0-libgcc, 15.2.0-lib, 15.2.0-libgcc, 15.3.0 x2, 15.3.0-lib x4, 15.3.0-libgcc x4, 16.1.0-lib, 16.1.0-libgcc -> 14.3.0-lib, 14.3.0-libgcc, 15.2.0-lib, 15.2.0-libgcc, 15.3.0, 15.3.0-lib x4, 15.3.0-libgcc x4, 15.3.0-man, 16.2.0, 16.2.0-lib x2, 16.2.0-libgcc x2
[C.]  #089  gdbm                              1.26-lib x4 -> 1.26-lib x5
[C.]  #090  gdk-pixbuf                        2.42.12, 2.44.6 x2, 2.44.6-dev -> 2.42.12, 2.44.6 x2, 2.44.7, 2.44.7-dev, 2.44.7-man
[C.]  #091  gettext                           1.0 x3 -> 1.0 x4
[C.]  #092  giflib                            5.2.2, 6.1.3 x3 -> 5.2.2, 6.1.3 x4
[U.]  #093  gjs                               1.88.0 -> 1.88.1
[C.]  #094  glib                              2.84.4, 2.88.1 x3, 2.88.1-bin x2, 2.88.1-dev, 2.88.1-fish-completions -> 2.84.4, 2.88.1 x2, 2.88.1-bin x2, 2.88.1-dev, 2.88.3 x2, 2.88.3-bin, 2.88.3-dev, 2.88.3-fish-completions
[C*]  #095  glibc                             2.40-66, 2.40-66-getent, 2.42-67 x4, 2.42-67-bin x2, 2.42-67-dev, 2.42-67-getent -> 2.40-66, 2.40-66-getent, 2.42-67 x5, 2.42-67-bin x3, 2.42-67-dev x2, 2.42-67-getent
[C.]  #096  glibc-iconv                       2.42 -> 2.42 x2
[C*]  #097  glibc-locales                     2.42-67 -> 2.42-67 x2
[C.]  #098  glibmm                            2.66.8 x3, 2.88.0 -> 2.66.8 x4, 2.88.1
[C.]  #099  glslang                           16.3.0 -> 16.3.0, 16.4.0
[C.]  #100  gmp-with-cxx                      6.3.0 x9, 6.3.0-dev -> 6.3.0 x11, 6.3.0-dev
[C*]  #101  gnugrep                           3.12 x3, 3.12_fish-completions, 3.12-info -> 3.12 x4, 3.12_fish-completions, 3.12-info
[C.]  #102  gnum4                             1.4.21 x3 -> 1.4.21 x4
[U.]  #103  gnuplot                           6.0.4 -> 6.0.5
[C*]  #104  gnused                            4.10 x3, 4.10_fish-completions, 4.10-info -> 4.10 x4, 4.10_fish-completions, 4.10-info
[C.]  #105  gnutls                            3.8.10, 3.8.13 x3 -> 3.8.10, 3.8.13 x4
[C.]  #106  gobject-introspection             1.84.0, 1.86.0, 1.86.0-dev -> 1.84.0, 1.86.0 x2, 1.86.0-dev
[C.]  #107  graphene                          1.10.8 x3 -> 1.10.8 x4
[C.]  #108  graphite2                         1.3.14, 1.3.15 x3, 1.3.15-dev -> 1.3.14, 1.3.15 x4, 1.3.15-dev x2
[C.]  #109  grim                              1.5.0 -> 1.5.0 x2
[U.]  #110  grpc                              1.82.1 -> 1.83.0
[C.]  #111  gsettings-desktop-schemas         48.0, 50.1 -> 48.0, 50.1 x2
[C.]  #112  gst-plugins-base                  1.28.4, 1.28.5 x2 -> 1.28.4, 1.28.5 x3
[C.]  #113  gstreamer                         1.28.4, 1.28.5 x2 -> 1.28.4, 1.28.5 x3
[C.]  #114  gtest                             1.17.0 x3, 1.17.0-dev -> 1.17.0 x4, 1.17.0-dev
[C.]  #115  gtk+3                             3.24.49, 3.24.52, 3.24.52-dev -> 3.24.49, 3.24.52 x2, 3.24.52-dev
[U*]  #116  gvfs                              1.60.1 x2 -> 1.60.2 x2
[C.]  #117  harfbuzz                          11.2.1, 13.2.1 x3, 13.2.1-dev -> 11.2.1, 13.2.1 x4, 13.2.1-dev x2
[C.]  #118  hostname-debian                   3.25, 3.25-man -> 3.25 x2, 3.25-man x2
[C*]  #119  hostname-hostname-debian          3.25, 3.25_fish-completions -> 3.25 x2, 3.25_fish-completions
[C.]  #120  hwdata                            0.408, 0.409 x2 -> 0.408, 0.409, 0.410 x2
[C.]  #121  hyprcursor                        0.1.13+date=2026-04-18_3943590-lib, 0.1.13-lib -> 0.1.13+date=2026-08-11_e4ed7c0-lib, 0.1.13-lib
[C.]  #122  hyprgraphics                      0.5.1, 0.5.1+date=2026-08-04_8699c38 -> 0.5.1, 0.5.1+date=2026-08-11_7c895c4, 0.5.1+date=2026-08-11_7c895c4-dev
[U.]  #123  hypridle                          0.1.8+date=2026-07-26_e5c01af -> 0.1.8+date=2026-08-11_aa958ed
[C*]  #124  hyprland                          0.56.0+date=2026-08-08_5dee44a, 0.56.0+date=2026-08-08_5dee44a-man, 0.56.1 -> 0.56.0+date=2026-08-15_a1b9dc0, 0.56.0+date=2026-08-15_a1b9dc0-man, 0.56.2
[U.]  #125  hyprland-guiutils                 0.2.2+date=2026-07-20_a16ad89 -> 0.2.2+date=2026-08-11_4c30cf3
[C.]  #126  hyprlang                          0.6.8, 0.6.8+date=2026-04-27_0901175, 0.6.8+date=2026-04-27_0901175-dev -> 0.6.8, 0.6.8+date=2026-08-11_9508458, 0.6.8+date=2026-08-11_9508458-dev
[U.]  #127  hyprpaper                         0.8.4+date=2026-05-25_c011bd2 -> 0.8.4+date=2026-08-13_39029bd
[C.]  #128  hyprtoolkit                       0.5.3+date=2026-03-02_9af245a, 0.5.4 -> 0.5.4, 0.5.4+date=2026-08-11_be487c4
[C.]  #129  hyprutils                         0.14.0, 0.14.0+date=2026-08-04_5a7b8cf, 0.14.0+date=2026-08-04_5a7b8cf-dev -> 0.14.0 x2, 0.14.0+date=2026-08-11_c157fe1, 0.14.0+date=2026-08-11_c157fe1-dev
[C.]  #130  hyprwire                          0.3.1, 0.3.1+date=2026-07-19_7d935bb -> 0.3.1, 0.3.1+date=2026-08-11_4ce7cd6
[C.]  #131  icu4c                             76.1 x2, 77.1, 78.3 x2, 78.3-dev -> 76.1 x2, 77.1, 78.3 x3, 78.3-dev
[C.]  #132  iniparser                         4.2.6 -> 4.2.6 x2
[U.]  #133  initrd-linux                      6.18.43 -> 6.18.44
[C.]  #134  iso-codes                         4.18.0, 4.20.1 x3 -> 4.18.0, 4.20.1 x4
[C.]  #135  jq                                1.8.2, 1.8.2-bin, 1.8.2-fish-completions, 1.8.2-man -> 1.8.2 x2, 1.8.2-bin x2, 1.8.2-fish-completions, 1.8.2-man
[C.]  #136  json-c                            0.18 x3 -> 0.18 x4
[C.]  #137  json-glib                         1.10.6, 1.10.8 -> 1.10.6, 1.10.8 x2
[C*]  #138  kbd                               2.8.0-unstable-2025-08-12, 2.9.0 x3, 2.9.0-man -> 2.8.0-unstable-2025-08-12, 2.9.0 x4, 2.9.0-man
[C*]  #139  kexec-tools                       2.0.31, 2.0.32 x3, 2.0.32_fish-completions -> 2.0.31, 2.0.32 x4, 2.0.32_fish-completions
[C.]  #140  keyutils                          1.6.3-lib x4 -> 1.6.3-lib x5
[C*]  #141  kmod                              31 x4, 31-lib x4, 31-man -> 31 x5, 31-lib x5, 31-man
[C.]  #142  krb5                              1.22.2-lib x4 -> 1.22.2-lib x5
[C.]  #143  lame                              3.100-lib x3 -> 3.100-lib x4
[C.]  #144  lcms2                             2.17, 2.19.1 x3 -> 2.17, 2.19.1 x4
[C.]  #145  ldacbt                            2.0.72 x3 -> 2.0.72 x4
[C.]  #146  lerc                              4.0.0, 4.1.0, 4.1.1 x2, 4.1.1-dev -> 4.0.0, 4.1.0, 4.1.1, 4.2.0 x2, 4.2.0-dev

_… diff truncated (460 lines total); see the `closure-diff-tuathaan` artifact for the full output._

</details>

