### PR TITLE
Auto update 2026-08-23

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786464219,
-        "narHash": "sha256-WKqWL8r7CyTDYueTr2ffJ9ya50dellv6IR1JX5PghDY=",
+        "lastModified": 1787400831,
+        "narHash": "sha256-H3MEkFDZf+UH+QrVgW8TdKrssPFltF8fBg/rh0J1zIc=",
         "owner": "hyprwm",
         "repo": "aquamarine",
-        "rev": "f3d1804205e8158c15595cdda1b566f93349ffae",
+        "rev": "7ce889cb78b97979b83a4648509fc3ef405c3286",
         "type": "github"
       },
       "original": {
@@ -111,11 +111,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787421598,
-        "narHash": "sha256-zO2nvYmdgzYSJIpEfqINvLJEyaH8fqOKA99+zm1LkGA=",
+        "lastModified": 1787472945,
+        "narHash": "sha256-/1AP8y0Kr0CW9/CLDCKs3RFITJwOEWQCGNrBTLFOas8=",
         "owner": "Gako358",
         "repo": "emacs-flake",
-        "rev": "c86b877b619e455eea763c46ce285f843cf4f089",
+        "rev": "ef88db4d9fc29cbfdaa400995e8fe4b5fc9943a6",
         "type": "github"
       },
       "original": {
@@ -372,11 +372,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1786717298,
-        "narHash": "sha256-asdPlqtM0AweQ5YNLad6eY4tSYW55YNr1uyayf7mOMQ=",
+        "lastModified": 1787144466,
+        "narHash": "sha256-HHfv2/HkNSKbbSyU9iD/g8lbP6r4tl33sSw1W4rXCk0=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "2dda192987ab6815e44df0130f03d6c907b79134",
+        "rev": "0471accf8d0a8210b31d947497d179ecc99e0021",
         "type": "github"
       },
       "original": {
@@ -392,11 +392,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786826571,
-        "narHash": "sha256-nNqmXIFmESRnU91KARtiekSox0+o+E3AS0d1TuUQ/9o=",
+        "lastModified": 1787379775,
+        "narHash": "sha256-XL2qfqmocfsvuEGyomZg4nOZfkuSe8vZtrOX99I+b6I=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c8058ecc1329a71a3c99c4d0353dba4009a66152",
+        "rev": "ec1a8fdf74ed3f276148ee106299a2ba0e65d51f",
         "type": "github"
       },
       "original": {
@@ -536,11 +536,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1786807079,
-        "narHash": "sha256-8Pyv0ORHhzsUElqqESECxSr3xr+SFibDZTizTF48k9I=",
+        "lastModified": 1787436444,
+        "narHash": "sha256-iLWbH4BQ7x/x7oGGwlj/OarJjrmuisOFDZgc2rar9tw=",
         "owner": "hyprwm",
         "repo": "hyprland",
-        "rev": "a1b9dc0e8cdfeca3e2d96a24b10b3d85e14fbd50",
+        "rev": "45a79e5e84136025a5da1de34c9c65fe00cb813e",
         "type": "github"
       },
       "original": {
@@ -557,11 +557,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782811467,
-        "narHash": "sha256-JP0D8r8o9+jnYk0/B5O722La+oZeC5iNQ3lonKFTmbQ=",
+        "lastModified": 1787301232,
+        "narHash": "sha256-qSzrIIqQUtEVeVZxQLj/L4p7+xKBEtPhgMTzFW2c6P8=",
         "owner": "hyprwm",
         "repo": "contrib",
-        "rev": "3dcbce715ae8b93107fa8632db15bf976862a573",
+        "rev": "57baf317e5196a8286b80976771ef55febad8660",
         "type": "github"
       },
       "original": {
@@ -633,11 +633,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786227627,
-        "narHash": "sha256-bc4jNVx0agB40xwxJ0r7hAAk5tk5Lm0uKtwP5rNyvZQ=",
+        "lastModified": 1787071735,
+        "narHash": "sha256-1DDAvYcJ7q1x4JdhoXU+PTQWxAUcv53gSNmmi9pBVuU=",
         "owner": "hyprwm",
         "repo": "hyprland-plugins",
-        "rev": "faf5ef1bd5916051ed3252463697dd2ae479f629",
+        "rev": "83ce4b2a70d3c1a6ed8dc6db7f1fac17db2215b1",
         "type": "github"
       },
       "original": {
@@ -884,11 +884,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786464080,
-        "narHash": "sha256-W1hxvumEM57yV+QwsZ4QdAHEqOkr7e4S8VAkLX60qDE=",
+        "lastModified": 1786903207,
+        "narHash": "sha256-QTwMqLLONRhv9iz6CVeuX6BqQNQCIqI8hL/cPYlR/24=",
         "owner": "hyprwm",
         "repo": "hyprutils",
-        "rev": "c157fe1e3092b980cc69315a6631f89aff09dcce",
+        "rev": "6cf50415e06dc6bd9f1252f1b745eac6b4a1cc39",
         "type": "github"
       },
       "original": {
@@ -1063,11 +1063,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786473774,
-        "narHash": "sha256-BDedo9F6NJOw+Ii+luFZh0MVIheKqiYgiVzMWc6WB24=",
+        "lastModified": 1786958661,
+        "narHash": "sha256-DAH84NNJezuk7M4WfAZtLQzJnofpXJFZFVoTPgCyUC0=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "4a773989235545c56f408d168cb63bc41d468832",
+        "rev": "b1b7d87faa06649f7c72666107bac2c6e6459c23",
         "type": "github"
       },
       "original": {
@@ -1262,11 +1262,11 @@
     },
     "nixpkgs_10": {
       "locked": {
-        "lastModified": 1786599213,
-        "narHash": "sha256-yNJd40f11EzXBjSByCB7IPpeFFAdeoSKKM67dGkfFoU=",
+        "lastModified": 1787360063,
+        "narHash": "sha256-dt4WdcvsA8/RCe+VZZwqU0X+XMM3wBbGCWA0/sFWzGo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0e251e24a4f24e036a084b6b4b2d2491af4167f4",
+        "rev": "2c423e03bbafcff28bfadc6781a4a8257f205cb5",
         "type": "github"
       },
       "original": {
@@ -1307,11 +1307,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1786247143,
-        "narHash": "sha256-8S3Kcxs7D4UtxJxSJZz0m14CGhuW0MxfrIwJxeGWGnQ=",
+        "lastModified": 1787360063,
+        "narHash": "sha256-dt4WdcvsA8/RCe+VZZwqU0X+XMM3wBbGCWA0/sFWzGo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "279b4a8275f032c566576b3f181fa0f27197f588",
+        "rev": "2c423e03bbafcff28bfadc6781a4a8257f205cb5",
         "type": "github"
       },
       "original": {
@@ -1403,11 +1403,11 @@
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1786599213,
-        "narHash": "sha256-yNJd40f11EzXBjSByCB7IPpeFFAdeoSKKM67dGkfFoU=",
+        "lastModified": 1787360063,
+        "narHash": "sha256-dt4WdcvsA8/RCe+VZZwqU0X+XMM3wBbGCWA0/sFWzGo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0e251e24a4f24e036a084b6b4b2d2491af4167f4",
+        "rev": "2c423e03bbafcff28bfadc6781a4a8257f205cb5",
         "type": "github"
       },
       "original": {
@@ -1423,11 +1423,11 @@
         "nixpkgs": "nixpkgs_10"
       },
       "locked": {
-        "lastModified": 1786847921,
-        "narHash": "sha256-3BjmH0+2Vmj+NznuGuBU8hhOOy1yKO5zRyu3XJZs/Gg=",
+        "lastModified": 1787472636,
+        "narHash": "sha256-5i0/tlYUoIfUFQMQweVzUSrCaYVh2RTWx2qjFKSJAHk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e0bbd1b1afc716fd7c591ae609e6b5a98f832584",
+        "rev": "f6c28426699e4ba46004a5219dfd74e039ce9bf1",
         "type": "github"
       },
       "original": {
@@ -1549,11 +1549,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784288435,
-        "narHash": "sha256-ReRHaLgr/uVqdD8afFSn+myXIfpHeOhP0yYe0TJqAA8=",
+        "lastModified": 1787424939,
+        "narHash": "sha256-O2tBn84NNuHrnqNVxx/XqsXwfYvS1YwBh+7CBnbCYsk=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "43b3c1ab9d40fb1dbb008f451988a91e375825e9",
+        "rev": "809414f0cdadf82cf11b06c2b29ba9b3168b3297",
         "type": "github"
       },
       "original": {
@@ -1618,11 +1618,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786849542,
-        "narHash": "sha256-MS8cOa/ii1+QA8R3JWVzqEIoXimu9n50GwQDiBVTFOM=",
+        "lastModified": 1787454509,
+        "narHash": "sha256-r4LDUF+zmJnkftvCVkCrUhSJazsf6EVJF+V2l4/MYbI=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "b211eadeba8b180da9453ec3413a8a3535c85b3f",
+        "rev": "f60c1b57ff805a46b5175c76fc981fb4f81efbcc",
         "type": "github"
       },
       "original": {
@@ -1729,11 +1729,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786464334,
-        "narHash": "sha256-/TBQT5rhBB2Dm4HoZzhGDaCwYmRTs3W3DPhMXFWc/BU=",
+        "lastModified": 1786988229,
+        "narHash": "sha256-frEFLVRj8xXvBBDs44IRiqHo6R2PxsRpluygL7abjjI=",
         "owner": "hyprwm",
         "repo": "xdg-desktop-portal-hyprland",
-        "rev": "9f0e9ff02739cd538d39bd706422dc50e9ca60dd",
+        "rev": "59d429bf45aed4e2209043c0c36565ad8e2859a5",
         "type": "github"
       },
       "original": {
@@ -1749,11 +1749,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786685380,
-        "narHash": "sha256-3ZuubfWk7CHPF/60w5BVrVkzdO7Oed1MgZ+ugLsgww8=",
+        "lastModified": 1787200418,
+        "narHash": "sha256-4d24Wa/CO8WsSEjKwzFwJXn+oxbI4Bm8xuMR77xJgYI=",
         "owner": "youwen5",
         "repo": "zen-browser-flake",
-        "rev": "e1e4aa6433a352f07059aeb8483ae42deb61f9b2",
+        "rev": "20195bc99e82b02abe82bb81ac366ae81c67dc5a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automatic flake update on 2026-08-23.

Review the per-host package changes below before merging.

## Input changes

```
unpacking 'github:nix-community/disko/de5708739256238fb912c62f03988815db89ec9a' into the Git cache...
unpacking 'github:Gako358/emacs-flake/ef88db4d9fc29cbfdaa400995e8fe4b5fc9943a6' into the Git cache...
unpacking 'github:hercules-ci/flake-parts/427bf4bd9435fdf21321c8cc628c24efc14c0f7a' into the Git cache...
unpacking 'github:nixos/nixos-hardware/0471accf8d0a8210b31d947497d179ecc99e0021' into the Git cache...
unpacking 'github:nix-community/home-manager/ec1a8fdf74ed3f276148ee106299a2ba0e65d51f' into the Git cache...
unpacking 'github:hyprwm/hypridle/aa958ed7ad4863860b93ecd7189419e193bfae2c' into the Git cache...
unpacking 'github:hyprwm/hyprland/45a79e5e84136025a5da1de34c9c65fe00cb813e' into the Git cache...
unpacking 'github:hyprwm/contrib/57baf317e5196a8286b80976771ef55febad8660' into the Git cache...
unpacking 'github:hyprwm/hyprland-plugins/83ce4b2a70d3c1a6ed8dc6db7f1fac17db2215b1' into the Git cache...
unpacking 'github:hyprwm/hyprpaper/39029bdfda857a5ea60340a427681893d12d4892' into the Git cache...
unpacking 'github:nix-community/impermanence/7b1d382faf603b6d264f58627330f9faa5cba149' into the Git cache...
unpacking 'github:vic/import-tree/4ebb10ae17d5f1ad366e7aef5b92cb8eecf24f69' into the Git cache...
unpacking 'github:nix-community/lanzaboote/b1b7d87faa06649f7c72666107bac2c6e6459c23' into the Git cache...
unpacking 'github:misterio77/nix-colors/b01f024090d2c4fc3152cd0cf12027a7b8453ba1' into the Git cache...
unpacking 'github:nixos/nixpkgs/2c423e03bbafcff28bfadc6781a4a8257f205cb5' into the Git cache...
unpacking 'github:nix-community/NUR/f6c28426699e4ba46004a5219dfd74e039ce9bf1' into the Git cache...
unpacking 'github:nix-community/plasma-manager/a19a2a029fa180911bd89c554dca1616e10f4c1d' into the Git cache...
unpacking 'github:cachix/pre-commit-hooks.nix/809414f0cdadf82cf11b06c2b29ba9b3168b3297' into the Git cache...
unpacking 'github:oxalica/rust-overlay/f60c1b57ff805a46b5175c76fc981fb4f81efbcc' into the Git cache...
unpacking 'github:gako358/scram/19595501de0215f989be7eb27cb58fdf8ab27c75' into the Git cache...
unpacking 'github:Mic92/sops-nix/a8627b21b9107c5711c96b84f32a9a4b3d45295f' into the Git cache...
unpacking 'github:youwen5/zen-browser-flake/20195bc99e82b02abe82bb81ac366ae81c67dc5a' into the Git cache...
warning: updating lock file "/home/runner/work/dotfiles/dotfiles/flake.lock":
• Updated input 'emacs-flake':
    'github:Gako358/emacs-flake/c86b877b619e455eea763c46ce285f843cf4f089?narHash=sha256-zO2nvYmdgzYSJIpEfqINvLJEyaH8fqOKA99%2Bzm1LkGA%3D' (2026-08-22)
  → 'github:Gako358/emacs-flake/ef88db4d9fc29cbfdaa400995e8fe4b5fc9943a6?narHash=sha256-/1AP8y0Kr0CW9/CLDCKs3RFITJwOEWQCGNrBTLFOas8%3D' (2026-08-23)
• Updated input 'hardware':
    'github:nixos/nixos-hardware/2dda192987ab6815e44df0130f03d6c907b79134?narHash=sha256-asdPlqtM0AweQ5YNLad6eY4tSYW55YNr1uyayf7mOMQ%3D' (2026-08-14)
  → 'github:nixos/nixos-hardware/0471accf8d0a8210b31d947497d179ecc99e0021?narHash=sha256-HHfv2/HkNSKbbSyU9iD/g8lbP6r4tl33sSw1W4rXCk0%3D' (2026-08-19)
• Updated input 'home-manager':
    'github:nix-community/home-manager/c8058ecc1329a71a3c99c4d0353dba4009a66152?narHash=sha256-nNqmXIFmESRnU91KARtiekSox0%2Bo%2BE3AS0d1TuUQ/9o%3D' (2026-08-15)
  → 'github:nix-community/home-manager/ec1a8fdf74ed3f276148ee106299a2ba0e65d51f?narHash=sha256-XL2qfqmocfsvuEGyomZg4nOZfkuSe8vZtrOX99I%2Bb6I%3D' (2026-08-22)
• Updated input 'hyprland':
    'github:hyprwm/hyprland/a1b9dc0e8cdfeca3e2d96a24b10b3d85e14fbd50?narHash=sha256-8Pyv0ORHhzsUElqqESECxSr3xr%2BSFibDZTizTF48k9I%3D' (2026-08-15)
  → 'github:hyprwm/hyprland/45a79e5e84136025a5da1de34c9c65fe00cb813e?narHash=sha256-iLWbH4BQ7x/x7oGGwlj/OarJjrmuisOFDZgc2rar9tw%3D' (2026-08-22)
• Updated input 'hyprland/aquamarine':
    'github:hyprwm/aquamarine/f3d1804205e8158c15595cdda1b566f93349ffae?narHash=sha256-WKqWL8r7CyTDYueTr2ffJ9ya50dellv6IR1JX5PghDY%3D' (2026-08-11)
  → 'github:hyprwm/aquamarine/7ce889cb78b97979b83a4648509fc3ef405c3286?narHash=sha256-H3MEkFDZf%2BUH%2BQrVgW8TdKrssPFltF8fBg/rh0J1zIc%3D' (2026-08-22)
• Updated input 'hyprland/hyprutils':
    'github:hyprwm/hyprutils/c157fe1e3092b980cc69315a6631f89aff09dcce?narHash=sha256-W1hxvumEM57yV%2BQwsZ4QdAHEqOkr7e4S8VAkLX60qDE%3D' (2026-08-11)
  → 'github:hyprwm/hyprutils/6cf50415e06dc6bd9f1252f1b745eac6b4a1cc39?narHash=sha256-QTwMqLLONRhv9iz6CVeuX6BqQNQCIqI8hL/cPYlR/24%3D' (2026-08-16)
• Updated input 'hyprland/nixpkgs':
    'github:NixOS/nixpkgs/279b4a8275f032c566576b3f181fa0f27197f588?narHash=sha256-8S3Kcxs7D4UtxJxSJZz0m14CGhuW0MxfrIwJxeGWGnQ%3D' (2026-08-09)
  → 'github:NixOS/nixpkgs/2c423e03bbafcff28bfadc6781a4a8257f205cb5?narHash=sha256-dt4WdcvsA8/RCe%2BVZZwqU0X%2BXMM3wBbGCWA0/sFWzGo%3D' (2026-08-22)
• Updated input 'hyprland/xdph':
    'github:hyprwm/xdg-desktop-portal-hyprland/9f0e9ff02739cd538d39bd706422dc50e9ca60dd?narHash=sha256-/TBQT5rhBB2Dm4HoZzhGDaCwYmRTs3W3DPhMXFWc/BU%3D' (2026-08-11)
  → 'github:hyprwm/xdg-desktop-portal-hyprland/59d429bf45aed4e2209043c0c36565ad8e2859a5?narHash=sha256-frEFLVRj8xXvBBDs44IRiqHo6R2PxsRpluygL7abjjI%3D' (2026-08-17)
• Updated input 'hyprland-contrib':
    'github:hyprwm/contrib/3dcbce715ae8b93107fa8632db15bf976862a573?narHash=sha256-JP0D8r8o9%2BjnYk0/B5O722La%2BoZeC5iNQ3lonKFTmbQ%3D' (2026-06-30)
  → 'github:hyprwm/contrib/57baf317e5196a8286b80976771ef55febad8660?narHash=sha256-qSzrIIqQUtEVeVZxQLj/L4p7%2BxKBEtPhgMTzFW2c6P8%3D' (2026-08-21)
• Updated input 'hyprland-plugins':
    'github:hyprwm/hyprland-plugins/faf5ef1bd5916051ed3252463697dd2ae479f629?narHash=sha256-bc4jNVx0agB40xwxJ0r7hAAk5tk5Lm0uKtwP5rNyvZQ%3D' (2026-08-08)
  → 'github:hyprwm/hyprland-plugins/83ce4b2a70d3c1a6ed8dc6db7f1fac17db2215b1?narHash=sha256-1DDAvYcJ7q1x4JdhoXU%2BPTQWxAUcv53gSNmmi9pBVuU%3D' (2026-08-18)
• Updated input 'lanzaboote':
    'github:nix-community/lanzaboote/4a773989235545c56f408d168cb63bc41d468832?narHash=sha256-BDedo9F6NJOw%2BIi%2BluFZh0MVIheKqiYgiVzMWc6WB24%3D' (2026-08-11)
  → 'github:nix-community/lanzaboote/b1b7d87faa06649f7c72666107bac2c6e6459c23?narHash=sha256-DAH84NNJezuk7M4WfAZtLQzJnofpXJFZFVoTPgCyUC0%3D' (2026-08-17)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/0e251e24a4f24e036a084b6b4b2d2491af4167f4?narHash=sha256-yNJd40f11EzXBjSByCB7IPpeFFAdeoSKKM67dGkfFoU%3D' (2026-08-13)
  → 'github:nixos/nixpkgs/2c423e03bbafcff28bfadc6781a4a8257f205cb5?narHash=sha256-dt4WdcvsA8/RCe%2BVZZwqU0X%2BXMM3wBbGCWA0/sFWzGo%3D' (2026-08-22)
• Updated input 'nur':
    'github:nix-community/NUR/e0bbd1b1afc716fd7c591ae609e6b5a98f832584?narHash=sha256-3BjmH0%2B2Vmj%2BNznuGuBU8hhOOy1yKO5zRyu3XJZs/Gg%3D' (2026-08-16)
  → 'github:nix-community/NUR/f6c28426699e4ba46004a5219dfd74e039ce9bf1?narHash=sha256-5i0/tlYUoIfUFQMQweVzUSrCaYVh2RTWx2qjFKSJAHk%3D' (2026-08-23)
• Updated input 'nur/nixpkgs':
    'github:nixos/nixpkgs/0e251e24a4f24e036a084b6b4b2d2491af4167f4?narHash=sha256-yNJd40f11EzXBjSByCB7IPpeFFAdeoSKKM67dGkfFoU%3D' (2026-08-13)
  → 'github:nixos/nixpkgs/2c423e03bbafcff28bfadc6781a4a8257f205cb5?narHash=sha256-dt4WdcvsA8/RCe%2BVZZwqU0X%2BXMM3wBbGCWA0/sFWzGo%3D' (2026-08-22)
• Updated input 'pre-commit-hooks-nix':
    'github:cachix/pre-commit-hooks.nix/43b3c1ab9d40fb1dbb008f451988a91e375825e9?narHash=sha256-ReRHaLgr/uVqdD8afFSn%2BmyXIfpHeOhP0yYe0TJqAA8%3D' (2026-07-17)
  → 'github:cachix/pre-commit-hooks.nix/809414f0cdadf82cf11b06c2b29ba9b3168b3297?narHash=sha256-O2tBn84NNuHrnqNVxx/XqsXwfYvS1YwBh%2B7CBnbCYsk%3D' (2026-08-22)
• Updated input 'rust-overlay':
    'github:oxalica/rust-overlay/b211eadeba8b180da9453ec3413a8a3535c85b3f?narHash=sha256-MS8cOa/ii1%2BQA8R3JWVzqEIoXimu9n50GwQDiBVTFOM%3D' (2026-08-16)
  → 'github:oxalica/rust-overlay/f60c1b57ff805a46b5175c76fc981fb4f81efbcc?narHash=sha256-r4LDUF%2BzmJnkftvCVkCrUhSJazsf6EVJF%2BV2l4/MYbI%3D' (2026-08-23)
• Updated input 'zen-browser':
    'github:youwen5/zen-browser-flake/e1e4aa6433a352f07059aeb8483ae42deb61f9b2?narHash=sha256-3ZuubfWk7CHPF/60w5BVrVkzdO7Oed1MgZ%2BugLsgww8%3D' (2026-08-14)
  → 'github:youwen5/zen-browser-flake/20195bc99e82b02abe82bb81ac366ae81c67dc5a?narHash=sha256-4d24Wa/CO8WsSEjKwzFwJXn%2BoxbI4Bm8xuMR77xJgYI%3D' (2026-08-20)
```

## Per-host package diff

<details><summary><b>aanallein</b></summary>

```
<<< result-old
>>> result-new
Version changes:
[U.]  #01  bcachefs-tools          1.39.1 -> 1.39.2
[U.]  #02  breeze-icons            6.28.0, 6.28.0-dev -> 6.29.0, 6.29.0-dev
[U*]  #03  cpupower                6.18.44, 6.18.44_fish-completions -> 6.18.45, 6.18.45_fish-completions
[U.]  #04  extra-cmake-modules     6.28.0 -> 6.29.0
[U.]  #05  fzf                     0.74.2, 0.74.2-fish-completions, 0.74.2-man -> 0.74.3, 0.74.3-fish-completions, 0.74.3-man
[U.]  #06  gh                      2.97.0, 2.97.0-fish-completions -> 2.98.0, 2.98.0-fish-completions
[U.]  #07  initrd-linux            6.18.44 -> 6.18.45
[U.]  #08  libgit2                 1.9.4-lib -> 1.9.7-lib
[U.]  #09  linux                   6.18.44, 6.18.44-modules x2 -> 6.18.45, 6.18.45-modules x2
[U.]  #10  mesa                    26.2.0 x2 -> 26.2.1 x2
[U.]  #11  ncdu                    2.11.0, 2.11.0-fish-completions -> 2.11.1, 2.11.1-fish-completions
[U.]  #12  nixos-system-aanallein  26.11.20260813.0e251e2 -> 26.11.20260822.2c423e0
[C*]  #13  openssh                 10.4p1 x2, 10.4p1-man -> 10.4p1, 10.5p1, 10.5p1-man
[C*]  #14  perl                    5.42.0 x2, 5.42.0-env x4, 5.42.0-man -> 5.42.0 x2, 5.42.0-env x3, 5.42.0-man
[U*]  #15  podman                  5.8.4, 5.8.4-man -> 5.8.6, 5.8.6-man
[C.]  #16  unifont                 17.0.05, 17.0.05-bin -> 17.0.05
Removed packages:
[R.]  #1  dash           0.5.13.5
[R.]  #2  getty          <none> x2
[R.]  #3  perl5.42.0-GD  2.86
Closure size: 1893 -> 1887 (169 paths added, 175 paths removed, delta -6, disk usage -22.5MiB).
```

</details>

<details><summary><b>rhuidean</b></summary>

```
<<< result-old
>>> result-new
Version changes:
[U.]  #01  attica                 6.28.0 -> 6.29.0
[U.]  #02  bcachefs-tools         1.39.1 -> 1.39.2
[U.]  #03  botan                  3.12.0 -> 3.13.0
[U.]  #04  breeze-icons           6.28.0, 6.28.0-dev -> 6.29.0, 6.29.0-dev
[U*]  #05  cpupower               6.18.44, 6.18.44_fish-completions -> 6.18.45, 6.18.45_fish-completions
[U.]  #06  electron               41.10.3 -> 43.4.1
[U.]  #07  electron-unwrapped     41.10.3 -> 43.4.1
[U.]  #08  extra-cmake-modules    6.28.0 -> 6.29.0
[C.]  #09  ffmpeg                 4.4.8-data, 4.4.8-lib, 7.1.5-data, 7.1.5-lib, 9.0-data, 9.0-lib -> 7.1.5-data, 7.1.5-lib, 9.0-data, 9.0-lib
[C.]  #10  ffmpeg-headless        8.1.2-data, 8.1.2-lib, 9.0-data x2, 9.0-lib x2 -> 7.1.5-data, 7.1.5-lib, 8.1.2-data, 8.1.2-lib, 9.0-data x2, 9.0-lib x2
[U.]  #11  flatpak                1.18.0 -> 1.18.1
[U.]  #12  frameworkintegration   6.28.0 -> 6.29.0
[U.]  #13  fzf                    0.74.2, 0.74.2-fish-completions, 0.74.2-man -> 0.74.3, 0.74.3-fish-completions, 0.74.3-man
[U.]  #14  gh                     2.97.0, 2.97.0-fish-completions -> 2.98.0, 2.98.0-fish-completions
[U.]  #15  initrd-linux           6.18.44 -> 6.18.45
[U.]  #16  karchive               6.28.0 -> 6.29.0
[U.]  #17  kauth                  6.28.0 -> 6.29.0
[U.]  #18  kbookmarks             6.28.0 -> 6.29.0
[U.]  #19  kcmutils               6.28.0 -> 6.29.0
[U.]  #20  kcodecs                6.28.0 -> 6.29.0
[U.]  #21  kcolorscheme           6.28.0 -> 6.29.0
[U.]  #22  kcompletion            6.28.0 -> 6.29.0
[U.]  #23  kconfig                6.28.0 -> 6.29.0
[U.]  #24  kconfigwidgets         6.28.0 -> 6.29.0
[U.]  #25  kcoreaddons            6.28.0 -> 6.29.0
[U.]  #26  kcrash                 6.28.0 -> 6.29.0
[U.]  #27  kdbusaddons            6.28.0 -> 6.29.0
[U.]  #28  kdoctools              6.28.0 -> 6.29.0
[U.]  #29  kglobalaccel           6.28.0 -> 6.29.0
[U.]  #30  kguiaddons             6.28.0 -> 6.29.0
[U.]  #31  ki18n                  6.28.0 -> 6.29.0
[U.]  #32  kiconthemes            6.28.0 -> 6.29.0
[U.]  #33  kio                    6.28.0 -> 6.29.0
[U.]  #34  kirigami               6.28.0 -> 6.29.0
[U.]  #35  kitemmodels            6.28.0 -> 6.29.0
[U.]  #36  kitemviews             6.28.0 -> 6.29.0
[U.]  #37  kjobwidgets            6.28.0 -> 6.29.0
[U.]  #38  knewstuff              6.28.0 -> 6.29.0
[U.]  #39  knotifications         6.28.0 -> 6.29.0
[U.]  #40  kpackage               6.28.0 -> 6.29.0
[U.]  #41  kservice               6.28.0 -> 6.29.0
[U.]  #42  ktextwidgets           6.28.0 -> 6.29.0
[U.]  #43  kwallet                6.28.0 -> 6.29.0
[U.]  #44  kwidgetsaddons         6.28.0 -> 6.29.0
[U.]  #45  kwindowsystem          6.28.0 -> 6.29.0
[U.]  #46  kxmlgui                6.28.0 -> 6.29.0
[U.]  #47  libgit2                1.9.4-lib -> 1.9.7-lib
[U.]  #48  libphonenumber         9.0.36 -> 9.0.37
[U.]  #49  libtraceevent          1.9 -> 1.9.0
[U.]  #50  linux                  6.18.44, 6.18.44-modules x2 -> 6.18.45, 6.18.45-modules x2
[U.]  #51  lsp-plugins            1.2.33 -> 1.2.34
[U.]  #52  mesa                   26.2.0 x2 -> 26.2.1 x2
[U.]  #53  ncdu                   2.11.0, 2.11.0-fish-completions -> 2.11.1, 2.11.1-fish-completions
[U.]  #54  nixos-system-rhuidean  26.11.20260813.0e251e2 -> 26.11.20260822.2c423e0
[C.]  #55  nss                    3.112.5, 3.112.5-man, 3.126 -> 3.112.5, 3.112.5-man, 3.127
[C*]  #56  openssh                10.4p1 x2, 10.4p1-man -> 10.4p1, 10.5p1, 10.5p1-man
[U.]  #57  osinfo-db              20251212 -> 20260812
[U.]  #58  oxygen-icons           6.28.0 -> 6.29.0
[U*]  #59  podman                 5.8.4, 5.8.4-man -> 5.8.6, 5.8.6-man
[U.]  #60  qqc2-desktop-style     6.28.0 -> 6.29.0
[U.]  #61  solid                  6.28.0 -> 6.29.0
[U.]  #62  sonnet                 6.28.0 -> 6.29.0
[U.]  #63  syndication            6.28.0 -> 6.29.0
[U.]  #64  webkitgtk              2.52.5+abi=4.1, 2.52.5+abi=6.0 -> 2.52.6+abi=4.1, 2.52.6+abi=6.0
[U*]  #65  xlsclients             1.1.5, 1.1.5_fish-completions -> 1.1.6, 1.1.6_fish-completions
[U.]  #66  zen-browser            1.21.14b, 1.21.14b-fish-completions -> 1.21.15b, 1.21.15b-fish-completions
[U.]  #67  zen-browser-unwrapped  1.21.14b -> 1.21.15b
Added packages:
[A.]  #1  X-Restart-Triggers-gamemoded        <none>
[A.]  #2  squashfs-tools                      4.7.5
[A.]  #3  unit-gnome-session-monitor.service  <none>
Removed packages:
[R.]  #1  dash      0.5.13.5
[R.]  #2  getty     <none> x2
[R.]  #3  squashfs  4.7.5
Closure size: 2734 -> 2733 (371 paths added, 372 paths removed, delta -1, disk usage +30.7MiB).
```

</details>

<details><summary><b>tanchico</b></summary>

```
<<< result-old
>>> result-new
Version changes:
[U.]  #01  attica                 6.28.0 -> 6.29.0
[U.]  #02  bcachefs-tools         1.39.1 -> 1.39.2
[U.]  #03  botan                  3.12.0 -> 3.13.0
[U.]  #04  breeze-icons           6.28.0, 6.28.0-dev -> 6.29.0, 6.29.0-dev
[U*]  #05  cpupower               6.18.44, 6.18.44_fish-completions -> 6.18.45, 6.18.45_fish-completions
[U.]  #06  electron               41.10.3 -> 43.4.1
[U.]  #07  electron-unwrapped     41.10.3 -> 43.4.1
[U.]  #08  extra-cmake-modules    6.28.0 -> 6.29.0
[C.]  #09  ffmpeg                 4.4.8-data, 4.4.8-lib, 7.1.5-data, 7.1.5-lib, 9.0-data, 9.0-lib -> 7.1.5-data, 7.1.5-lib, 9.0-data, 9.0-lib
[C.]  #10  ffmpeg-headless        8.1.2-data, 8.1.2-lib, 9.0-data x2, 9.0-lib x2 -> 7.1.5-data, 7.1.5-lib, 8.1.2-data, 8.1.2-lib, 9.0-data x2, 9.0-lib x2
[U.]  #11  flatpak                1.18.0 -> 1.18.1
[U.]  #12  frameworkintegration   6.28.0 -> 6.29.0
[U.]  #13  fzf                    0.74.2, 0.74.2-fish-completions, 0.74.2-man -> 0.74.3, 0.74.3-fish-completions, 0.74.3-man
[U.]  #14  gh                     2.97.0, 2.97.0-fish-completions -> 2.98.0, 2.98.0-fish-completions
[U.]  #15  initrd-linux           6.18.44 -> 6.18.45
[U.]  #16  karchive               6.28.0 -> 6.29.0
[U.]  #17  kauth                  6.28.0 -> 6.29.0
[U.]  #18  kbookmarks             6.28.0 -> 6.29.0
[U.]  #19  kcmutils               6.28.0 -> 6.29.0
[U.]  #20  kcodecs                6.28.0 -> 6.29.0
[U.]  #21  kcolorscheme           6.28.0 -> 6.29.0
[U.]  #22  kcompletion            6.28.0 -> 6.29.0
[U.]  #23  kconfig                6.28.0 -> 6.29.0
[U.]  #24  kconfigwidgets         6.28.0 -> 6.29.0
[U.]  #25  kcoreaddons            6.28.0 -> 6.29.0
[U.]  #26  kcrash                 6.28.0 -> 6.29.0
[U.]  #27  kdbusaddons            6.28.0 -> 6.29.0
[U.]  #28  kdoctools              6.28.0 -> 6.29.0
[U.]  #29  kglobalaccel           6.28.0 -> 6.29.0
[U.]  #30  kguiaddons             6.28.0 -> 6.29.0
[U.]  #31  ki18n                  6.28.0 -> 6.29.0
[U.]  #32  kiconthemes            6.28.0 -> 6.29.0
[U.]  #33  kio                    6.28.0 -> 6.29.0
[U.]  #34  kirigami               6.28.0 -> 6.29.0
[U.]  #35  kitemmodels            6.28.0 -> 6.29.0
[U.]  #36  kitemviews             6.28.0 -> 6.29.0
[U.]  #37  kjobwidgets            6.28.0 -> 6.29.0
[U.]  #38  knewstuff              6.28.0 -> 6.29.0
[U.]  #39  knotifications         6.28.0 -> 6.29.0
[U.]  #40  kpackage               6.28.0 -> 6.29.0
[U.]  #41  kservice               6.28.0 -> 6.29.0
[U.]  #42  ktextwidgets           6.28.0 -> 6.29.0
[U.]  #43  kwallet                6.28.0 -> 6.29.0
[U.]  #44  kwidgetsaddons         6.28.0 -> 6.29.0
[U.]  #45  kwindowsystem          6.28.0 -> 6.29.0
[U.]  #46  kxmlgui                6.28.0 -> 6.29.0
[U.]  #47  libgit2                1.9.4-lib -> 1.9.7-lib
[U.]  #48  libphonenumber         9.0.36 -> 9.0.37
[U.]  #49  libtraceevent          1.9 -> 1.9.0
[U.]  #50  linux                  6.18.44, 6.18.44-modules x2 -> 6.18.45, 6.18.45-modules x2
[U.]  #51  lsp-plugins            1.2.33 -> 1.2.34
[U.]  #52  mesa                   26.2.0 x2 -> 26.2.1 x2
[U.]  #53  ncdu                   2.11.0, 2.11.0-fish-completions -> 2.11.1, 2.11.1-fish-completions
[U.]  #54  nixos-system-tanchico  26.11.20260813.0e251e2 -> 26.11.20260822.2c423e0
[C.]  #55  nss                    3.112.5, 3.112.5-man, 3.126 -> 3.112.5, 3.112.5-man, 3.127
[C*]  #56  openssh                10.4p1 x2, 10.4p1-man -> 10.4p1, 10.5p1, 10.5p1-man
[U.]  #57  osinfo-db              20251212 -> 20260812
[U.]  #58  oxygen-icons           6.28.0 -> 6.29.0
[U*]  #59  podman                 5.8.4, 5.8.4-man -> 5.8.6, 5.8.6-man
[U.]  #60  qqc2-desktop-style     6.28.0 -> 6.29.0
[U.]  #61  solid                  6.28.0 -> 6.29.0
[U.]  #62  sonnet                 6.28.0 -> 6.29.0
[U.]  #63  syndication            6.28.0 -> 6.29.0
[U.]  #64  webkitgtk              2.52.5+abi=4.1, 2.52.5+abi=6.0 -> 2.52.6+abi=4.1, 2.52.6+abi=6.0
[U*]  #65  xlsclients             1.1.5, 1.1.5_fish-completions -> 1.1.6, 1.1.6_fish-completions
[U.]  #66  zen-browser            1.21.14b, 1.21.14b-fish-completions -> 1.21.15b, 1.21.15b-fish-completions
[U.]  #67  zen-browser-unwrapped  1.21.14b -> 1.21.15b
Added packages:
[A.]  #1  X-Restart-Triggers-gamemoded        <none>
[A.]  #2  squashfs-tools                      4.7.5
[A.]  #3  unit-gnome-session-monitor.service  <none>
Removed packages:
[R.]  #1  dash      0.5.13.5
[R.]  #2  getty     <none> x2
[R.]  #3  squashfs  4.7.5
Closure size: 2731 -> 2730 (371 paths added, 372 paths removed, delta -1, disk usage +30.7MiB).
```

</details>

<details><summary><b>terangreal</b></summary>

```
<<< result-old
>>> result-new
Version changes:
[C.]  #001  abseil-cpp                        20260107.1 x5, 20260107.1-dev -> 20260107.1 x4, 20260107.1-dev
[C*]  #002  acl                               2.3.2 x2, 2.4.0 x4, 2.4.0-bin, 2.4.0-doc, 2.4.0-man -> 2.3.2 x2, 2.4.0 x3, 2.4.0-bin, 2.4.0-doc, 2.4.0-man
[C.]  #003  alsa-lib                          1.2.14, 1.2.16, 1.2.16.1 x3 -> 1.2.14, 1.2.16, 1.2.16.1 x2
[C.]  #004  alsa-topology-conf                1.2.5.1 x5 -> 1.2.5.1 x4
[C.]  #005  alsa-ucm-conf                     1.2.14, 1.2.16, 1.2.16.1 x3 -> 1.2.14, 1.2.16, 1.2.16.1 x2
[C.]  #006  aquamarine                        0.14.0, 0.14.0+date=2026-08-11_f3d1804 -> 0.14.0, 0.14.0+date=2026-08-22_7ce889c
[U.]  #007  astyle                            3.6.17 -> 3.6.18
[C.]  #008  at-spi2-core                      2.56.2, 2.60.4, 2.60.6, 2.60.6-dev -> 2.56.2, 2.60.6, 2.60.6-dev
[U.]  #009  attica                            6.28.0 -> 6.29.0
[C*]  #010  attr                              2.5.2 x2, 2.6.0 x4, 2.6.0-bin, 2.6.0-doc, 2.6.0-man -> 2.5.2 x2, 2.6.0 x3, 2.6.0-bin, 2.6.0-doc, 2.6.0-man
[C.]  #011  audit                             4.1.4-lib x2, 4.2-lib, 4.2.1-lib x2 -> 4.1.4-lib x2, 4.2.1-lib x2
[C.]  #012  avahi                             0.8 x5 -> 0.8 x4
[C.]  #013  bash                              5.3p3, 5.3p9, 5.3p15 x4 -> 5.3p3, 5.3p9, 5.3p15 x3
[C*]  #014  bash-interactive                  5.3p9, 5.3p15 x4, 5.3p15-doc, 5.3p15-info, 5.3p15-man x2 -> 5.3p9, 5.3p15 x3, 5.3p15-doc, 5.3p15-info, 5.3p15-man x2
[U.]  #015  bcachefs-tools                    1.39.1 -> 1.39.2
[C.]  #016  binutils                          2.46 x2, 2.46-lib x2 -> 2.46, 2.46-lib
[C.]  #017  binutils-wrapper                  2.46 x2 -> 2.46
[C.]  #018  bluez                             5.86 x2, 5.87 x2 -> 5.86, 5.87 x2
[U.]  #019  bottom                            0.14.7, 0.14.7-fish-completions -> 0.14.8, 0.14.8-fish-completions
[U.]  #020  breeze-icons                      6.28.0, 6.28.0-dev -> 6.29.0, 6.29.0-dev
[C.]  #021  brotli                            1.1.0-lib, 1.2.0 x2, 1.2.0-dev x2, 1.2.0-lib x5 -> 1.1.0-lib, 1.2.0, 1.2.0-dev, 1.2.0-lib x4
[C*]  #022  bzip2                             1.0.8 x6, 1.0.8-bin x2, 1.0.8-dev x2, 1.0.8-man -> 1.0.8 x5, 1.0.8-bin, 1.0.8-dev, 1.0.8-man
[C.]  #023  cairo                             1.18.4 x5, 1.18.4-dev x2 -> 1.18.4 x4, 1.18.4-dev
[C.]  #024  cdparanoia-iii                    10.2 x4 -> 10.2 x3
[C.]  #025  cjson                             1.7.19 x4 -> 1.7.19 x3
[C.]  #026  coreutils                         9.7, 9.11 x5 -> 9.7, 9.11 x4
[U*]  #027  cpupower                          6.18.44, 6.18.44_fish-completions -> 6.18.45, 6.18.45_fish-completions
[C.]  #028  cracklib                          2.10.3 x4 -> 2.10.3 x3
[C*]  #029  cryptsetup                        2.8.6 x4, 2.8.6-bin, 2.8.6-man -> 2.8.6 x3, 2.8.6-bin, 2.8.6-man
[C.]  #030  cups                              2.4.12-lib, 2.4.19, 2.4.19-dev, 2.4.19-lib x2, 2.4.19-man -> 2.4.12-lib, 2.4.19, 2.4.19-dev, 2.4.19-lib, 2.4.19-man
[C*]  #031  curl                              8.21.0 x5, 8.21.0-bin, 8.21.0-man -> 8.21.0 x4, 8.21.0-bin, 8.21.0-man
[C.]  #032  dav1d                             1.5.3 x4 -> 1.5.3 x3
[C.]  #033  db                                4.8.30 x5, 5.3.28 -> 4.8.30 x4, 5.3.28
[C*]  #034  dbus                              1, 1.14.10-lib, 1.16.2 x2, 1.16.2-dev x2, 1.16.2-doc, 1.16.2-lib x4, 1.16.2-man -> 1, 1.14.10-lib, 1.16.2, 1.16.2-dev, 1.16.2-doc, 1.16.2-lib x3, 1.16.2-man
[C*]  #035  dconf                             0.40.0-lib, 0.49.0, 0.49.0_fish-completions, 0.49.0-lib x4 -> 0.40.0-lib, 0.49.0, 0.49.0_fish-completions, 0.49.0-lib x3
[C.]  #036  dejavu-fonts-minimal              2.37 x5 -> 2.37 x4
[C.]  #037  dns-root-data                     2025-04-14 x6 -> 2025-04-14 x5
[C.]  #038  double-conversion                 3.4.0 x2, 3.4.0-dev -> 3.4.0, 3.4.0-dev
[C.]  #039  duktape                           2.7.0 x2 -> 2.7.0
[U.]  #040  electron                          41.10.3 -> 43.4.1
[U.]  #041  electron-unwrapped                41.10.3 -> 43.4.1
[C.]  #042  elfutils                          0.195 x4 -> 0.195 x3
[C.]  #043  ell                               0.83 x4 -> 0.83 x3
[U.]  #044  emacs-evil-ghostel                0.49.0 -> 0.50.0
[U.]  #045  emacs-ghostel                     0.49.0 -> 0.50.0
[C.]  #046  expand-response-params            <none> x4 -> <none> x2
[C.]  #047  expat                             2.7.1, 2.8.2 x5, 2.8.2-dev x2 -> 2.7.1, 2.8.2 x4, 2.8.2-dev
[U.]  #048  extra-cmake-modules               6.28.0 -> 6.29.0
[C.]  #049  fdk-aac                           2.0.3 x4 -> 2.0.3 x3
[C.]  #050  ffado                             2.4.9 x4 -> 2.4.9 x3
[C.]  #051  ffmpeg-headless                   8.1.2-data x3, 8.1.2-lib x3, 9.0-data x2, 9.0-lib x2 -> 8.1.2-data x2, 8.1.2-lib x2, 9.0-data x2, 9.0-lib x2
[C.]  #052  fftw-double                       3.3.11 x4 -> 3.3.11 x3
[C.]  #053  fftw-single                       3.3.11 x4 -> 3.3.11 x3
[C.]  #054  file                              5.45, 5.48 x4 -> 5.45, 5.48 x3
[C.]  #055  flac                              1.5.0 x4 -> 1.5.0 x3
[U.]  #056  flatpak                           1.18.0 -> 1.18.1
[C*]  #057  fontconfig                        2.16.2, 2.16.2-lib, 2.18.1, 2.18.1-lib, 2.18.2 x3, 2.18.2-bin x2, 2.18.2-dev x2, 2.18.2_fish-completions, 2.18.2-lib x3 -> 2.16.2, 2.16.2-lib, 2.18.1, 2.18.1-lib, 2.18.2 x2, 2.18.2-bin, 2.18.2-dev, 2.18.2_fish-completions, 2.18.2-lib x2
[U.]  #058  frameworkintegration              6.28.0 -> 6.29.0
[C.]  #059  freetype                          2.13.3, 2.14.3 x4, 2.14.3-dev x2 -> 2.13.3, 2.14.3 x3, 2.14.3-dev
[C.]  #060  fribidi                           1.0.16 x5, 1.0.16-dev -> 1.0.16 x4, 1.0.16-dev
[U.]  #061  fzf                               0.74.2, 0.74.2-fish-completions, 0.74.2-man -> 0.74.3, 0.74.3-fish-completions, 0.74.3-man
[C*]  #062  gawk                              5.4.1 x2, 5.4.1-info, 5.4.1-man -> 5.4.1, 5.4.1-info, 5.4.1-man
[C.]  #063  gcc                               14.3.0-lib, 14.3.0-libgcc, 15.2.0-lib, 15.2.0-libgcc, 15.3.0, 15.3.0-lib x4, 15.3.0-libgcc x4, 15.3.0-man, 16.2.0, 16.2.0-lib x2, 16.2.0-libgcc x2 -> 14.3.0-lib, 14.3.0-libgcc, 15.2.0-lib, 15.2.0-libgcc, 15.3.0, 15.3.0-lib x3, 15.3.0-libgcc x3, 15.3.0-man, 16.2.0, 16.2.0-lib, 16.2.0-libgcc
[C.]  #064  gdbm                              1.26-lib x5 -> 1.26-lib x4
[C.]  #065  gdk-pixbuf                        2.42.12, 2.44.6 x2, 2.44.7, 2.44.7-dev, 2.44.7-man -> 2.42.12, 2.44.6, 2.44.7, 2.44.7-dev, 2.44.7-man
[C.]  #066  gettext                           1.0 x4 -> 1.0 x3
[U.]  #067  gh                                2.97.0, 2.97.0-fish-completions -> 2.98.0, 2.98.0-fish-completions
[C.]  #068  giflib                            5.2.2, 6.1.3 x4 -> 5.2.2, 6.1.3 x3
[C.]  #069  glib                              2.84.4, 2.88.1 x2, 2.88.1-bin x2, 2.88.1-dev, 2.88.3 x2, 2.88.3-bin, 2.88.3-dev, 2.88.3-fish-completions -> 2.84.4, 2.88.1, 2.88.1-bin, 2.88.3 x2, 2.88.3-bin, 2.88.3-dev, 2.88.3-fish-completions
[C*]  #070  glibc                             2.40-66, 2.40-66-getent, 2.42-67 x5, 2.42-67-bin x3, 2.42-67-dev x2, 2.42-67-getent -> 2.40-66, 2.40-66-getent, 2.42-67 x4, 2.42-67-bin x2, 2.42-67-dev, 2.42-67-getent
[C.]  #071  glibc-iconv                       2.42 x2 -> 2.42
[C.]  #072  glibmm                            2.66.8 x4, 2.88.1 -> 2.66.8 x3, 2.88.1
[C.]  #073  glslang                           16.3.0, 16.4.0 -> 16.4.0
[C.]  #074  gmp-with-cxx                      6.3.0 x11, 6.3.0-dev -> 6.3.0 x9, 6.3.0-dev
[C*]  #075  gnugrep                           3.12 x4, 3.12_fish-completions, 3.12-info -> 3.12 x3, 3.12_fish-completions, 3.12-info
[C.]  #076  gnum4                             1.4.21 x4 -> 1.4.21 x3
[C*]  #077  gnused                            4.10 x4, 4.10_fish-completions, 4.10-info -> 4.10 x3, 4.10_fish-completions, 4.10-info
[C.]  #078  gnutls                            3.8.10, 3.8.13 x4 -> 3.8.10, 3.8.13 x3
[C.]  #079  gobject-introspection             1.84.0, 1.86.0 x2, 1.86.0-dev -> 1.84.0, 1.86.0, 1.86.0-dev
[C.]  #080  graphene                          1.10.8 x4 -> 1.10.8 x3
[C.]  #081  graphite2                         1.3.14, 1.3.15 x4, 1.3.15-dev x2 -> 1.3.14, 1.3.15 x3, 1.3.15-dev
[C.]  #082  grim                              1.5.0 x2 -> 1.5.0
[C.]  #083  gsettings-desktop-schemas         48.0, 50.1 x2 -> 48.0, 50.1
[C.]  #084  gst-plugins-base                  1.28.4, 1.28.5 x3 -> 1.28.4, 1.28.5 x2
[C.]  #085  gstreamer                         1.28.4, 1.28.5 x3 -> 1.28.4, 1.28.5 x2
[C.]  #086  gtest                             1.17.0 x4, 1.17.0-dev -> 1.17.0 x3, 1.17.0-dev
[C.]  #087  gtk+3                             3.24.49, 3.24.52 x2, 3.24.52-dev -> 3.24.49, 3.24.52, 3.24.52-dev
[C.]  #088  harfbuzz                          11.2.1, 13.2.1 x4, 13.2.1-dev x2 -> 11.2.1, 13.2.1 x3, 13.2.1-dev
[C.]  #089  hostname-debian                   3.25 x2, 3.25-man x2 -> 3.25, 3.25-man
[C*]  #090  hostname-hostname-debian          3.25 x2, 3.25_fish-completions -> 3.25, 3.25_fish-completions
[C.]  #091  hwdata                            0.408, 0.409, 0.410 x2 -> 0.408, 0.410 x2
[C*]  #092  hyprland                          0.56.0+date=2026-08-15_a1b9dc0, 0.56.0+date=2026-08-15_a1b9dc0-man, 0.56.2 -> 0.56.0+date=2026-08-22_45a79e5, 0.56.0+date=2026-08-22_45a79e5-man, 0.56.2
[U.]  #093  hyprutils                         0.14.0 x2, 0.14.0+date=2026-08-11_c157fe1, 0.14.0+date=2026-08-11_c157fe1-dev -> 0.14.1, 0.14.1+date=2026-08-16_6cf5041, 0.14.1+date=2026-08-16_6cf5041-dev
[C.]  #094  icu4c                             76.1 x2, 77.1, 78.3 x3, 78.3-dev -> 76.1 x2, 77.1, 78.3 x2, 78.3-dev
[C.]  #095  iniparser                         4.2.6 x2 -> 4.2.6
[U.]  #096  initrd-linux                      6.18.44 -> 6.18.45
[C.]  #097  iso-codes                         4.18.0, 4.20.1 x4 -> 4.18.0, 4.20.1 x3
[C.]  #098  jq                                1.8.2 x2, 1.8.2-bin x2, 1.8.2-fish-completions, 1.8.2-man -> 1.8.2, 1.8.2-bin, 1.8.2-fish-completions, 1.8.2-man
[C.]  #099  json-c                            0.18 x4 -> 0.18 x3
[C.]  #100  json-glib                         1.10.6, 1.10.8 x2 -> 1.10.6, 1.10.8
[U.]  #101  karchive                          6.28.0 -> 6.29.0
[U.]  #102  kauth                             6.28.0 -> 6.29.0
[C*]  #103  kbd                               2.8.0-unstable-2025-08-12, 2.9.0 x4, 2.9.0-man -> 2.8.0-unstable-2025-08-12, 2.9.0 x3, 2.9.0-man
[U.]  #104  kbookmarks                        6.28.0 -> 6.29.0
[U.]  #105  kcmutils                          6.28.0 -> 6.29.0
[U.]  #106  kcodecs                           6.28.0 -> 6.29.0
[U.]  #107  kcolorscheme                      6.28.0 -> 6.29.0
[U.]  #108  kcompletion                       6.28.0 -> 6.29.0
[U.]  #109  kconfig                           6.28.0 -> 6.29.0
[U.]  #110  kconfigwidgets                    6.28.0 -> 6.29.0
[U.]  #111  kcoreaddons                       6.28.0 -> 6.29.0
[U.]  #112  kcrash                            6.28.0 -> 6.29.0
[U.]  #113  kdbusaddons                       6.28.0 -> 6.29.0
[U.]  #114  kdoctools                         6.28.0 -> 6.29.0
[C*]  #115  kexec-tools                       2.0.31, 2.0.32 x4, 2.0.32_fish-completions -> 2.0.31, 2.0.32 x3, 2.0.32_fish-completions
[C.]  #116  keyutils                          1.6.3-lib x5 -> 1.6.3-lib x4
[U.]  #117  kglobalaccel                      6.28.0 -> 6.29.0
[U.]  #118  kguiaddons                        6.28.0 -> 6.29.0
[U.]  #119  ki18n                             6.28.0 -> 6.29.0
[U.]  #120  kiconthemes                       6.28.0 -> 6.29.0
[U.]  #121  kio                               6.28.0 -> 6.29.0
[U.]  #122  kirigami                          6.28.0 -> 6.29.0
[U.]  #123  kitemmodels                       6.28.0 -> 6.29.0
[U.]  #124  kitemviews                        6.28.0 -> 6.29.0
[U.]  #125  kjobwidgets                       6.28.0 -> 6.29.0
[C*]  #126  kmod                              31 x5, 31-lib x5, 31-man -> 31 x4, 31-lib x4, 31-man
[U.]  #127  knewstuff                         6.28.0 -> 6.29.0
[U.]  #128  knotifications                    6.28.0 -> 6.29.0
[U.]  #129  kpackage                          6.28.0 -> 6.29.0
[C.]  #130  krb5                              1.22.2-lib x5 -> 1.22.2-lib x4
[U.]  #131  kservice                          6.28.0 -> 6.29.0
[U.]  #132  ktextwidgets                      6.28.0 -> 6.29.0
[U.]  #133  kwallet                           6.28.0 -> 6.29.0
[U.]  #134  kwidgetsaddons                    6.28.0 -> 6.29.0
[U.]  #135  kwindowsystem                     6.28.0 -> 6.29.0
[U.]  #136  kxmlgui                           6.28.0 -> 6.29.0
[C.]  #137  lame                              3.100-lib x4 -> 3.100-lib x3
[C.]  #138  lcms2                             2.17, 2.19.1 x4 -> 2.17, 2.19.1 x3
[C.]  #139  ldacbt                            2.0.72 x4 -> 2.0.72 x3
[C.]  #140  lerc                              4.0.0, 4.1.0, 4.1.1, 4.2.0 x2, 4.2.0-dev -> 4.0.0, 4.1.0, 4.2.0 x2, 4.2.0-dev
[C.]  #141  libao                             1.2.2 x4 -> 1.2.2 x3
[C.]  #142  libaom                            3.12.1 x4 -> 3.12.1 x3
[C.]  #143  libapparmor                       5.0.0, 5.0.2 x3 -> 5.0.0, 5.0.2 x2
[C.]  #144  libarchive                        3.8.8-lib x4 -> 3.8.8-lib x3
[C.]  #145  libass                            0.17.4 x4 -> 0.17.4 x3
[C.]  #146  libavc1394                        0.5.4 x4 -> 0.5.4 x3

_… diff truncated (444 lines total); see the `closure-diff-terangreal` artifact for the full output._

</details>

<details><summary><b>tuathaan</b></summary>

```
<<< result-old
>>> result-new
Version changes:
[C.]  #001  abseil-cpp                        20260107.1 x5, 20260107.1-dev -> 20260107.1 x4, 20260107.1-dev
[C*]  #002  acl                               2.3.2 x2, 2.4.0 x4, 2.4.0-bin, 2.4.0-doc, 2.4.0-man -> 2.3.2 x2, 2.4.0 x3, 2.4.0-bin, 2.4.0-doc, 2.4.0-man
[C.]  #003  alsa-lib                          1.2.14, 1.2.16, 1.2.16.1 x3 -> 1.2.14, 1.2.16, 1.2.16.1 x2
[C.]  #004  alsa-topology-conf                1.2.5.1 x5 -> 1.2.5.1 x4
[C.]  #005  alsa-ucm-conf                     1.2.14, 1.2.16, 1.2.16.1 x3 -> 1.2.14, 1.2.16, 1.2.16.1 x2
[C.]  #006  aquamarine                        0.14.0, 0.14.0+date=2026-08-11_f3d1804 -> 0.14.0, 0.14.0+date=2026-08-22_7ce889c
[U.]  #007  astyle                            3.6.17 -> 3.6.18
[C.]  #008  at-spi2-core                      2.56.2, 2.60.4, 2.60.6, 2.60.6-dev -> 2.56.2, 2.60.6, 2.60.6-dev
[U.]  #009  attica                            6.28.0 -> 6.29.0
[C*]  #010  attr                              2.5.2 x2, 2.6.0 x4, 2.6.0-bin, 2.6.0-doc, 2.6.0-man -> 2.5.2 x2, 2.6.0 x3, 2.6.0-bin, 2.6.0-doc, 2.6.0-man
[C.]  #011  audit                             4.1.4-lib x2, 4.2-lib, 4.2.1-lib x2 -> 4.1.4-lib x2, 4.2.1-lib x2
[C.]  #012  avahi                             0.8 x5 -> 0.8 x4
[C.]  #013  bash                              5.3p3, 5.3p9, 5.3p15 x4 -> 5.3p3, 5.3p9, 5.3p15 x3
[C*]  #014  bash-interactive                  5.3p9, 5.3p15 x4, 5.3p15-doc, 5.3p15-info, 5.3p15-man x2 -> 5.3p9, 5.3p15 x3, 5.3p15-doc, 5.3p15-info, 5.3p15-man x2
[U.]  #015  bcachefs-tools                    1.39.1 -> 1.39.2
[C.]  #016  binutils                          2.46 x2, 2.46-lib x2 -> 2.46, 2.46-lib
[C.]  #017  binutils-wrapper                  2.46 x2 -> 2.46
[C*]  #018  bluez                             5.86 x2, 5.87 x2, 5.87_fish-completions -> 5.86, 5.87 x2, 5.87_fish-completions
[U.]  #019  bottom                            0.14.7, 0.14.7-fish-completions -> 0.14.8, 0.14.8-fish-completions
[U.]  #020  breeze-icons                      6.28.0, 6.28.0-dev -> 6.29.0, 6.29.0-dev
[C.]  #021  brotli                            1.1.0-lib, 1.2.0 x2, 1.2.0-dev x2, 1.2.0-lib x5 -> 1.1.0-lib, 1.2.0, 1.2.0-dev, 1.2.0-lib x4
[C*]  #022  bzip2                             1.0.8 x6, 1.0.8-bin x2, 1.0.8-dev x2, 1.0.8-man -> 1.0.8 x5, 1.0.8-bin, 1.0.8-dev, 1.0.8-man
[C.]  #023  cairo                             1.18.4 x5, 1.18.4-dev x2 -> 1.18.4 x4, 1.18.4-dev
[C.]  #024  cdparanoia-iii                    10.2 x4 -> 10.2 x3
[C.]  #025  cjson                             1.7.19 x4 -> 1.7.19 x3
[C.]  #026  coreutils                         9.7, 9.11 x5 -> 9.7, 9.11 x4
[U*]  #027  cpupower                          6.18.44, 6.18.44_fish-completions -> 6.18.45, 6.18.45_fish-completions
[C.]  #028  cracklib                          2.10.3 x4 -> 2.10.3 x3
[C*]  #029  cryptsetup                        2.8.6 x4, 2.8.6-bin, 2.8.6-man -> 2.8.6 x3, 2.8.6-bin, 2.8.6-man
[C.]  #030  cups                              2.4.12-lib, 2.4.19, 2.4.19-dev, 2.4.19-lib x2, 2.4.19-man -> 2.4.12-lib, 2.4.19, 2.4.19-dev, 2.4.19-lib, 2.4.19-man
[C*]  #031  curl                              8.21.0 x5, 8.21.0-bin, 8.21.0-man -> 8.21.0 x4, 8.21.0-bin, 8.21.0-man
[C.]  #032  dav1d                             1.5.3 x4 -> 1.5.3 x3
[C.]  #033  db                                4.8.30 x5, 5.3.28 -> 4.8.30 x4, 5.3.28
[C*]  #034  dbus                              1, 1.14.10-lib, 1.16.2 x2, 1.16.2-dev x2, 1.16.2-doc, 1.16.2-lib x4, 1.16.2-man -> 1, 1.14.10-lib, 1.16.2, 1.16.2-dev, 1.16.2-doc, 1.16.2-lib x3, 1.16.2-man
[C*]  #035  dconf                             0.40.0-lib, 0.49.0, 0.49.0_fish-completions, 0.49.0-lib x4 -> 0.40.0-lib, 0.49.0, 0.49.0_fish-completions, 0.49.0-lib x3
[C.]  #036  dejavu-fonts-minimal              2.37 x5 -> 2.37 x4
[C.]  #037  dns-root-data                     2025-04-14 x6 -> 2025-04-14 x5
[C.]  #038  double-conversion                 3.4.0 x2, 3.4.0-dev -> 3.4.0, 3.4.0-dev
[C.]  #039  duktape                           2.7.0 x2 -> 2.7.0
[U.]  #040  electron                          41.10.3 -> 43.4.1
[U.]  #041  electron-unwrapped                41.10.3 -> 43.4.1
[C.]  #042  elfutils                          0.195 x4 -> 0.195 x3
[C.]  #043  ell                               0.83 x4 -> 0.83 x3
[U.]  #044  emacs-evil-ghostel                0.49.0 -> 0.50.0
[U.]  #045  emacs-ghostel                     0.49.0 -> 0.50.0
[C.]  #046  expand-response-params            <none> x4 -> <none> x2
[C.]  #047  expat                             2.7.1, 2.8.2 x5, 2.8.2-dev x2 -> 2.7.1, 2.8.2 x4, 2.8.2-dev
[U.]  #048  extra-cmake-modules               6.28.0 -> 6.29.0
[C.]  #049  fdk-aac                           2.0.3 x4 -> 2.0.3 x3
[C.]  #050  ffado                             2.4.9 x4 -> 2.4.9 x3
[C.]  #051  ffmpeg-headless                   8.1.2-data x3, 8.1.2-lib x3, 9.0-data x2, 9.0-lib x2 -> 8.1.2-data x2, 8.1.2-lib x2, 9.0-data x2, 9.0-lib x2
[C.]  #052  fftw-double                       3.3.11 x4 -> 3.3.11 x3
[C.]  #053  fftw-single                       3.3.11 x4 -> 3.3.11 x3
[C.]  #054  file                              5.45, 5.48 x4 -> 5.45, 5.48 x3
[C.]  #055  flac                              1.5.0 x4 -> 1.5.0 x3
[U.]  #056  flatpak                           1.18.0 -> 1.18.1
[C*]  #057  fontconfig                        2.16.2, 2.16.2-lib, 2.18.1, 2.18.1-lib, 2.18.2 x3, 2.18.2-bin x2, 2.18.2-dev x2, 2.18.2_fish-completions, 2.18.2-lib x3 -> 2.16.2, 2.16.2-lib, 2.18.1, 2.18.1-lib, 2.18.2 x2, 2.18.2-bin, 2.18.2-dev, 2.18.2_fish-completions, 2.18.2-lib x2
[U.]  #058  frameworkintegration              6.28.0 -> 6.29.0
[C.]  #059  freetype                          2.13.3, 2.14.3 x4, 2.14.3-dev x2 -> 2.13.3, 2.14.3 x3, 2.14.3-dev
[C.]  #060  fribidi                           1.0.16 x5, 1.0.16-dev -> 1.0.16 x4, 1.0.16-dev
[U.]  #061  fzf                               0.74.2, 0.74.2-fish-completions, 0.74.2-man -> 0.74.3, 0.74.3-fish-completions, 0.74.3-man
[C*]  #062  gawk                              5.4.1 x2, 5.4.1-info, 5.4.1-man -> 5.4.1, 5.4.1-info, 5.4.1-man
[C.]  #063  gcc                               14.3.0-lib, 14.3.0-libgcc, 15.2.0-lib, 15.2.0-libgcc, 15.3.0, 15.3.0-lib x4, 15.3.0-libgcc x4, 15.3.0-man, 16.2.0, 16.2.0-lib x2, 16.2.0-libgcc x2 -> 14.3.0-lib, 14.3.0-libgcc, 15.2.0-lib, 15.2.0-libgcc, 15.3.0, 15.3.0-lib x3, 15.3.0-libgcc x3, 15.3.0-man, 16.2.0, 16.2.0-lib, 16.2.0-libgcc
[C.]  #064  gdbm                              1.26-lib x5 -> 1.26-lib x4
[C.]  #065  gdk-pixbuf                        2.42.12, 2.44.6 x2, 2.44.7, 2.44.7-dev, 2.44.7-man -> 2.42.12, 2.44.6, 2.44.7, 2.44.7-dev, 2.44.7-man
[C.]  #066  gettext                           1.0 x4 -> 1.0 x3
[U.]  #067  gh                                2.97.0, 2.97.0-fish-completions -> 2.98.0, 2.98.0-fish-completions
[C.]  #068  giflib                            5.2.2, 6.1.3 x4 -> 5.2.2, 6.1.3 x3
[C.]  #069  glib                              2.84.4, 2.88.1 x2, 2.88.1-bin x2, 2.88.1-dev, 2.88.3 x2, 2.88.3-bin, 2.88.3-dev, 2.88.3-fish-completions -> 2.84.4, 2.88.1, 2.88.1-bin, 2.88.3 x2, 2.88.3-bin, 2.88.3-dev, 2.88.3-fish-completions
[C*]  #070  glibc                             2.40-66, 2.40-66-getent, 2.42-67 x5, 2.42-67-bin x3, 2.42-67-dev x2, 2.42-67-getent -> 2.40-66, 2.40-66-getent, 2.42-67 x4, 2.42-67-bin x2, 2.42-67-dev, 2.42-67-getent
[C.]  #071  glibc-iconv                       2.42 x2 -> 2.42
[C.]  #072  glibmm                            2.66.8 x4, 2.88.1 -> 2.66.8 x3, 2.88.1
[C.]  #073  glslang                           16.3.0, 16.4.0 -> 16.4.0
[C.]  #074  gmp-with-cxx                      6.3.0 x11, 6.3.0-dev -> 6.3.0 x9, 6.3.0-dev
[C*]  #075  gnugrep                           3.12 x4, 3.12_fish-completions, 3.12-info -> 3.12 x3, 3.12_fish-completions, 3.12-info
[C.]  #076  gnum4                             1.4.21 x4 -> 1.4.21 x3
[C*]  #077  gnused                            4.10 x4, 4.10_fish-completions, 4.10-info -> 4.10 x3, 4.10_fish-completions, 4.10-info
[C.]  #078  gnutls                            3.8.10, 3.8.13 x4 -> 3.8.10, 3.8.13 x3
[C.]  #079  gobject-introspection             1.84.0, 1.86.0 x2, 1.86.0-dev -> 1.84.0, 1.86.0, 1.86.0-dev
[C.]  #080  graphene                          1.10.8 x4 -> 1.10.8 x3
[C.]  #081  graphite2                         1.3.14, 1.3.15 x4, 1.3.15-dev x2 -> 1.3.14, 1.3.15 x3, 1.3.15-dev
[C.]  #082  grim                              1.5.0 x2 -> 1.5.0
[C.]  #083  gsettings-desktop-schemas         48.0, 50.1 x2 -> 48.0, 50.1
[C.]  #084  gst-plugins-base                  1.28.4, 1.28.5 x3 -> 1.28.4, 1.28.5 x2
[C.]  #085  gstreamer                         1.28.4, 1.28.5 x3 -> 1.28.4, 1.28.5 x2
[C.]  #086  gtest                             1.17.0 x4, 1.17.0-dev -> 1.17.0 x3, 1.17.0-dev
[C.]  #087  gtk+3                             3.24.49, 3.24.52 x2, 3.24.52-dev -> 3.24.49, 3.24.52, 3.24.52-dev
[C.]  #088  harfbuzz                          11.2.1, 13.2.1 x4, 13.2.1-dev x2 -> 11.2.1, 13.2.1 x3, 13.2.1-dev
[C.]  #089  hostname-debian                   3.25 x2, 3.25-man x2 -> 3.25, 3.25-man
[C*]  #090  hostname-hostname-debian          3.25 x2, 3.25_fish-completions -> 3.25, 3.25_fish-completions
[C.]  #091  hwdata                            0.408, 0.409, 0.410 x2 -> 0.408, 0.410 x2
[C*]  #092  hyprland                          0.56.0+date=2026-08-15_a1b9dc0, 0.56.0+date=2026-08-15_a1b9dc0-man, 0.56.2 -> 0.56.0+date=2026-08-22_45a79e5, 0.56.0+date=2026-08-22_45a79e5-man, 0.56.2
[U.]  #093  hyprutils                         0.14.0 x2, 0.14.0+date=2026-08-11_c157fe1, 0.14.0+date=2026-08-11_c157fe1-dev -> 0.14.1, 0.14.1+date=2026-08-16_6cf5041, 0.14.1+date=2026-08-16_6cf5041-dev
[C.]  #094  icu4c                             76.1 x2, 77.1, 78.3 x3, 78.3-dev -> 76.1 x2, 77.1, 78.3 x2, 78.3-dev
[C.]  #095  iniparser                         4.2.6 x2 -> 4.2.6
[U.]  #096  initrd-linux                      6.18.44 -> 6.18.45
[C.]  #097  iso-codes                         4.18.0, 4.20.1 x4 -> 4.18.0, 4.20.1 x3
[C.]  #098  jq                                1.8.2 x2, 1.8.2-bin x2, 1.8.2-fish-completions, 1.8.2-man -> 1.8.2, 1.8.2-bin, 1.8.2-fish-completions, 1.8.2-man
[C.]  #099  json-c                            0.18 x4 -> 0.18 x3
[C.]  #100  json-glib                         1.10.6, 1.10.8 x2 -> 1.10.6, 1.10.8
[U.]  #101  karchive                          6.28.0 -> 6.29.0
[U.]  #102  kauth                             6.28.0 -> 6.29.0
[C*]  #103  kbd                               2.8.0-unstable-2025-08-12, 2.9.0 x4, 2.9.0-man -> 2.8.0-unstable-2025-08-12, 2.9.0 x3, 2.9.0-man
[U.]  #104  kbookmarks                        6.28.0 -> 6.29.0
[U.]  #105  kcmutils                          6.28.0 -> 6.29.0
[U.]  #106  kcodecs                           6.28.0 -> 6.29.0
[U.]  #107  kcolorscheme                      6.28.0 -> 6.29.0
[U.]  #108  kcompletion                       6.28.0 -> 6.29.0
[U.]  #109  kconfig                           6.28.0 -> 6.29.0
[U.]  #110  kconfigwidgets                    6.28.0 -> 6.29.0
[U.]  #111  kcoreaddons                       6.28.0 -> 6.29.0
[U.]  #112  kcrash                            6.28.0 -> 6.29.0
[U.]  #113  kdbusaddons                       6.28.0 -> 6.29.0
[U.]  #114  kdoctools                         6.28.0 -> 6.29.0
[C*]  #115  kexec-tools                       2.0.31, 2.0.32 x4, 2.0.32_fish-completions -> 2.0.31, 2.0.32 x3, 2.0.32_fish-completions
[C.]  #116  keyutils                          1.6.3-lib x5 -> 1.6.3-lib x4
[U.]  #117  kglobalaccel                      6.28.0 -> 6.29.0
[U.]  #118  kguiaddons                        6.28.0 -> 6.29.0
[U.]  #119  ki18n                             6.28.0 -> 6.29.0
[U.]  #120  kiconthemes                       6.28.0 -> 6.29.0
[U.]  #121  kio                               6.28.0 -> 6.29.0
[U.]  #122  kirigami                          6.28.0 -> 6.29.0
[U.]  #123  kitemmodels                       6.28.0 -> 6.29.0
[U.]  #124  kitemviews                        6.28.0 -> 6.29.0
[U.]  #125  kjobwidgets                       6.28.0 -> 6.29.0
[C*]  #126  kmod                              31 x5, 31-lib x5, 31-man -> 31 x4, 31-lib x4, 31-man
[U.]  #127  knewstuff                         6.28.0 -> 6.29.0
[U.]  #128  knotifications                    6.28.0 -> 6.29.0
[U.]  #129  kpackage                          6.28.0 -> 6.29.0
[C.]  #130  krb5                              1.22.2-lib x5 -> 1.22.2-lib x4
[U.]  #131  kservice                          6.28.0 -> 6.29.0
[U.]  #132  ktextwidgets                      6.28.0 -> 6.29.0
[U.]  #133  kwallet                           6.28.0 -> 6.29.0
[U.]  #134  kwidgetsaddons                    6.28.0 -> 6.29.0
[U.]  #135  kwindowsystem                     6.28.0 -> 6.29.0
[U.]  #136  kxmlgui                           6.28.0 -> 6.29.0
[C.]  #137  lame                              3.100-lib x4 -> 3.100-lib x3
[C.]  #138  lcms2                             2.17, 2.19.1 x4 -> 2.17, 2.19.1 x3
[C.]  #139  ldacbt                            2.0.72 x4 -> 2.0.72 x3
[C.]  #140  lerc                              4.0.0, 4.1.0, 4.1.1, 4.2.0 x2, 4.2.0-dev -> 4.0.0, 4.1.0, 4.2.0 x2, 4.2.0-dev
[C.]  #141  libao                             1.2.2 x4 -> 1.2.2 x3
[C.]  #142  libaom                            3.12.1 x4 -> 3.12.1 x3
[C.]  #143  libapparmor                       5.0.0, 5.0.2 x3 -> 5.0.0, 5.0.2 x2
[C.]  #144  libarchive                        3.8.8-lib x4 -> 3.8.8-lib x3
[C.]  #145  libass                            0.17.4 x4 -> 0.17.4 x3
[C.]  #146  libavc1394                        0.5.4 x4 -> 0.5.4 x3

_… diff truncated (443 lines total); see the `closure-diff-tuathaan` artifact for the full output._

</details>

