### PR TITLE
Auto update 2026-08-30

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787400831,
-        "narHash": "sha256-H3MEkFDZf+UH+QrVgW8TdKrssPFltF8fBg/rh0J1zIc=",
+        "lastModified": 1787574976,
+        "narHash": "sha256-8Egg3kenaiXNS4NNCI6ptJpwr4du00I5UCdmwGMvShg=",
         "owner": "hyprwm",
         "repo": "aquamarine",
-        "rev": "7ce889cb78b97979b83a4648509fc3ef405c3286",
+        "rev": "cf056dcfefc5282133928b81dcaf1993d33c4ea3",
         "type": "github"
       },
       "original": {
@@ -67,11 +67,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1785782307,
-        "narHash": "sha256-MPaRdVkf6zZP5fCPxYCi8Dr4pZzgmXzg8T9nVEbp3Mw=",
+        "lastModified": 1787326676,
+        "narHash": "sha256-lWhBbBvC05/xwivKBBiM2YNizpmgqCgyOIzomvRuwxs=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "2c71e194474d13de031d729b729c968ddbe3507f",
+        "rev": "692f7e9ef2ece8125b466f66f2af532b3edaed0d",
         "type": "github"
       },
       "original": {
@@ -261,11 +261,11 @@
         "nixpkgs-lib": "nixpkgs-lib_3"
       },
       "locked": {
-        "lastModified": 1785627969,
-        "narHash": "sha256-4dtXQk/NMePegK/nWp5NSeuZKLATItOq61lpEvmXqGw=",
+        "lastModified": 1787559586,
+        "narHash": "sha256-onL0VLf9vPllmT0H/OlURIU5r5t5WIEl7t4tVNKT0Nw=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "427bf4bd9435fdf21321c8cc628c24efc14c0f7a",
+        "rev": "9d0d87172c374f89da73c1cfe6d81ae62feac1f1",
         "type": "github"
       },
       "original": {
@@ -372,11 +372,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1787144466,
-        "narHash": "sha256-HHfv2/HkNSKbbSyU9iD/g8lbP6r4tl33sSw1W4rXCk0=",
+        "lastModified": 1788044418,
+        "narHash": "sha256-cmOd3iGoE140M2GidgQMQbyxHZ4dT7C0QZq2+CrXQyA=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "0471accf8d0a8210b31d947497d179ecc99e0021",
+        "rev": "dc3f0cfde2050172abf6c3cdb684f735c15a57c5",
         "type": "github"
       },
       "original": {
@@ -392,11 +392,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787379775,
-        "narHash": "sha256-XL2qfqmocfsvuEGyomZg4nOZfkuSe8vZtrOX99I+b6I=",
+        "lastModified": 1787797243,
+        "narHash": "sha256-8+Q7NOB7RPajRjA4pbCDLzqH+MTjnG9x6LUPLfL2joA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ec1a8fdf74ed3f276148ee106299a2ba0e65d51f",
+        "rev": "99c9ec63390f1d8c14d95d9e8b17cc29cfbd4e11",
         "type": "github"
       },
       "original": {
@@ -536,11 +536,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1787436444,
-        "narHash": "sha256-iLWbH4BQ7x/x7oGGwlj/OarJjrmuisOFDZgc2rar9tw=",
+        "lastModified": 1788037247,
+        "narHash": "sha256-EbOTegP9NxRMmuw59MZxXkEw5QGE9jY11N/DQtiAAXg=",
         "owner": "hyprwm",
         "repo": "hyprland",
-        "rev": "45a79e5e84136025a5da1de34c9c65fe00cb813e",
+        "rev": "e43eaaac6b9ff7987609244f920d978e2b6598c3",
         "type": "github"
       },
       "original": {
@@ -633,11 +633,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787071735,
-        "narHash": "sha256-1DDAvYcJ7q1x4JdhoXU+PTQWxAUcv53gSNmmi9pBVuU=",
+        "lastModified": 1788037253,
+        "narHash": "sha256-QSGOM0IFpp45DwmtIwcih8+kKuSgAoQal9QkVVSRNew=",
         "owner": "hyprwm",
         "repo": "hyprland-plugins",
-        "rev": "83ce4b2a70d3c1a6ed8dc6db7f1fac17db2215b1",
+        "rev": "67c3a4c019f223c27b5bdc6bb656ce891a60861a",
         "type": "github"
       },
       "original": {
@@ -1063,11 +1063,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786958661,
-        "narHash": "sha256-DAH84NNJezuk7M4WfAZtLQzJnofpXJFZFVoTPgCyUC0=",
+        "lastModified": 1787658383,
+        "narHash": "sha256-I+zCjwAtkmgnet+08H+7HV8qJjf6BoFMYsX/8lMiW/s=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "b1b7d87faa06649f7c72666107bac2c6e6459c23",
+        "rev": "69cf334f9dbc11213c6228c97e9b32924d51443f",
         "type": "github"
       },
       "original": {
@@ -1262,11 +1262,11 @@
     },
     "nixpkgs_10": {
       "locked": {
-        "lastModified": 1787360063,
-        "narHash": "sha256-dt4WdcvsA8/RCe+VZZwqU0X+XMM3wBbGCWA0/sFWzGo=",
+        "lastModified": 1787900134,
+        "narHash": "sha256-VYXO0XZlgj06dxJZRhrD3WoSsvq/c7+/Akyoa22pefw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2c423e03bbafcff28bfadc6781a4a8257f205cb5",
+        "rev": "83199d0d373dd3ac2b9a1996b1d0263f76ab7a4c",
         "type": "github"
       },
       "original": {
@@ -1307,11 +1307,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1787360063,
-        "narHash": "sha256-dt4WdcvsA8/RCe+VZZwqU0X+XMM3wBbGCWA0/sFWzGo=",
+        "lastModified": 1787736819,
+        "narHash": "sha256-cV5xEJJK3BvhU8rEd4mC9UsmDi5qscv/kzGPhBRC5WA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2c423e03bbafcff28bfadc6781a4a8257f205cb5",
+        "rev": "9fbb54b33e91ee4ca368e35a78e0613c720600b3",
         "type": "github"
       },
       "original": {
@@ -1403,11 +1403,11 @@
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1787360063,
-        "narHash": "sha256-dt4WdcvsA8/RCe+VZZwqU0X+XMM3wBbGCWA0/sFWzGo=",
+        "lastModified": 1787900134,
+        "narHash": "sha256-VYXO0XZlgj06dxJZRhrD3WoSsvq/c7+/Akyoa22pefw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2c423e03bbafcff28bfadc6781a4a8257f205cb5",
+        "rev": "83199d0d373dd3ac2b9a1996b1d0263f76ab7a4c",
         "type": "github"
       },
       "original": {
@@ -1423,11 +1423,11 @@
         "nixpkgs": "nixpkgs_10"
       },
       "locked": {
-        "lastModified": 1787472636,
-        "narHash": "sha256-5i0/tlYUoIfUFQMQweVzUSrCaYVh2RTWx2qjFKSJAHk=",
+        "lastModified": 1788074645,
+        "narHash": "sha256-+W1i5yea1QYjo6SJ/xptZvNUZ6IB4XOlgHVpdn7ELYU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f6c28426699e4ba46004a5219dfd74e039ce9bf1",
+        "rev": "05006ef015734ea09be9445c8849ea5261f566ff",
         "type": "github"
       },
       "original": {
@@ -1468,11 +1468,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784288435,
-        "narHash": "sha256-ReRHaLgr/uVqdD8afFSn+myXIfpHeOhP0yYe0TJqAA8=",
+        "lastModified": 1787424939,
+        "narHash": "sha256-O2tBn84NNuHrnqNVxx/XqsXwfYvS1YwBh+7CBnbCYsk=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "43b3c1ab9d40fb1dbb008f451988a91e375825e9",
+        "rev": "809414f0cdadf82cf11b06c2b29ba9b3168b3297",
         "type": "github"
       },
       "original": {
@@ -1490,11 +1490,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784288435,
-        "narHash": "sha256-ReRHaLgr/uVqdD8afFSn+myXIfpHeOhP0yYe0TJqAA8=",
+        "lastModified": 1787424939,
+        "narHash": "sha256-O2tBn84NNuHrnqNVxx/XqsXwfYvS1YwBh+7CBnbCYsk=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "43b3c1ab9d40fb1dbb008f451988a91e375825e9",
+        "rev": "809414f0cdadf82cf11b06c2b29ba9b3168b3297",
         "type": "github"
       },
       "original": {
@@ -1618,11 +1618,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787454509,
-        "narHash": "sha256-r4LDUF+zmJnkftvCVkCrUhSJazsf6EVJF+V2l4/MYbI=",
+        "lastModified": 1787993548,
+        "narHash": "sha256-+IAEnmmx5YIhUWo0lp15jLLHchnXo5yKgWsi6C6Cf+0=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "f60c1b57ff805a46b5175c76fc981fb4f81efbcc",
+        "rev": "996e9b0b019a4a9eb9e9a5641aefa06d801b5895",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automatic flake update on 2026-08-30.

Review the per-host package changes below before merging.

## Input changes

```
unpacking 'github:nix-community/disko/de5708739256238fb912c62f03988815db89ec9a' into the Git cache...
unpacking 'github:Gako358/emacs-flake/186b049c2e094bb1195eae4206eeefa52503d015' into the Git cache...
unpacking 'github:hercules-ci/flake-parts/9d0d87172c374f89da73c1cfe6d81ae62feac1f1' into the Git cache...
unpacking 'github:nixos/nixos-hardware/dc3f0cfde2050172abf6c3cdb684f735c15a57c5' into the Git cache...
unpacking 'github:nix-community/home-manager/99c9ec63390f1d8c14d95d9e8b17cc29cfbd4e11' into the Git cache...
unpacking 'github:hyprwm/hypridle/aa958ed7ad4863860b93ecd7189419e193bfae2c' into the Git cache...
unpacking 'github:hyprwm/hyprland/e43eaaac6b9ff7987609244f920d978e2b6598c3' into the Git cache...
unpacking 'github:hyprwm/contrib/57baf317e5196a8286b80976771ef55febad8660' into the Git cache...
unpacking 'github:hyprwm/hyprland-plugins/67c3a4c019f223c27b5bdc6bb656ce891a60861a' into the Git cache...
unpacking 'github:hyprwm/hyprpaper/39029bdfda857a5ea60340a427681893d12d4892' into the Git cache...
unpacking 'github:nix-community/impermanence/7b1d382faf603b6d264f58627330f9faa5cba149' into the Git cache...
unpacking 'github:vic/import-tree/4ebb10ae17d5f1ad366e7aef5b92cb8eecf24f69' into the Git cache...
unpacking 'github:nix-community/lanzaboote/69cf334f9dbc11213c6228c97e9b32924d51443f' into the Git cache...
unpacking 'github:misterio77/nix-colors/b01f024090d2c4fc3152cd0cf12027a7b8453ba1' into the Git cache...
unpacking 'github:nixos/nixpkgs/83199d0d373dd3ac2b9a1996b1d0263f76ab7a4c' into the Git cache...
unpacking 'github:nix-community/NUR/05006ef015734ea09be9445c8849ea5261f566ff' into the Git cache...
unpacking 'github:nix-community/plasma-manager/a19a2a029fa180911bd89c554dca1616e10f4c1d' into the Git cache...
unpacking 'github:cachix/pre-commit-hooks.nix/809414f0cdadf82cf11b06c2b29ba9b3168b3297' into the Git cache...
unpacking 'github:oxalica/rust-overlay/996e9b0b019a4a9eb9e9a5641aefa06d801b5895' into the Git cache...
unpacking 'github:gako358/scram/19595501de0215f989be7eb27cb58fdf8ab27c75' into the Git cache...
unpacking 'github:Mic92/sops-nix/a8627b21b9107c5711c96b84f32a9a4b3d45295f' into the Git cache...
unpacking 'github:youwen5/zen-browser-flake/20195bc99e82b02abe82bb81ac366ae81c67dc5a' into the Git cache...
warning: updating lock file "/home/runner/work/dotfiles/dotfiles/flake.lock":
• Updated input 'flake-parts':
    'github:hercules-ci/flake-parts/427bf4bd9435fdf21321c8cc628c24efc14c0f7a?narHash=sha256-4dtXQk/NMePegK/nWp5NSeuZKLATItOq61lpEvmXqGw%3D' (2026-08-01)
  → 'github:hercules-ci/flake-parts/9d0d87172c374f89da73c1cfe6d81ae62feac1f1?narHash=sha256-onL0VLf9vPllmT0H/OlURIU5r5t5WIEl7t4tVNKT0Nw%3D' (2026-08-24)
• Updated input 'hardware':
    'github:nixos/nixos-hardware/0471accf8d0a8210b31d947497d179ecc99e0021?narHash=sha256-HHfv2/HkNSKbbSyU9iD/g8lbP6r4tl33sSw1W4rXCk0%3D' (2026-08-19)
  → 'github:nixos/nixos-hardware/dc3f0cfde2050172abf6c3cdb684f735c15a57c5?narHash=sha256-cmOd3iGoE140M2GidgQMQbyxHZ4dT7C0QZq2%2BCrXQyA%3D' (2026-08-29)
• Updated input 'home-manager':
    'github:nix-community/home-manager/ec1a8fdf74ed3f276148ee106299a2ba0e65d51f?narHash=sha256-XL2qfqmocfsvuEGyomZg4nOZfkuSe8vZtrOX99I%2Bb6I%3D' (2026-08-22)
  → 'github:nix-community/home-manager/99c9ec63390f1d8c14d95d9e8b17cc29cfbd4e11?narHash=sha256-8%2BQ7NOB7RPajRjA4pbCDLzqH%2BMTjnG9x6LUPLfL2joA%3D' (2026-08-27)
• Updated input 'hyprland':
    'github:hyprwm/hyprland/45a79e5e84136025a5da1de34c9c65fe00cb813e?narHash=sha256-iLWbH4BQ7x/x7oGGwlj/OarJjrmuisOFDZgc2rar9tw%3D' (2026-08-22)
  → 'github:hyprwm/hyprland/e43eaaac6b9ff7987609244f920d978e2b6598c3?narHash=sha256-EbOTegP9NxRMmuw59MZxXkEw5QGE9jY11N/DQtiAAXg%3D' (2026-08-29)
• Updated input 'hyprland/aquamarine':
    'github:hyprwm/aquamarine/7ce889cb78b97979b83a4648509fc3ef405c3286?narHash=sha256-H3MEkFDZf%2BUH%2BQrVgW8TdKrssPFltF8fBg/rh0J1zIc%3D' (2026-08-22)
  → 'github:hyprwm/aquamarine/cf056dcfefc5282133928b81dcaf1993d33c4ea3?narHash=sha256-8Egg3kenaiXNS4NNCI6ptJpwr4du00I5UCdmwGMvShg%3D' (2026-08-24)
• Updated input 'hyprland/nixpkgs':
    'github:NixOS/nixpkgs/2c423e03bbafcff28bfadc6781a4a8257f205cb5?narHash=sha256-dt4WdcvsA8/RCe%2BVZZwqU0X%2BXMM3wBbGCWA0/sFWzGo%3D' (2026-08-22)
  → 'github:NixOS/nixpkgs/9fbb54b33e91ee4ca368e35a78e0613c720600b3?narHash=sha256-cV5xEJJK3BvhU8rEd4mC9UsmDi5qscv/kzGPhBRC5WA%3D' (2026-08-26)
• Updated input 'hyprland/pre-commit-hooks':
    'github:cachix/git-hooks.nix/43b3c1ab9d40fb1dbb008f451988a91e375825e9?narHash=sha256-ReRHaLgr/uVqdD8afFSn%2BmyXIfpHeOhP0yYe0TJqAA8%3D' (2026-07-17)
  → 'github:cachix/git-hooks.nix/809414f0cdadf82cf11b06c2b29ba9b3168b3297?narHash=sha256-O2tBn84NNuHrnqNVxx/XqsXwfYvS1YwBh%2B7CBnbCYsk%3D' (2026-08-22)
• Updated input 'hyprland-plugins':
    'github:hyprwm/hyprland-plugins/83ce4b2a70d3c1a6ed8dc6db7f1fac17db2215b1?narHash=sha256-1DDAvYcJ7q1x4JdhoXU%2BPTQWxAUcv53gSNmmi9pBVuU%3D' (2026-08-18)
  → 'github:hyprwm/hyprland-plugins/67c3a4c019f223c27b5bdc6bb656ce891a60861a?narHash=sha256-QSGOM0IFpp45DwmtIwcih8%2BkKuSgAoQal9QkVVSRNew%3D' (2026-08-29)
• Updated input 'lanzaboote':
    'github:nix-community/lanzaboote/b1b7d87faa06649f7c72666107bac2c6e6459c23?narHash=sha256-DAH84NNJezuk7M4WfAZtLQzJnofpXJFZFVoTPgCyUC0%3D' (2026-08-17)
  → 'github:nix-community/lanzaboote/69cf334f9dbc11213c6228c97e9b32924d51443f?narHash=sha256-I%2BzCjwAtkmgnet%2B08H%2B7HV8qJjf6BoFMYsX/8lMiW/s%3D' (2026-08-25)
• Updated input 'lanzaboote/crane':
    'github:ipetkov/crane/2c71e194474d13de031d729b729c968ddbe3507f?narHash=sha256-MPaRdVkf6zZP5fCPxYCi8Dr4pZzgmXzg8T9nVEbp3Mw%3D' (2026-08-03)
  → 'github:ipetkov/crane/692f7e9ef2ece8125b466f66f2af532b3edaed0d?narHash=sha256-lWhBbBvC05/xwivKBBiM2YNizpmgqCgyOIzomvRuwxs%3D' (2026-08-21)
• Updated input 'lanzaboote/pre-commit':
    'github:cachix/git-hooks.nix/43b3c1ab9d40fb1dbb008f451988a91e375825e9?narHash=sha256-ReRHaLgr/uVqdD8afFSn%2BmyXIfpHeOhP0yYe0TJqAA8%3D' (2026-07-17)
  → 'github:cachix/git-hooks.nix/809414f0cdadf82cf11b06c2b29ba9b3168b3297?narHash=sha256-O2tBn84NNuHrnqNVxx/XqsXwfYvS1YwBh%2B7CBnbCYsk%3D' (2026-08-22)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/2c423e03bbafcff28bfadc6781a4a8257f205cb5?narHash=sha256-dt4WdcvsA8/RCe%2BVZZwqU0X%2BXMM3wBbGCWA0/sFWzGo%3D' (2026-08-22)
  → 'github:nixos/nixpkgs/83199d0d373dd3ac2b9a1996b1d0263f76ab7a4c?narHash=sha256-VYXO0XZlgj06dxJZRhrD3WoSsvq/c7%2B/Akyoa22pefw%3D' (2026-08-28)
• Updated input 'nur':
    'github:nix-community/NUR/f6c28426699e4ba46004a5219dfd74e039ce9bf1?narHash=sha256-5i0/tlYUoIfUFQMQweVzUSrCaYVh2RTWx2qjFKSJAHk%3D' (2026-08-23)
  → 'github:nix-community/NUR/05006ef015734ea09be9445c8849ea5261f566ff?narHash=sha256-%2BW1i5yea1QYjo6SJ/xptZvNUZ6IB4XOlgHVpdn7ELYU%3D' (2026-08-30)
• Updated input 'nur/nixpkgs':
    'github:nixos/nixpkgs/2c423e03bbafcff28bfadc6781a4a8257f205cb5?narHash=sha256-dt4WdcvsA8/RCe%2BVZZwqU0X%2BXMM3wBbGCWA0/sFWzGo%3D' (2026-08-22)
  → 'github:nixos/nixpkgs/83199d0d373dd3ac2b9a1996b1d0263f76ab7a4c?narHash=sha256-VYXO0XZlgj06dxJZRhrD3WoSsvq/c7%2B/Akyoa22pefw%3D' (2026-08-28)
• Updated input 'rust-overlay':
    'github:oxalica/rust-overlay/f60c1b57ff805a46b5175c76fc981fb4f81efbcc?narHash=sha256-r4LDUF%2BzmJnkftvCVkCrUhSJazsf6EVJF%2BV2l4/MYbI%3D' (2026-08-23)
  → 'github:oxalica/rust-overlay/996e9b0b019a4a9eb9e9a5641aefa06d801b5895?narHash=sha256-%2BIAEnmmx5YIhUWo0lp15jLLHchnXo5yKgWsi6C6Cf%2B0%3D' (2026-08-29)
```

## Per-host package diff

<details><summary><b>aanallein</b></summary>

```
<<< result-old
>>> result-new
Version changes:
[C.]  #001  audit                             4.1.4-lib, 4.2.1-lib x2 -> 4.1.4-lib, 4.2.1-lib
[U*]  #002  cachix                            1.11.1-bin -> 1.12.0-bin
[U.]  #003  chromaprint                       1.6.0 -> 1.6.1
[U*]  #004  cpupower                          6.18.45, 6.18.45_fish-completions -> 6.18.47, 6.18.47_fish-completions
[C.]  #005  cracklib                          2.10.3 x2 -> 2.10.3
[U.]  #006  crun                              1.27.1 -> 1.29.1
[U*]  #007  cryptsetup                        2.8.6 x2, 2.8.6-bin, 2.8.6-man -> 2.8.7, 2.8.7-bin, 2.8.7-man
[C.]  #008  db                                4.8.30 x3, 5.3.28 -> 4.8.30 x2, 5.3.28
[U.]  #009  elementary-icon-theme             8.2.0-unstable-2026-07-06 -> 9.0.0
[C.]  #010  expat                             2.8.2 x3, 2.8.2-dev -> 2.8.2, 2.8.3 x2, 2.8.3-dev
[U.]  #011  fd                                10.4.2, 10.4.2-fish-completions -> 10.5.0, 10.5.0-fish-completions
[U.]  #012  ffmpeg-headless                   9.0-data x2, 9.0-lib x2 -> 9.0.1-data x2, 9.0.1-lib x2
[U*]  #013  getent-glibc                      2.42-67 -> 2.42-84
[C*]  #014  glibc                             2.42-67 x3, 2.42-67-bin, 2.42-67-dev, 2.42-67-getent -> 2.42-67, 2.42-84 x2, 2.42-84-bin, 2.42-84-dev, 2.42-84-getent
[U*]  #015  glibc-locales                     2.42-67 -> 2.42-84
[U.]  #016  gst-plugins-bad                   1.28.5 -> 1.28.6
[U.]  #017  gst-plugins-base                  1.28.5 x2 -> 1.28.6 x2
[U.]  #018  gst-plugins-good                  1.28.5 -> 1.28.6
[U.]  #019  gstreamer                         1.28.5 x2 -> 1.28.6 x2
[U.]  #020  initrd-linux                      6.18.45 -> 6.18.47
[C*]  #021  iproute2                          7.1.0, 7.1.0_fish-completions -> 7.1.0, 7.1.0-man
[C.]  #022  jemalloc                          5.3.1 x2 -> 5.3.1
[C*]  #023  kbd                               2.9.0 x2, 2.9.0-man -> 2.9.0, 2.9.0-man
[C*]  #024  kexec-tools                       2.0.32 x2, 2.0.32_fish-completions -> 2.0.32, 2.0.32_fish-completions
[C.]  #025  libapparmor                       5.0.2 x2 -> 5.0.2
[U.]  #026  libarchive                        3.8.8-lib x2 -> 3.8.9-lib
[U.]  #027  libblake3                         1.8.5 -> 1.8.6
[C.]  #028  libbpf                            1.7.0 x2 -> 1.7.0
[U.]  #029  libcamera                         0.7.0 x2 -> 0.7.2 x2
[C.]  #030  libcap-ng                         0.9.3 x3 -> 0.9.3 x2
[C.]  #031  libcbor                           0.14.0 x3 -> 0.14.0 x2
[C.]  #032  libffi                            3.7.0, 3.7.1 x2, 3.7.1-dev -> 3.7.0, 3.8.0 x2, 3.8.0-dev
[C.]  #033  libfido2                          1.17.0 x3 -> 1.17.0 x2
[C.]  #034  libgcrypt                         1.12.2-lib x2 -> 1.12.2-lib
[C.]  #035  libgpg-error                      1.61 x2 -> 1.61
[C.]  #036  libmicrohttpd                     1.0.6 x2 -> 1.0.6
[U.]  #037  libpq                             18.4 -> 18.6
[C.]  #038  libpwquality                      1.4.5-lib x2 -> 1.4.5-lib
[C.]  #039  libseccomp                        2.6.1-lib x2 -> 2.6.1-lib
[U.]  #040  libsodium                         1.0.22-unstable-2026-07-08 -> 1.0.22-unstable-2026-07-31
[C.]  #041  libtpms                           0.10.2-unstable-2026-05-06 x2 -> 0.10.2-unstable-2026-05-06
[C.]  #042  libyuv                            1908 -> 1908 x2
[U.]  #043  linux                             6.18.45, 6.18.45-modules x2 -> 6.18.47, 6.18.47-modules x2
[C*]  #044  linux-pam                         1.7.2 x3, 1.7.2-doc, 1.7.2-man -> 1.7.2 x2, 1.7.2-doc, 1.7.2-man
[C*]  #045  lvm2                              2.03.41, 2.03.41-bin, 2.03.41-lib x2, 2.03.41-man, 2.03.41-scripts -> 2.03.41, 2.03.41-bin, 2.03.41-lib, 2.03.41-man, 2.03.41-scripts
[C.]  #046  lz4                               1.10.0-lib x2 -> 1.10.0-lib
[C.]  #047  nghttp2                           1.69.0-lib x3 -> 1.69.0-lib, 1.70.0-lib x2
[U.]  #048  nixos-system-aanallein            26.11.20260822.2c423e0 -> 26.11.20260828.83199d0
[U.]  #049  nspr                              4.39 -> 4.40
[C*]  #050  pcsclite                          2.4.1, 2.4.1-doc, 2.4.1-lib x3, 2.4.1-man -> 2.4.1, 2.4.1-doc, 2.4.1-lib x2, 2.4.1-man
[C*]  #051  perl                              5.42.0 x2, 5.42.0-env x3, 5.42.0-man -> 5.42.0, 5.42.3, 5.42.3-env x3, 5.42.3-man
[C.]  #052  perl5.42.0-Authen-SASL            2.1900 x2 -> 2.1900
[C.]  #053  perl5.42.0-CGI                    4.59 x2 -> 4.59
[C.]  #054  perl5.42.0-CGI-Fast               2.16 x2 -> 2.16
[C.]  #055  perl5.42.0-Clone                  0.46 x2 -> 0.46
[C.]  #056  perl5.42.0-Compress-Raw-Bzip2     2.218 x2 -> 2.218
[C.]  #057  perl5.42.0-Compress-Raw-Zlib      2.222 x2 -> 2.222
[C.]  #058  perl5.42.0-Crypt-URandom          0.55 x2 -> 0.55
[C.]  #059  perl5.42.0-Digest-HMAC            1.05 x2 -> 1.05
[C.]  #060  perl5.42.0-Encode-Locale          1.05 x2 -> 1.05
[C.]  #061  perl5.42.0-FCGI                   0.82 x2 -> 0.82
[C.]  #062  perl5.42.0-FCGI-ProcManager       0.28 x2 -> 0.28
[C.]  #063  perl5.42.0-File-Listing           6.16 x2 -> 6.16
[C.]  #064  perl5.42.0-HTML-Parser            3.85 x2 -> 3.85
[C.]  #065  perl5.42.0-HTML-TagCloud          0.38 x2 -> 0.38
[C.]  #066  perl5.42.0-HTML-Tagset            3.20 x2 -> 3.20
[C.]  #067  perl5.42.0-HTTP-CookieJar         0.014 x2 -> 0.014
[C.]  #068  perl5.42.0-HTTP-Cookies           6.10 x2 -> 6.10
[C.]  #069  perl5.42.0-HTTP-Daemon            6.17 x2 -> 6.17
[C.]  #070  perl5.42.0-HTTP-Date              6.06 x2 -> 6.06
[C.]  #071  perl5.42.0-HTTP-Message           7.02 x2 -> 7.02
[C.]  #072  perl5.42.0-HTTP-Negotiate         6.01 x2 -> 6.01
[C.]  #073  perl5.42.0-IO-Compress            2.221 x2 -> 2.221
[C.]  #074  perl5.42.0-IO-HTML                1.004 x2 -> 1.004
[C.]  #075  perl5.42.0-IO-Socket-SSL          2.083 x2 -> 2.083
[C.]  #076  perl5.42.0-LWP-MediaTypes         6.04 x2 -> 6.04
[C.]  #077  perl5.42.0-Mozilla-CA             20230821 x2 -> 20230821
[C.]  #078  perl5.42.0-Net-HTTP               6.23 x2 -> 6.23
[C.]  #079  perl5.42.0-Net-SMTP-SSL           1.04 x2 -> 1.04
[C.]  #080  perl5.42.0-Net-SSLeay             1.92 x2 -> 1.92
[C.]  #081  perl5.42.0-TermReadKey            2.38 x2 -> 2.38
[C.]  #082  perl5.42.0-Test-Fatal             0.017 x2 -> 0.017
[C.]  #083  perl5.42.0-Test-Needs             0.002010 x2 -> 0.002010
[C.]  #084  perl5.42.0-Test-RequiresInternet  0.05 x2 -> 0.05
[C.]  #085  perl5.42.0-TimeDate               2.33 x2 -> 2.33
[C.]  #086  perl5.42.0-Try-Tiny               0.31 x2 -> 0.31
[C.]  #087  perl5.42.0-URI                    5.21 x2 -> 5.21
[C.]  #088  perl5.42.0-WWW-RobotRules         6.02 x2 -> 6.02
[C.]  #089  perl5.42.0-libnet                 3.15 x2 -> 3.15
[C.]  #090  perl5.42.0-libwww-perl            6.83 x2 -> 6.83
[U*]  #091  procps                            4.0.6, 4.0.6-doc, 4.0.6-man -> 4.0.7, 4.0.7-doc, 4.0.7-man
[C.]  #092  publicsuffix-list                 0-unstable-2026-06-24, 0-unstable-2026-07-25 x2 -> 0-unstable-2026-06-24, 0-unstable-2026-08-14 x2
[C.]  #093  qrencode                          4.1.1 x2, 4.1.1-bin -> 4.1.1, 4.1.1-bin
[U.]  #094  qtbase                            6.11.1, 6.11.1-dev -> 6.11.2, 6.11.2-dev
[U.]  #095  qtsvg                             6.11.1, 6.11.1-dev -> 6.11.2, 6.11.2-dev
[U.]  #096  qttranslations                    6.11.1 -> 6.11.2
[U*]  #097  rsync                             3.4.4, 3.4.4_fish-completions -> 3.5.0, 3.5.0_fish-completions
[U*]  #098  shadow                            4.20.0, 4.20.0-man, 4.20.0-su -> 4.20.2, 4.20.2-man, 4.20.2-su
[U*]  #099  strace                            7.1, 7.1-man -> 7.2, 7.2-man
[C*]  #100  systemd                           <none>, 261.1 x2, 261.1-dev, 261.1-man -> <none>, 261.2, 261.2-dev, 261.2-man
[U.]  #101  systemd-minimal                   261.1 x2 -> 261.2 x2
[C.]  #102  systemd-minimal-libs              261, 261.1 x2, 261.1-dev -> 261, 261.2 x2, 261.2-dev
[U*]  #103  texinfo-interactive               7.2, 7.2_fish-completions -> 7.3, 7.3_fish-completions
[C.]  #104  tpm2-tss                          4.2.0 x2 -> 4.2.0
[U.]  #105  unbound                           1.25.2-lib x2 -> 1.26.0-lib x2
[U.]  #106  zvbi                              0.2.44 x2 -> 0.2.45 x2
Added packages:
[A.]  #01  perl5.42.3-Authen-SASL                2.1900
[A.]  #02  perl5.42.3-CGI                        4.59
[A.]  #03  perl5.42.3-CGI-Fast                   2.16
[A.]  #04  perl5.42.3-Cairo                      1.109
[A.]  #05  perl5.42.3-Cairo-GObject              1.005
[A.]  #06  perl5.42.3-Chipcard-PCSC              1.4.16
[A.]  #07  perl5.42.3-Clone                      0.46
[A.]  #08  perl5.42.3-Compress-Raw-Bzip2         2.218
[A.]  #09  perl5.42.3-Compress-Raw-Zlib          2.222
[A.]  #10  perl5.42.3-Config-IniFiles            3.002000
[A.]  #11  perl5.42.3-Crypt-URandom              0.55
[A.]  #12  perl5.42.3-Digest-HMAC                1.05
[A.]  #13  perl5.42.3-Encode-Locale              1.05
[A.]  #14  perl5.42.3-ExtUtils-Depends           0.8001
[A.]  #15  perl5.42.3-ExtUtils-PkgConfig         1.16
[A.]  #16  perl5.42.3-FCGI                       0.82
[A.]  #17  perl5.42.3-FCGI-ProcManager           0.28
[A.]  #18  perl5.42.3-File-Listing               6.16
[A.]  #19  perl5.42.3-File-Slurp                 9999.32
[A.]  #20  perl5.42.3-Glib                       1.3294
[A.]  #21  perl5.42.3-Glib-Object-Introspection  0.051
[A.]  #22  perl5.42.3-Gtk3                       0.038
[A.]  #23  perl5.42.3-HTML-Parser                3.85
[A.]  #24  perl5.42.3-HTML-TagCloud              0.38
[A.]  #25  perl5.42.3-HTML-Tagset                3.20
[A.]  #26  perl5.42.3-HTTP-CookieJar             0.014
[A.]  #27  perl5.42.3-HTTP-Cookies               6.10
[A.]  #28  perl5.42.3-HTTP-Daemon                6.17
[A.]  #29  perl5.42.3-HTTP-Date                  6.08
[A.]  #30  perl5.42.3-HTTP-Message               7.02
[A.]  #31  perl5.42.3-HTTP-Negotiate             6.01
[A.]  #32  perl5.42.3-IO-Compress                2.221
[A.]  #33  perl5.42.3-IO-HTML                    1.004
[A.]  #34  perl5.42.3-IO-Socket-SSL              2.083
[A.]  #35  perl5.42.3-IO-Stringy                 2.113
[A.]  #36  perl5.42.3-JSON                       4.10
[A.]  #37  perl5.42.3-LWP-MediaTypes             6.04
[A.]  #38  perl5.42.3-Mozilla-CA                 20230821
[A.]  #39  perl5.42.3-Net-HTTP                   6.23

_… diff truncated (183 lines total); see the `closure-diff-aanallein` artifact for the full output._

</details>

<details><summary><b>rhuidean</b></summary>

```
<<< result-old
>>> result-new
Version changes:
[U*]  #001  cachix                            1.11.1-bin -> 1.12.0-bin
[U.]  #002  cfitsio                           4.6.4 -> 4.7.0
[U.]  #003  chromaprint                       1.6.0 -> 1.6.1
[U*]  #004  cpupower                          6.18.45, 6.18.45_fish-completions -> 6.18.47, 6.18.47_fish-completions
[U.]  #005  crun                              1.27.1 -> 1.29.1
[U*]  #006  cryptsetup                        2.8.6 x2, 2.8.6-bin, 2.8.6-man -> 2.8.7 x2, 2.8.7-bin, 2.8.7-man
[U.]  #007  discord                           1.0.153, 1.0.153-bwrap, 1.0.153-fhsenv-profile, 1.0.153-fhsenv-rootfs, 1.0.153-fish-completions, 1.0.153-init -> 1.0.154, 1.0.154-bwrap, 1.0.154-fhsenv-profile, 1.0.154-fhsenv-rootfs, 1.0.154-fish-completions, 1.0.154-init
[U.]  #008  discord-unwrapped                 1.0.153 -> 1.0.154
[U.]  #009  elementary-icon-theme             8.2.0-unstable-2026-07-06 -> 9.0.0
[C.]  #010  expat                             2.8.2 x3, 2.8.2-dev -> 2.8.2, 2.8.3 x2, 2.8.3-dev
[U.]  #011  fd                                10.4.2, 10.4.2-fish-completions -> 10.5.0, 10.5.0-fish-completions
[C.]  #012  ffmpeg                            7.1.5-data, 7.1.5-lib, 9.0-data, 9.0-lib -> 8.1.2-data, 8.1.2-lib, 9.0.1-data, 9.0.1-lib
[C.]  #013  ffmpeg-headless                   7.1.5-data, 7.1.5-lib, 8.1.2-data, 8.1.2-lib, 9.0-data x2, 9.0-lib x2 -> 7.1.5-data, 7.1.5-lib, 9.0.1-data x2, 9.0.1-lib x2
[U*]  #014  geoclue                           2.8.1, 2.8.1_fish-completions -> 2.8.2, 2.8.2_fish-completions
[U*]  #015  getent-glibc                      2.42-67 -> 2.42-84
[C*]  #016  glibc                             2.42-67 x3, 2.42-67-bin x2, 2.42-67-dev, 2.42-67-getent -> 2.42-67, 2.42-84 x2, 2.42-84-bin x2, 2.42-84-dev, 2.42-84-getent
[U*]  #017  glibc-locales                     2.42-67 x2 -> 2.42-84 x2
[U.]  #018  glibc-multi                       2.42-67, 2.42-67-bin -> 2.42-84, 2.42-84-bin
[U.]  #019  graphviz                          15.1.0 -> 15.1.1
[U.]  #020  gst-devtools                      1.28.5 -> 1.28.6
[U.]  #021  gst-editing-services              1.28.5 -> 1.28.6
[U.]  #022  gst-libav                         1.28.5 -> 1.28.6
[U.]  #023  gst-plugins-bad                   1.28.5 -> 1.28.6
[U.]  #024  gst-plugins-base                  1.28.5 x2 -> 1.28.6 x2
[U.]  #025  gst-plugins-good                  1.28.5 x2 -> 1.28.6 x2
[U.]  #026  gst-plugins-ugly                  1.28.5 -> 1.28.6
[U.]  #027  gst-rtsp-server                   1.28.5 -> 1.28.6
[U.]  #028  gstreamer                         1.28.5 x2, 1.28.5-bin -> 1.28.6 x2, 1.28.6-bin
[U.]  #029  initrd-linux                      6.18.45 -> 6.18.47
[C*]  #030  iproute2                          7.1.0, 7.1.0_fish-completions -> 7.1.0, 7.1.0-man
[C.]  #031  jemalloc                          5.3.1 x2 -> 5.3.1
[U.]  #032  libarchive                        3.8.8, 3.8.8-lib x2 -> 3.8.9, 3.8.9-lib x2
[U.]  #033  libblake3                         1.8.5 -> 1.8.6
[U.]  #034  libcamera                         0.7.0 x2 -> 0.7.2 x2
[C.]  #035  libffi                            3.7.0, 3.7.1 x2, 3.7.1-dev -> 3.7.0, 3.8.0 x2, 3.8.0-dev
[U.]  #036  libphonenumber                    9.0.37 -> 9.0.38
[U.]  #037  libpq                             18.4 -> 18.6
[U.]  #038  libsodium                         1.0.22-unstable-2026-07-08 -> 1.0.22-unstable-2026-07-31
[C.]  #039  libyuv                            1908 -> 1908 x2
[U.]  #040  linux                             6.18.45, 6.18.45-modules x2 -> 6.18.47, 6.18.47-modules x2
[U.]  #041  lmdb                              0.9.35 -> 0.9.36
[U.]  #042  lsp-plugins                       1.2.34 -> 1.2.35
[U.]  #043  luajit                            2.1.1774638290 -> 2.1.1785763465
[C.]  #044  nghttp2                           1.69.0-lib x3 -> 1.69.0-lib, 1.70.0-lib x2
[U.]  #045  nixos-system-rhuidean             26.11.20260822.2c423e0 -> 26.11.20260828.83199d0
[U.]  #046  nspr                              4.39 -> 4.40
[C*]  #047  perl                              5.42.0 x3, 5.42.0-env x4, 5.42.0-man -> 5.42.0, 5.42.3 x2, 5.42.3-env x4, 5.42.3-man
[C.]  #048  perl5.42.0-Authen-SASL            2.1900 x2 -> 2.1900
[C.]  #049  perl5.42.0-CGI                    4.59 x2 -> 4.59
[C.]  #050  perl5.42.0-CGI-Fast               2.16 x2 -> 2.16
[C.]  #051  perl5.42.0-Clone                  0.46 x3 -> 0.46
[C.]  #052  perl5.42.0-Compress-Raw-Bzip2     2.218 x3 -> 2.218
[C.]  #053  perl5.42.0-Compress-Raw-Zlib      2.222 x3 -> 2.222
[C.]  #054  perl5.42.0-Crypt-URandom          0.55 x2 -> 0.55
[C.]  #055  perl5.42.0-Digest-HMAC            1.05 x2 -> 1.05
[C.]  #056  perl5.42.0-Encode-Locale          1.05 x3 -> 1.05
[C.]  #057  perl5.42.0-FCGI                   0.82 x2 -> 0.82
[C.]  #058  perl5.42.0-FCGI-ProcManager       0.28 x2 -> 0.28
[C.]  #059  perl5.42.0-File-Listing           6.16 x3 -> 6.16
[C.]  #060  perl5.42.0-HTML-Parser            3.85 x3 -> 3.85
[C.]  #061  perl5.42.0-HTML-TagCloud          0.38 x2 -> 0.38
[C.]  #062  perl5.42.0-HTML-Tagset            3.20 x3 -> 3.20
[C.]  #063  perl5.42.0-HTTP-CookieJar         0.014 x3 -> 0.014
[C.]  #064  perl5.42.0-HTTP-Cookies           6.10 x3 -> 6.10
[C.]  #065  perl5.42.0-HTTP-Daemon            6.17 x3 -> 6.17
[C.]  #066  perl5.42.0-HTTP-Date              6.06 x3 -> 6.06
[C.]  #067  perl5.42.0-HTTP-Message           7.02 x3 -> 7.02
[C.]  #068  perl5.42.0-HTTP-Negotiate         6.01 x3 -> 6.01
[C.]  #069  perl5.42.0-IO-Compress            2.221 x3 -> 2.221
[C.]  #070  perl5.42.0-IO-HTML                1.004 x3 -> 1.004
[C.]  #071  perl5.42.0-IO-Socket-SSL          2.083 x2 -> 2.083
[C.]  #072  perl5.42.0-LWP-MediaTypes         6.04 x3 -> 6.04
[C.]  #073  perl5.42.0-Mozilla-CA             20230821 x2 -> 20230821
[C.]  #074  perl5.42.0-Net-HTTP               6.23 x3 -> 6.23
[C.]  #075  perl5.42.0-Net-SMTP-SSL           1.04 x2 -> 1.04
[C.]  #076  perl5.42.0-Net-SSLeay             1.92 x2 -> 1.92
[C.]  #077  perl5.42.0-TermReadKey            2.38 x2 -> 2.38
[C.]  #078  perl5.42.0-Test-Fatal             0.017 x3 -> 0.017
[C.]  #079  perl5.42.0-Test-Needs             0.002010 x3 -> 0.002010
[C.]  #080  perl5.42.0-Test-RequiresInternet  0.05 x3 -> 0.05
[C.]  #081  perl5.42.0-TimeDate               2.33 x3 -> 2.33
[C.]  #082  perl5.42.0-Try-Tiny               0.31 x3 -> 0.31
[C.]  #083  perl5.42.0-URI                    5.21 x3 -> 5.21
[C.]  #084  perl5.42.0-WWW-RobotRules         6.02 x3 -> 6.02
[C.]  #085  perl5.42.0-libnet                 3.15 x2 -> 3.15
[C.]  #086  perl5.42.0-libwww-perl            6.83 x3 -> 6.83
[U*]  #087  procps                            4.0.6 x2, 4.0.6-doc, 4.0.6-man -> 4.0.7 x2, 4.0.7-doc, 4.0.7-man
[C.]  #088  publicsuffix-list                 0-unstable-2026-06-24, 0-unstable-2026-07-25 x2 -> 0-unstable-2026-06-24, 0-unstable-2026-08-14 x2
[U.]  #089  python3.14-gst-python             1.28.5 -> 1.28.6
[U.]  #090  qt5compat                         6.11.1 -> 6.11.2
[U.]  #091  qtbase                            6.11.1, 6.11.1-dev, 6.11.1-only-plugins-qml -> 6.11.2, 6.11.2-dev, 6.11.2-only-plugins-qml
[U.]  #092  qtcharts                          6.11.1 -> 6.11.2
[U.]  #093  qtdeclarative                     6.11.1 -> 6.11.2
[U.]  #094  qtgraphs                          6.11.1 -> 6.11.2
[U.]  #095  qtmultimedia                      6.11.1 -> 6.11.2
[U.]  #096  qtquick3d                         6.11.1 -> 6.11.2
[U.]  #097  qtquicktimeline                   6.11.1 -> 6.11.2
[U.]  #098  qtshadertools                     6.11.1 -> 6.11.2
[U.]  #099  qtspeech                          6.11.1 -> 6.11.2
[U.]  #100  qtsvg                             6.11.1, 6.11.1-dev -> 6.11.2, 6.11.2-dev
[U.]  #101  qttools                           6.11.1 -> 6.11.2
[U.]  #102  qttranslations                    6.11.1 -> 6.11.2
[U.]  #103  qtwayland                         6.11.1 -> 6.11.2
[U*]  #104  rsync                             3.4.4, 3.4.4_fish-completions -> 3.5.0, 3.5.0_fish-completions
[U.]  #105  sdl3                              3.4.12-lib x2 -> 3.4.14-lib x2
[U*]  #106  shadow                            4.20.0, 4.20.0-man, 4.20.0-su -> 4.20.2, 4.20.2-man, 4.20.2-su
[U.]  #107  spice-gtk                         0.42 -> 0.43
[U*]  #108  strace                            7.1, 7.1-man -> 7.2, 7.2-man
[C*]  #109  systemd                           <none>, 261.1 x2, 261.1-dev, 261.1-man -> <none>, 261.2 x2, 261.2-dev, 261.2-man
[U.]  #110  systemd-minimal                   261.1 x2 -> 261.2 x2
[C.]  #111  systemd-minimal-libs              261, 261.1 x2, 261.1-dev -> 261, 261.2 x2, 261.2-dev
[U*]  #112  texinfo-interactive               7.2, 7.2_fish-completions -> 7.3, 7.3_fish-completions
[U.]  #113  unbound                           1.25.2-lib x2 -> 1.26.0-lib x2
[U.]  #114  zvbi                              0.2.44 x2 -> 0.2.45 x2
Added packages:
[A.]  #01  perl5.42.3-Authen-SASL                2.1900
[A.]  #02  perl5.42.3-CGI                        4.59
[A.]  #03  perl5.42.3-CGI-Fast                   2.16
[A.]  #04  perl5.42.3-Cairo                      1.109
[A.]  #05  perl5.42.3-Cairo-GObject              1.005
[A.]  #06  perl5.42.3-Chipcard-PCSC              1.4.16
[A.]  #07  perl5.42.3-Clone                      0.46 x2
[A.]  #08  perl5.42.3-Compress-Raw-Bzip2         2.218 x2
[A.]  #09  perl5.42.3-Compress-Raw-Zlib          2.222 x2
[A.]  #10  perl5.42.3-Config-IniFiles            3.002000
[A.]  #11  perl5.42.3-Crypt-URandom              0.55
[A.]  #12  perl5.42.3-Digest-HMAC                1.05
[A.]  #13  perl5.42.3-Encode-Locale              1.05 x2
[A.]  #14  perl5.42.3-ExtUtils-Depends           0.8001
[A.]  #15  perl5.42.3-ExtUtils-PkgConfig         1.16
[A.]  #16  perl5.42.3-FCGI                       0.82
[A.]  #17  perl5.42.3-FCGI-ProcManager           0.28
[A.]  #18  perl5.42.3-File-BaseDir               0.09 x2
[A.]  #19  perl5.42.3-File-DesktopEntry          0.22 x2
[A.]  #20  perl5.42.3-File-Listing               6.16 x2
[A.]  #21  perl5.42.3-File-MimeInfo              0.33 x2
[A.]  #22  perl5.42.3-File-Slurp                 9999.32
[A.]  #23  perl5.42.3-GD                         2.86
[A.]  #24  perl5.42.3-Glib                       1.3294
[A.]  #25  perl5.42.3-Glib-Object-Introspection  0.051
[A.]  #26  perl5.42.3-Gtk3                       0.038
[A.]  #27  perl5.42.3-HTML-Parser                3.85 x2
[A.]  #28  perl5.42.3-HTML-TagCloud              0.38
[A.]  #29  perl5.42.3-HTML-Tagset                3.20 x2
[A.]  #30  perl5.42.3-HTTP-CookieJar             0.014 x2
[A.]  #31  perl5.42.3-HTTP-Cookies               6.10 x2

_… diff truncated (209 lines total); see the `closure-diff-rhuidean` artifact for the full output._

</details>

<details><summary><b>tanchico</b></summary>

```
<<< result-old
>>> result-new
Version changes:
[U*]  #001  cachix                            1.11.1-bin -> 1.12.0-bin
[U.]  #002  cfitsio                           4.6.4 -> 4.7.0
[U.]  #003  chromaprint                       1.6.0 -> 1.6.1
[U*]  #004  cpupower                          6.18.45, 6.18.45_fish-completions -> 6.18.47, 6.18.47_fish-completions
[U.]  #005  crun                              1.27.1 -> 1.29.1
[U*]  #006  cryptsetup                        2.8.6 x2, 2.8.6-bin, 2.8.6-man -> 2.8.7 x2, 2.8.7-bin, 2.8.7-man
[U.]  #007  discord                           1.0.153, 1.0.153-bwrap, 1.0.153-fhsenv-profile, 1.0.153-fhsenv-rootfs, 1.0.153-fish-completions, 1.0.153-init -> 1.0.154, 1.0.154-bwrap, 1.0.154-fhsenv-profile, 1.0.154-fhsenv-rootfs, 1.0.154-fish-completions, 1.0.154-init
[U.]  #008  discord-unwrapped                 1.0.153 -> 1.0.154
[U.]  #009  elementary-icon-theme             8.2.0-unstable-2026-07-06 -> 9.0.0
[C.]  #010  expat                             2.8.2 x3, 2.8.2-dev -> 2.8.2, 2.8.3 x2, 2.8.3-dev
[U.]  #011  fd                                10.4.2, 10.4.2-fish-completions -> 10.5.0, 10.5.0-fish-completions
[C.]  #012  ffmpeg                            7.1.5-data, 7.1.5-lib, 9.0-data, 9.0-lib -> 8.1.2-data, 8.1.2-lib, 9.0.1-data, 9.0.1-lib
[C.]  #013  ffmpeg-headless                   7.1.5-data, 7.1.5-lib, 8.1.2-data, 8.1.2-lib, 9.0-data x2, 9.0-lib x2 -> 7.1.5-data, 7.1.5-lib, 9.0.1-data x2, 9.0.1-lib x2
[U*]  #014  geoclue                           2.8.1, 2.8.1_fish-completions -> 2.8.2, 2.8.2_fish-completions
[U*]  #015  getent-glibc                      2.42-67 -> 2.42-84
[C*]  #016  glibc                             2.42-67 x3, 2.42-67-bin x2, 2.42-67-dev, 2.42-67-getent -> 2.42-67, 2.42-84 x2, 2.42-84-bin x2, 2.42-84-dev, 2.42-84-getent
[U*]  #017  glibc-locales                     2.42-67 x2 -> 2.42-84 x2
[U.]  #018  glibc-multi                       2.42-67, 2.42-67-bin -> 2.42-84, 2.42-84-bin
[U.]  #019  graphviz                          15.1.0 -> 15.1.1
[U.]  #020  gst-devtools                      1.28.5 -> 1.28.6
[U.]  #021  gst-editing-services              1.28.5 -> 1.28.6
[U.]  #022  gst-libav                         1.28.5 -> 1.28.6
[U.]  #023  gst-plugins-bad                   1.28.5 -> 1.28.6
[U.]  #024  gst-plugins-base                  1.28.5 x2 -> 1.28.6 x2
[U.]  #025  gst-plugins-good                  1.28.5 x2 -> 1.28.6 x2
[U.]  #026  gst-plugins-ugly                  1.28.5 -> 1.28.6
[U.]  #027  gst-rtsp-server                   1.28.5 -> 1.28.6
[U.]  #028  gstreamer                         1.28.5 x2, 1.28.5-bin -> 1.28.6 x2, 1.28.6-bin
[U.]  #029  initrd-linux                      6.18.45 -> 6.18.47
[C*]  #030  iproute2                          7.1.0, 7.1.0_fish-completions -> 7.1.0, 7.1.0-man
[C.]  #031  jemalloc                          5.3.1 x2 -> 5.3.1
[U.]  #032  libarchive                        3.8.8, 3.8.8-lib x2 -> 3.8.9, 3.8.9-lib x2
[U.]  #033  libblake3                         1.8.5 -> 1.8.6
[U.]  #034  libcamera                         0.7.0 x2 -> 0.7.2 x2
[C.]  #035  libffi                            3.7.0, 3.7.1 x2, 3.7.1-dev -> 3.7.0, 3.8.0 x2, 3.8.0-dev
[U.]  #036  libphonenumber                    9.0.37 -> 9.0.38
[U.]  #037  libpq                             18.4 -> 18.6
[U.]  #038  libsodium                         1.0.22-unstable-2026-07-08 -> 1.0.22-unstable-2026-07-31
[C.]  #039  libyuv                            1908 -> 1908 x2
[U.]  #040  linux                             6.18.45, 6.18.45-modules x2 -> 6.18.47, 6.18.47-modules x2
[U.]  #041  lmdb                              0.9.35 -> 0.9.36
[U.]  #042  lsp-plugins                       1.2.34 -> 1.2.35
[U.]  #043  luajit                            2.1.1774638290 -> 2.1.1785763465
[C.]  #044  nghttp2                           1.69.0-lib x3 -> 1.69.0-lib, 1.70.0-lib x2
[U.]  #045  nixos-system-tanchico             26.11.20260822.2c423e0 -> 26.11.20260828.83199d0
[U.]  #046  nspr                              4.39 -> 4.40
[C*]  #047  perl                              5.42.0 x3, 5.42.0-env x4, 5.42.0-man -> 5.42.0, 5.42.3 x2, 5.42.3-env x4, 5.42.3-man
[C.]  #048  perl5.42.0-Authen-SASL            2.1900 x2 -> 2.1900
[C.]  #049  perl5.42.0-CGI                    4.59 x2 -> 4.59
[C.]  #050  perl5.42.0-CGI-Fast               2.16 x2 -> 2.16
[C.]  #051  perl5.42.0-Clone                  0.46 x3 -> 0.46
[C.]  #052  perl5.42.0-Compress-Raw-Bzip2     2.218 x3 -> 2.218
[C.]  #053  perl5.42.0-Compress-Raw-Zlib      2.222 x3 -> 2.222
[C.]  #054  perl5.42.0-Crypt-URandom          0.55 x2 -> 0.55
[C.]  #055  perl5.42.0-Digest-HMAC            1.05 x2 -> 1.05
[C.]  #056  perl5.42.0-Encode-Locale          1.05 x3 -> 1.05
[C.]  #057  perl5.42.0-FCGI                   0.82 x2 -> 0.82
[C.]  #058  perl5.42.0-FCGI-ProcManager       0.28 x2 -> 0.28
[C.]  #059  perl5.42.0-File-Listing           6.16 x3 -> 6.16
[C.]  #060  perl5.42.0-HTML-Parser            3.85 x3 -> 3.85
[C.]  #061  perl5.42.0-HTML-TagCloud          0.38 x2 -> 0.38
[C.]  #062  perl5.42.0-HTML-Tagset            3.20 x3 -> 3.20
[C.]  #063  perl5.42.0-HTTP-CookieJar         0.014 x3 -> 0.014
[C.]  #064  perl5.42.0-HTTP-Cookies           6.10 x3 -> 6.10
[C.]  #065  perl5.42.0-HTTP-Daemon            6.17 x3 -> 6.17
[C.]  #066  perl5.42.0-HTTP-Date              6.06 x3 -> 6.06
[C.]  #067  perl5.42.0-HTTP-Message           7.02 x3 -> 7.02
[C.]  #068  perl5.42.0-HTTP-Negotiate         6.01 x3 -> 6.01
[C.]  #069  perl5.42.0-IO-Compress            2.221 x3 -> 2.221
[C.]  #070  perl5.42.0-IO-HTML                1.004 x3 -> 1.004
[C.]  #071  perl5.42.0-IO-Socket-SSL          2.083 x2 -> 2.083
[C.]  #072  perl5.42.0-LWP-MediaTypes         6.04 x3 -> 6.04
[C.]  #073  perl5.42.0-Mozilla-CA             20230821 x2 -> 20230821
[C.]  #074  perl5.42.0-Net-HTTP               6.23 x3 -> 6.23
[C.]  #075  perl5.42.0-Net-SMTP-SSL           1.04 x2 -> 1.04
[C.]  #076  perl5.42.0-Net-SSLeay             1.92 x2 -> 1.92
[C.]  #077  perl5.42.0-TermReadKey            2.38 x2 -> 2.38
[C.]  #078  perl5.42.0-Test-Fatal             0.017 x3 -> 0.017
[C.]  #079  perl5.42.0-Test-Needs             0.002010 x3 -> 0.002010
[C.]  #080  perl5.42.0-Test-RequiresInternet  0.05 x3 -> 0.05
[C.]  #081  perl5.42.0-TimeDate               2.33 x3 -> 2.33
[C.]  #082  perl5.42.0-Try-Tiny               0.31 x3 -> 0.31
[C.]  #083  perl5.42.0-URI                    5.21 x3 -> 5.21
[C.]  #084  perl5.42.0-WWW-RobotRules         6.02 x3 -> 6.02
[C.]  #085  perl5.42.0-libnet                 3.15 x2 -> 3.15
[C.]  #086  perl5.42.0-libwww-perl            6.83 x3 -> 6.83
[U*]  #087  procps                            4.0.6 x2, 4.0.6-doc, 4.0.6-man -> 4.0.7 x2, 4.0.7-doc, 4.0.7-man
[C.]  #088  publicsuffix-list                 0-unstable-2026-06-24, 0-unstable-2026-07-25 x2 -> 0-unstable-2026-06-24, 0-unstable-2026-08-14 x2
[U.]  #089  python3.14-gst-python             1.28.5 -> 1.28.6
[U.]  #090  qt5compat                         6.11.1 -> 6.11.2
[U.]  #091  qtbase                            6.11.1, 6.11.1-dev, 6.11.1-only-plugins-qml -> 6.11.2, 6.11.2-dev, 6.11.2-only-plugins-qml
[U.]  #092  qtcharts                          6.11.1 -> 6.11.2
[U.]  #093  qtdeclarative                     6.11.1 -> 6.11.2
[U.]  #094  qtgraphs                          6.11.1 -> 6.11.2
[U.]  #095  qtmultimedia                      6.11.1 -> 6.11.2
[U.]  #096  qtquick3d                         6.11.1 -> 6.11.2
[U.]  #097  qtquicktimeline                   6.11.1 -> 6.11.2
[U.]  #098  qtshadertools                     6.11.1 -> 6.11.2
[U.]  #099  qtspeech                          6.11.1 -> 6.11.2
[U.]  #100  qtsvg                             6.11.1, 6.11.1-dev -> 6.11.2, 6.11.2-dev
[U.]  #101  qttools                           6.11.1 -> 6.11.2
[U.]  #102  qttranslations                    6.11.1 -> 6.11.2
[U.]  #103  qtwayland                         6.11.1 -> 6.11.2
[U*]  #104  rsync                             3.4.4, 3.4.4_fish-completions -> 3.5.0, 3.5.0_fish-completions
[U.]  #105  sdl3                              3.4.12-lib x2 -> 3.4.14-lib x2
[U*]  #106  shadow                            4.20.0, 4.20.0-man, 4.20.0-su -> 4.20.2, 4.20.2-man, 4.20.2-su
[U.]  #107  spice-gtk                         0.42 -> 0.43
[U*]  #108  strace                            7.1, 7.1-man -> 7.2, 7.2-man
[C*]  #109  systemd                           <none>, 261.1 x2, 261.1-dev, 261.1-man -> <none>, 261.2 x2, 261.2-dev, 261.2-man
[U.]  #110  systemd-minimal                   261.1 x2 -> 261.2 x2
[C.]  #111  systemd-minimal-libs              261, 261.1 x2, 261.1-dev -> 261, 261.2 x2, 261.2-dev
[U*]  #112  texinfo-interactive               7.2, 7.2_fish-completions -> 7.3, 7.3_fish-completions
[U.]  #113  unbound                           1.25.2-lib x2 -> 1.26.0-lib x2
[U.]  #114  zvbi                              0.2.44 x2 -> 0.2.45 x2
Added packages:
[A.]  #01  perl5.42.3-Authen-SASL                2.1900
[A.]  #02  perl5.42.3-CGI                        4.59
[A.]  #03  perl5.42.3-CGI-Fast                   2.16
[A.]  #04  perl5.42.3-Cairo                      1.109
[A.]  #05  perl5.42.3-Cairo-GObject              1.005
[A.]  #06  perl5.42.3-Chipcard-PCSC              1.4.16
[A.]  #07  perl5.42.3-Clone                      0.46 x2
[A.]  #08  perl5.42.3-Compress-Raw-Bzip2         2.218 x2
[A.]  #09  perl5.42.3-Compress-Raw-Zlib          2.222 x2
[A.]  #10  perl5.42.3-Config-IniFiles            3.002000
[A.]  #11  perl5.42.3-Crypt-URandom              0.55
[A.]  #12  perl5.42.3-Digest-HMAC                1.05
[A.]  #13  perl5.42.3-Encode-Locale              1.05 x2
[A.]  #14  perl5.42.3-ExtUtils-Depends           0.8001
[A.]  #15  perl5.42.3-ExtUtils-PkgConfig         1.16
[A.]  #16  perl5.42.3-FCGI                       0.82
[A.]  #17  perl5.42.3-FCGI-ProcManager           0.28
[A.]  #18  perl5.42.3-File-BaseDir               0.09 x2
[A.]  #19  perl5.42.3-File-DesktopEntry          0.22 x2
[A.]  #20  perl5.42.3-File-Listing               6.16 x2
[A.]  #21  perl5.42.3-File-MimeInfo              0.33 x2
[A.]  #22  perl5.42.3-File-Slurp                 9999.32
[A.]  #23  perl5.42.3-GD                         2.86
[A.]  #24  perl5.42.3-Glib                       1.3294
[A.]  #25  perl5.42.3-Glib-Object-Introspection  0.051
[A.]  #26  perl5.42.3-Gtk3                       0.038
[A.]  #27  perl5.42.3-HTML-Parser                3.85 x2
[A.]  #28  perl5.42.3-HTML-TagCloud              0.38
[A.]  #29  perl5.42.3-HTML-Tagset                3.20 x2
[A.]  #30  perl5.42.3-HTTP-CookieJar             0.014 x2
[A.]  #31  perl5.42.3-HTTP-Cookies               6.10 x2

_… diff truncated (209 lines total); see the `closure-diff-tanchico` artifact for the full output._

</details>

<details><summary><b>terangreal</b></summary>

```
<<< result-old
>>> result-new
Version changes:
[U.]  #001  OVMF                              202605-fd -> 202608-fd
[U.]  #002  OVMF-xen                          202605-fd -> 202608-fd
[U.]  #003  ada                               3.4.4 -> 4.0.0
[C.]  #004  aquamarine                        0.14.0, 0.14.0+date=2026-08-22_7ce889c -> 0.14.0, 0.14.0+date=2026-08-24_cf056dc
[C.]  #005  audit                             4.1.4-lib x2, 4.2.1-lib x2 -> 4.1.4-lib x2, 4.2.1-lib
[U*]  #006  cachix                            1.11.1-bin -> 1.12.0-bin
[U.]  #007  cfitsio                           4.6.4 -> 4.7.0
[U.]  #008  chromaprint                       1.6.0 -> 1.6.1
[U*]  #009  cpupower                          6.18.45, 6.18.45_fish-completions -> 6.18.47, 6.18.47_fish-completions
[C.]  #010  cracklib                          2.10.3 x3 -> 2.10.3 x2
[U.]  #011  crun                              1.27.1 -> 1.29.1
[C*]  #012  cryptsetup                        2.8.6 x3, 2.8.6-bin, 2.8.6-man -> 2.8.6, 2.8.7, 2.8.7-bin, 2.8.7-man
[C.]  #013  db                                4.8.30 x4, 5.3.28 -> 4.8.30 x3, 5.3.28
[U.]  #014  discord                           1.0.153, 1.0.153-bwrap, 1.0.153-fhsenv-profile, 1.0.153-fhsenv-rootfs, 1.0.153-fish-completions, 1.0.153-init -> 1.0.154, 1.0.154-bwrap, 1.0.154-fhsenv-profile, 1.0.154-fhsenv-rootfs, 1.0.154-fish-completions, 1.0.154-init
[U.]  #015  discord-unwrapped                 1.0.153 -> 1.0.154
[U.]  #016  elementary-icon-theme             8.2.0-unstable-2026-07-06 -> 9.0.0
[D.]  #017  emacs                             31.1-rc1 -> 31.1
[U.]  #018  emacs-evil-ghostel                0.50.0 -> 0.51.0
[U.]  #019  emacs-ghostel                     0.50.0 -> 0.51.0
[D.]  #020  emacs-with-packages               31.1-rc1 x2, 31.1-rc1-fish-completions -> 31.1 x2, 31.1-fish-completions
[C.]  #021  expat                             2.7.1, 2.8.2 x4, 2.8.2-dev -> 2.7.1, 2.8.2 x2, 2.8.3 x2, 2.8.3-dev
[U.]  #022  fd                                10.4.2, 10.4.2-fish-completions -> 10.5.0, 10.5.0-fish-completions
[C.]  #023  ffmpeg                            7.1.5-data, 7.1.5-lib, 8.1.2-data, 8.1.2-lib, 9.0-data, 9.0-lib -> 8.1.2-data x2, 8.1.2-lib x2, 9.0.1-data, 9.0.1-lib
[C.]  #024  ffmpeg-headless                   8.1.2-data x2, 8.1.2-lib x2, 9.0-data x2, 9.0-lib x2 -> 8.1.2-data, 8.1.2-lib, 9.0.1-data x2, 9.0.1-lib x2
[U.]  #025  geoclue                           2.8.1 -> 2.8.2
[C*]  #026  getent-glibc                      2.40-66, 2.42-67 -> 2.40-66, 2.42-84
[C*]  #027  glibc                             2.40-66, 2.40-66-getent, 2.42-67 x4, 2.42-67-bin x2, 2.42-67-dev, 2.42-67-getent -> 2.40-66, 2.40-66-getent, 2.42-67 x2, 2.42-67-bin, 2.42-84 x2, 2.42-84-bin, 2.42-84-dev, 2.42-84-getent
[U*]  #028  glibc-locales                     2.42-67 x2 -> 2.42-84 x2
[U.]  #029  graphviz                          15.1.0 -> 15.1.1
[U.]  #030  gst-libav                         1.28.5 -> 1.28.6
[U.]  #031  gst-plugins-bad                   1.28.5 -> 1.28.6
[C.]  #032  gst-plugins-base                  1.28.4, 1.28.5 x2 -> 1.28.4, 1.28.6 x2
[U.]  #033  gst-plugins-good                  1.28.5 -> 1.28.6
[C.]  #034  gstreamer                         1.28.4, 1.28.5 x2 -> 1.28.4, 1.28.6 x2
[C*]  #035  hyprland                          0.56.0+date=2026-08-22_45a79e5, 0.56.0+date=2026-08-22_45a79e5-man, 0.56.2 -> 0.56.0+date=2026-08-29_e43eaaa, 0.56.0+date=2026-08-29_e43eaaa-man, 0.56.2
[U.]  #036  initrd-linux                      6.18.45 -> 6.18.47
[C*]  #037  iproute2                          7.1.0, 7.1.0_fish-completions -> 7.1.0, 7.1.0-man
[C.]  #038  jemalloc                          5.3.1 x2 -> 5.3.1
[C*]  #039  kbd                               2.8.0-unstable-2025-08-12, 2.9.0 x3, 2.9.0-man -> 2.8.0-unstable-2025-08-12, 2.9.0 x2, 2.9.0-man
[C*]  #040  kexec-tools                       2.0.31, 2.0.32 x3, 2.0.32_fish-completions -> 2.0.31, 2.0.32 x2, 2.0.32_fish-completions
[C.]  #041  libapparmor                       5.0.0, 5.0.2 x2 -> 5.0.0, 5.0.2
[C.]  #042  libarchive                        3.8.8-lib x3 -> 3.8.8-lib, 3.8.9-lib
[U.]  #043  libblake3                         1.8.5 -> 1.8.6
[C.]  #044  libbpf                            1.7.0 x3 -> 1.7.0 x2
[C.]  #045  libcamera                         0.7.0 x3 -> 0.7.0, 0.7.2 x2
[C.]  #046  libcap-ng                         0.9.3 x4 -> 0.9.3 x3
[C.]  #047  libcbor                           0.14.0 x4 -> 0.14.0 x3
[C.]  #048  libffi                            3.5.1, 3.5.2, 3.7.0, 3.7.1 x2, 3.7.1-dev -> 3.5.1, 3.5.2, 3.7.0, 3.8.0 x2, 3.8.0-dev
[C.]  #049  libfido2                          1.17.0 x4 -> 1.17.0 x3
[C.]  #050  libgcrypt                         1.12.2-lib x3 -> 1.12.2-lib x2
[C.]  #051  libgpg-error                      1.61 x3 -> 1.61 x2
[C.]  #052  libinput                          1.31.3, 1.31.3-bin, 1.31.3-dev -> 1.31.3, 1.31.3-dev
[C.]  #053  libmicrohttpd                     1.0.5, 1.0.6 x2 -> 1.0.5, 1.0.6
[U.]  #054  libphonenumber                    9.0.37 -> 9.0.38
[U.]  #055  libpq                             18.4 -> 18.6
[C.]  #056  libpwquality                      1.4.5-lib x3 -> 1.4.5-lib x2
[C.]  #057  libseccomp                        2.6.0-lib x2, 2.6.1-lib x2 -> 2.6.0-lib x2, 2.6.1-lib
[U.]  #058  libsodium                         1.0.22-unstable-2026-07-08 -> 1.0.22-unstable-2026-07-31
[C.]  #059  libtpms                           0.10.2-unstable-2026-05-06 x3 -> 0.10.2-unstable-2026-05-06 x2
[C.]  #060  libyuv                            1908 -> 1908 x2
[U.]  #061  linux                             6.18.45, 6.18.45-modules x2 -> 6.18.47, 6.18.47-modules x2
[C*]  #062  linux-pam                         1.7.2 x4, 1.7.2-doc, 1.7.2-man -> 1.7.2 x3, 1.7.2-doc, 1.7.2-man
[U.]  #063  lmdb                              0.9.35 -> 0.9.36
[U.]  #064  lsp-plugins                       1.2.34 -> 1.2.35
[C*]  #065  lvm2                              2.03.41, 2.03.41-bin, 2.03.41-lib x3, 2.03.41-man, 2.03.41-scripts -> 2.03.41, 2.03.41-bin, 2.03.41-lib x2, 2.03.41-man, 2.03.41-scripts
[C.]  #066  lz4                               1.10.0-lib x3 -> 1.10.0-lib x2
[C.]  #067  nghttp2                           1.66.0-lib, 1.69.0, 1.69.0-dev, 1.69.0-lib x4 -> 1.66.0-lib, 1.69.0-lib x2, 1.70.0, 1.70.0-dev, 1.70.0-lib x2
[U.]  #068  nixos-system-terangreal           26.11.20260822.2c423e0 -> 26.11.20260828.83199d0
[U.]  #069  nspr                              4.39 -> 4.40
[C*]  #070  pcsclite                          2.4.1, 2.4.1-doc, 2.4.1-lib x4, 2.4.1-man -> 2.4.1, 2.4.1-doc, 2.4.1-lib x3, 2.4.1-man
[C*]  #071  perl                              5.42.0 x3, 5.42.0-env x3, 5.42.0-man -> 5.42.0 x2, 5.42.3, 5.42.3-env x3, 5.42.3-man
[C.]  #072  perl5.42.0-Authen-SASL            2.1900 x3 -> 2.1900 x2
[C.]  #073  perl5.42.0-CGI                    4.59 x3 -> 4.59 x2
[C.]  #074  perl5.42.0-CGI-Fast               2.16 x3 -> 2.16 x2
[C.]  #075  perl5.42.0-Clone                  0.46 x3 -> 0.46 x2
[C.]  #076  perl5.42.0-Compress-Raw-Bzip2     2.218 x3 -> 2.218 x2
[C.]  #077  perl5.42.0-Compress-Raw-Zlib      2.222 x3 -> 2.222 x2
[C.]  #078  perl5.42.0-Crypt-URandom          0.55 x3 -> 0.55 x2
[C.]  #079  perl5.42.0-Digest-HMAC            1.05 x3 -> 1.05 x2
[C.]  #080  perl5.42.0-Encode-Locale          1.05 x3 -> 1.05 x2
[C.]  #081  perl5.42.0-FCGI                   0.82 x3 -> 0.82 x2
[C.]  #082  perl5.42.0-FCGI-ProcManager       0.28 x3 -> 0.28 x2
[C.]  #083  perl5.42.0-File-Listing           6.16 x3 -> 6.16 x2
[C.]  #084  perl5.42.0-HTML-Parser            3.85 x3 -> 3.85 x2
[C.]  #085  perl5.42.0-HTML-TagCloud          0.38 x3 -> 0.38 x2
[C.]  #086  perl5.42.0-HTML-Tagset            3.20 x3 -> 3.20 x2
[C.]  #087  perl5.42.0-HTTP-CookieJar         0.014 x3 -> 0.014 x2
[C.]  #088  perl5.42.0-HTTP-Cookies           6.10 x3 -> 6.10 x2
[C.]  #089  perl5.42.0-HTTP-Daemon            6.17 x3 -> 6.17 x2
[C.]  #090  perl5.42.0-HTTP-Date              6.06 x3 -> 6.06 x2
[C.]  #091  perl5.42.0-HTTP-Message           7.02 x3 -> 7.02 x2
[C.]  #092  perl5.42.0-HTTP-Negotiate         6.01 x3 -> 6.01 x2
[C.]  #093  perl5.42.0-IO-Compress            2.221 x3 -> 2.221 x2
[C.]  #094  perl5.42.0-IO-HTML                1.004 x3 -> 1.004 x2
[C.]  #095  perl5.42.0-IO-Socket-SSL          2.083 x3 -> 2.083 x2
[C.]  #096  perl5.42.0-LWP-MediaTypes         6.04 x3 -> 6.04 x2
[C.]  #097  perl5.42.0-Mozilla-CA             20230821 x3 -> 20230821 x2
[C.]  #098  perl5.42.0-Net-HTTP               6.23 x3 -> 6.23 x2
[C.]  #099  perl5.42.0-Net-SMTP-SSL           1.04 x3 -> 1.04 x2
[C.]  #100  perl5.42.0-Net-SSLeay             1.92 x3 -> 1.92 x2
[C.]  #101  perl5.42.0-TermReadKey            2.38 x3 -> 2.38 x2
[C.]  #102  perl5.42.0-Test-Fatal             0.017 x3 -> 0.017 x2
[C.]  #103  perl5.42.0-Test-Needs             0.002010 x3 -> 0.002010 x2
[C.]  #104  perl5.42.0-Test-RequiresInternet  0.05 x3 -> 0.05 x2
[C.]  #105  perl5.42.0-TimeDate               2.33 x3 -> 2.33 x2
[C.]  #106  perl5.42.0-Try-Tiny               0.31 x3 -> 0.31 x2
[C.]  #107  perl5.42.0-URI                    5.21 x3 -> 5.21 x2
[C.]  #108  perl5.42.0-WWW-RobotRules         6.02 x3 -> 6.02 x2
[C.]  #109  perl5.42.0-libnet                 3.15 x3 -> 3.15 x2
[C.]  #110  perl5.42.0-libwww-perl            6.83 x3 -> 6.83 x2
[U.]  #111  prettier                          3.8.3 -> 3.9.6
[U*]  #112  procps                            4.0.6, 4.0.6-doc, 4.0.6-man -> 4.0.7, 4.0.7-doc, 4.0.7-man
[C.]  #113  publicsuffix-list                 0-unstable-2025-07-22, 0-unstable-2026-05-13, 0-unstable-2026-06-24, 0-unstable-2026-07-25 x2 -> 0-unstable-2025-07-22, 0-unstable-2026-05-13, 0-unstable-2026-06-24, 0-unstable-2026-08-14 x2
[C.]  #114  python3                           3.13.15, 3.14.6 x2, 3.14.7 x2, 3.14.7-env x5 -> 3.13.15, 3.14.6 x2, 3.14.7 x2, 3.14.7-env x4
[C.]  #115  qrencode                          4.1.1 x3, 4.1.1-bin -> 4.1.1 x2, 4.1.1-bin
[U.]  #116  qt5compat                         6.11.1 -> 6.11.2
[C.]  #117  qtbase                            5.15.19, 5.15.19-bin, 6.11.1, 6.11.1-dev, 6.11.1-only-plugins-qml -> 5.15.19, 5.15.19-bin, 6.11.2, 6.11.2-dev, 6.11.2-only-plugins-qml
[C.]  #118  qtdeclarative                     5.15.19, 5.15.19-bin, 6.11.1 -> 5.15.19, 5.15.19-bin, 6.11.2
[U.]  #119  qtgraphs                          6.11.1 -> 6.11.2
[U.]  #120  qtmultimedia                      6.11.1 -> 6.11.2
[U.]  #121  qtquick3d                         6.11.1 -> 6.11.2
[U.]  #122  qtquicktimeline                   6.11.1 -> 6.11.2
[U.]  #123  qtshadertools                     6.11.1 -> 6.11.2
[U.]  #124  qtspeech                          6.11.1 -> 6.11.2
[C.]  #125  qtsvg                             5.15.19, 5.15.19-bin, 6.11.1, 6.11.1-dev -> 5.15.19, 5.15.19-bin, 6.11.2, 6.11.2-dev
[C.]  #126  qttools                           5.15.19, 5.15.19-bin, 6.11.1 -> 5.15.19, 5.15.19-bin, 6.11.2
[C.]  #127  qttranslations                    5.15.19, 6.11.1 -> 5.15.19, 6.11.2
[C.]  #128  qtwayland                         5.15.19, 5.15.19-bin, 6.11.1 -> 5.15.19, 5.15.19-bin, 6.11.2
[U*]  #129  rsync                             3.4.4, 3.4.4_fish-completions -> 3.5.0, 3.5.0_fish-completions
[U.]  #130  sdl3                              3.4.12-lib -> 3.4.14-lib
[C*]  #131  shadow                            4.19.4, 4.20.0, 4.20.0-man, 4.20.0-su -> 4.19.4, 4.20.2, 4.20.2-man, 4.20.2-su
[U*]  #132  spice-gtk                         0.42, 0.42-man -> 0.43, 0.43-man
[U*]  #133  strace                            7.1, 7.1-man -> 7.2, 7.2-man
[C*]  #134  systemd                           <none>, 261, 261.1 x2, 261.1-dev, 261.1-man -> <none>, 261, 261.2, 261.2-dev, 261.2-man
[C.]  #135  systemd-minimal                   257.8, 261, 261.1 x2 -> 257.8, 261, 261.2 x2
[C.]  #136  systemd-minimal-libs              257.8, 261 x2, 261.1 x2, 261.1-dev -> 257.8, 261 x2, 261.2 x2, 261.2-dev
[U*]  #137  texinfo-interactive               7.2, 7.2_fish-completions -> 7.3, 7.3_fish-completions
[C.]  #138  tpm2-tss                          4.1.3, 4.2.0 x2 -> 4.1.3, 4.2.0
[U.]  #139  tree-sitter                       0.26.9 -> 0.26.11
[U.]  #140  tree-sitter-scala                 0.26.0 -> 0.26.2
[C.]  #141  unbound                           1.23.1-lib, 1.25.1-lib, 1.25.2-lib x2 -> 1.23.1-lib, 1.25.1-lib, 1.26.0-lib x2
[U*]  #142  uwsm                              0.26.6, 0.26.6-man -> 0.26.7, 0.26.7-man
[U.]  #143  vue-language-server               3.3.9 -> 3.3.10
[U.]  #144  zfs-user                          2.4.3 -> 2.4.4
[C.]  #145  zvbi                              0.2.44 x3 -> 0.2.44, 0.2.45 x2
Added packages:

_… diff truncated (241 lines total); see the `closure-diff-terangreal` artifact for the full output._

</details>

<details><summary><b>tuathaan</b></summary>

```
<<< result-old
>>> result-new
Version changes:
[U.]  #001  ada                               3.4.4 -> 4.0.0
[C.]  #002  aquamarine                        0.14.0, 0.14.0+date=2026-08-22_7ce889c -> 0.14.0, 0.14.0+date=2026-08-24_cf056dc
[C.]  #003  audit                             4.1.4-lib x2, 4.2.1-lib x2 -> 4.1.4-lib x2, 4.2.1-lib
[U*]  #004  cachix                            1.11.1-bin -> 1.12.0-bin
[U.]  #005  cfitsio                           4.6.4 -> 4.7.0
[U.]  #006  chromaprint                       1.6.0 -> 1.6.1
[U*]  #007  cpupower                          6.18.45, 6.18.45_fish-completions -> 6.18.47, 6.18.47_fish-completions
[C.]  #008  cracklib                          2.10.3 x3 -> 2.10.3 x2
[U.]  #009  crun                              1.27.1 -> 1.29.1
[C*]  #010  cryptsetup                        2.8.6 x3, 2.8.6-bin, 2.8.6-man -> 2.8.6, 2.8.7, 2.8.7-bin, 2.8.7-man
[C.]  #011  db                                4.8.30 x4, 5.3.28 -> 4.8.30 x3, 5.3.28
[U.]  #012  discord                           1.0.153, 1.0.153-bwrap, 1.0.153-fhsenv-profile, 1.0.153-fhsenv-rootfs, 1.0.153-fish-completions, 1.0.153-init -> 1.0.154, 1.0.154-bwrap, 1.0.154-fhsenv-profile, 1.0.154-fhsenv-rootfs, 1.0.154-fish-completions, 1.0.154-init
[U.]  #013  discord-unwrapped                 1.0.153 -> 1.0.154
[U.]  #014  elementary-icon-theme             8.2.0-unstable-2026-07-06 -> 9.0.0
[D.]  #015  emacs                             31.1-rc1 -> 31.1
[U.]  #016  emacs-evil-ghostel                0.50.0 -> 0.51.0
[U.]  #017  emacs-ghostel                     0.50.0 -> 0.51.0
[D.]  #018  emacs-with-packages               31.1-rc1 x2, 31.1-rc1-fish-completions -> 31.1 x2, 31.1-fish-completions
[C.]  #019  expat                             2.7.1, 2.8.2 x4, 2.8.2-dev -> 2.7.1, 2.8.2 x2, 2.8.3 x2, 2.8.3-dev
[U.]  #020  fd                                10.4.2, 10.4.2-fish-completions -> 10.5.0, 10.5.0-fish-completions
[C.]  #021  ffmpeg                            7.1.5-data, 7.1.5-lib, 8.1.2-data, 8.1.2-lib, 9.0-data, 9.0-lib -> 8.1.2-data x2, 8.1.2-lib x2, 9.0.1-data, 9.0.1-lib
[C.]  #022  ffmpeg-headless                   8.1.2-data x2, 8.1.2-lib x2, 9.0-data x2, 9.0-lib x2 -> 8.1.2-data, 8.1.2-lib, 9.0.1-data x2, 9.0.1-lib x2
[U.]  #023  geoclue                           2.8.1 -> 2.8.2
[C*]  #024  getent-glibc                      2.40-66, 2.42-67 -> 2.40-66, 2.42-84
[C*]  #025  glibc                             2.40-66, 2.40-66-getent, 2.42-67 x4, 2.42-67-bin x2, 2.42-67-dev, 2.42-67-getent -> 2.40-66, 2.40-66-getent, 2.42-67 x2, 2.42-67-bin, 2.42-84 x2, 2.42-84-bin, 2.42-84-dev, 2.42-84-getent
[U*]  #026  glibc-locales                     2.42-67 x2 -> 2.42-84 x2
[U.]  #027  graphviz                          15.1.0 -> 15.1.1
[U.]  #028  gst-libav                         1.28.5 -> 1.28.6
[U.]  #029  gst-plugins-bad                   1.28.5 -> 1.28.6
[C.]  #030  gst-plugins-base                  1.28.4, 1.28.5 x2 -> 1.28.4, 1.28.6 x2
[U.]  #031  gst-plugins-good                  1.28.5 -> 1.28.6
[C.]  #032  gstreamer                         1.28.4, 1.28.5 x2 -> 1.28.4, 1.28.6 x2
[C*]  #033  hyprland                          0.56.0+date=2026-08-22_45a79e5, 0.56.0+date=2026-08-22_45a79e5-man, 0.56.2 -> 0.56.0+date=2026-08-29_e43eaaa, 0.56.0+date=2026-08-29_e43eaaa-man, 0.56.2
[U.]  #034  initrd-linux                      6.18.45 -> 6.18.47
[C*]  #035  iproute2                          7.1.0, 7.1.0_fish-completions -> 7.1.0, 7.1.0-man
[C.]  #036  jemalloc                          5.3.1 x2 -> 5.3.1
[C*]  #037  kbd                               2.8.0-unstable-2025-08-12, 2.9.0 x3, 2.9.0-man -> 2.8.0-unstable-2025-08-12, 2.9.0 x2, 2.9.0-man
[C*]  #038  kexec-tools                       2.0.31, 2.0.32 x3, 2.0.32_fish-completions -> 2.0.31, 2.0.32 x2, 2.0.32_fish-completions
[C.]  #039  libapparmor                       5.0.0, 5.0.2 x2 -> 5.0.0, 5.0.2
[C.]  #040  libarchive                        3.8.8-lib x3 -> 3.8.8-lib, 3.8.9-lib
[U.]  #041  libblake3                         1.8.5 -> 1.8.6
[C.]  #042  libbpf                            1.7.0 x3 -> 1.7.0 x2
[C.]  #043  libcamera                         0.7.0 x3 -> 0.7.0, 0.7.2 x2
[C.]  #044  libcap-ng                         0.9.3 x4 -> 0.9.3 x3
[C.]  #045  libcbor                           0.14.0 x4 -> 0.14.0 x3
[C.]  #046  libffi                            3.5.1, 3.5.2, 3.7.0, 3.7.1 x2, 3.7.1-dev -> 3.5.1, 3.5.2, 3.7.0, 3.8.0 x2, 3.8.0-dev
[C.]  #047  libfido2                          1.17.0 x4 -> 1.17.0 x3
[C.]  #048  libgcrypt                         1.12.2-lib x3 -> 1.12.2-lib x2
[C.]  #049  libgpg-error                      1.61 x3 -> 1.61 x2
[C.]  #050  libmicrohttpd                     1.0.5, 1.0.6 x2 -> 1.0.5, 1.0.6
[U.]  #051  libphonenumber                    9.0.37 -> 9.0.38
[U.]  #052  libpq                             18.4 -> 18.6
[C.]  #053  libpwquality                      1.4.5-lib x3 -> 1.4.5-lib x2
[C.]  #054  libseccomp                        2.6.0-lib x2, 2.6.1-lib x2 -> 2.6.0-lib x2, 2.6.1-lib
[U.]  #055  libsodium                         1.0.22-unstable-2026-07-08 -> 1.0.22-unstable-2026-07-31
[C.]  #056  libtpms                           0.10.2-unstable-2026-05-06 x3 -> 0.10.2-unstable-2026-05-06 x2
[C.]  #057  libyuv                            1908 -> 1908 x2
[U.]  #058  linux                             6.18.45, 6.18.45-modules x2 -> 6.18.47, 6.18.47-modules x2
[C*]  #059  linux-pam                         1.7.2 x4, 1.7.2-doc, 1.7.2-man -> 1.7.2 x3, 1.7.2-doc, 1.7.2-man
[U.]  #060  lmdb                              0.9.35 -> 0.9.36
[U.]  #061  lsp-plugins                       1.2.34 -> 1.2.35
[C*]  #062  lvm2                              2.03.41, 2.03.41-bin, 2.03.41-lib x3, 2.03.41-man, 2.03.41-scripts -> 2.03.41, 2.03.41-bin, 2.03.41-lib x2, 2.03.41-man, 2.03.41-scripts
[C.]  #063  lz4                               1.10.0-lib x3 -> 1.10.0-lib x2
[C.]  #064  nghttp2                           1.66.0-lib, 1.69.0, 1.69.0-dev, 1.69.0-lib x4 -> 1.66.0-lib, 1.69.0-lib x2, 1.70.0, 1.70.0-dev, 1.70.0-lib x2
[U.]  #065  nixos-system-tuathaan             26.11.20260822.2c423e0 -> 26.11.20260828.83199d0
[U.]  #066  nspr                              4.39 -> 4.40
[C*]  #067  pcsclite                          2.4.1, 2.4.1-doc, 2.4.1-lib x4, 2.4.1-man -> 2.4.1, 2.4.1-doc, 2.4.1-lib x3, 2.4.1-man
[C*]  #068  perl                              5.42.0 x3, 5.42.0-env x3, 5.42.0-man -> 5.42.0 x2, 5.42.3, 5.42.3-env x3, 5.42.3-man
[C.]  #069  perl5.42.0-Authen-SASL            2.1900 x3 -> 2.1900 x2
[C.]  #070  perl5.42.0-CGI                    4.59 x3 -> 4.59 x2
[C.]  #071  perl5.42.0-CGI-Fast               2.16 x3 -> 2.16 x2
[C.]  #072  perl5.42.0-Clone                  0.46 x3 -> 0.46 x2
[C.]  #073  perl5.42.0-Compress-Raw-Bzip2     2.218 x3 -> 2.218 x2
[C.]  #074  perl5.42.0-Compress-Raw-Zlib      2.222 x3 -> 2.222 x2
[C.]  #075  perl5.42.0-Crypt-URandom          0.55 x3 -> 0.55 x2
[C.]  #076  perl5.42.0-Digest-HMAC            1.05 x3 -> 1.05 x2
[C.]  #077  perl5.42.0-Encode-Locale          1.05 x3 -> 1.05 x2
[C.]  #078  perl5.42.0-FCGI                   0.82 x3 -> 0.82 x2
[C.]  #079  perl5.42.0-FCGI-ProcManager       0.28 x3 -> 0.28 x2
[C.]  #080  perl5.42.0-File-Listing           6.16 x3 -> 6.16 x2
[C.]  #081  perl5.42.0-HTML-Parser            3.85 x3 -> 3.85 x2
[C.]  #082  perl5.42.0-HTML-TagCloud          0.38 x3 -> 0.38 x2
[C.]  #083  perl5.42.0-HTML-Tagset            3.20 x3 -> 3.20 x2
[C.]  #084  perl5.42.0-HTTP-CookieJar         0.014 x3 -> 0.014 x2
[C.]  #085  perl5.42.0-HTTP-Cookies           6.10 x3 -> 6.10 x2
[C.]  #086  perl5.42.0-HTTP-Daemon            6.17 x3 -> 6.17 x2
[C.]  #087  perl5.42.0-HTTP-Date              6.06 x3 -> 6.06 x2
[C.]  #088  perl5.42.0-HTTP-Message           7.02 x3 -> 7.02 x2
[C.]  #089  perl5.42.0-HTTP-Negotiate         6.01 x3 -> 6.01 x2
[C.]  #090  perl5.42.0-IO-Compress            2.221 x3 -> 2.221 x2
[C.]  #091  perl5.42.0-IO-HTML                1.004 x3 -> 1.004 x2
[C.]  #092  perl5.42.0-IO-Socket-SSL          2.083 x3 -> 2.083 x2
[C.]  #093  perl5.42.0-LWP-MediaTypes         6.04 x3 -> 6.04 x2
[C.]  #094  perl5.42.0-Mozilla-CA             20230821 x3 -> 20230821 x2
[C.]  #095  perl5.42.0-Net-HTTP               6.23 x3 -> 6.23 x2
[C.]  #096  perl5.42.0-Net-SMTP-SSL           1.04 x3 -> 1.04 x2
[C.]  #097  perl5.42.0-Net-SSLeay             1.92 x3 -> 1.92 x2
[C.]  #098  perl5.42.0-TermReadKey            2.38 x3 -> 2.38 x2
[C.]  #099  perl5.42.0-Test-Fatal             0.017 x3 -> 0.017 x2
[C.]  #100  perl5.42.0-Test-Needs             0.002010 x3 -> 0.002010 x2
[C.]  #101  perl5.42.0-Test-RequiresInternet  0.05 x3 -> 0.05 x2
[C.]  #102  perl5.42.0-TimeDate               2.33 x3 -> 2.33 x2
[C.]  #103  perl5.42.0-Try-Tiny               0.31 x3 -> 0.31 x2
[C.]  #104  perl5.42.0-URI                    5.21 x3 -> 5.21 x2
[C.]  #105  perl5.42.0-WWW-RobotRules         6.02 x3 -> 6.02 x2
[C.]  #106  perl5.42.0-libnet                 3.15 x3 -> 3.15 x2
[C.]  #107  perl5.42.0-libwww-perl            6.83 x3 -> 6.83 x2
[U.]  #108  prettier                          3.8.3 -> 3.9.6
[U*]  #109  procps                            4.0.6, 4.0.6-doc, 4.0.6-man -> 4.0.7, 4.0.7-doc, 4.0.7-man
[C.]  #110  publicsuffix-list                 0-unstable-2025-07-22, 0-unstable-2026-05-13, 0-unstable-2026-06-24, 0-unstable-2026-07-25 x2 -> 0-unstable-2025-07-22, 0-unstable-2026-05-13, 0-unstable-2026-06-24, 0-unstable-2026-08-14 x2
[C.]  #111  qrencode                          4.1.1 x3, 4.1.1-bin -> 4.1.1 x2, 4.1.1-bin
[U.]  #112  qt5compat                         6.11.1 -> 6.11.2
[C.]  #113  qtbase                            5.15.19, 5.15.19-bin, 6.11.1, 6.11.1-dev, 6.11.1-only-plugins-qml -> 5.15.19, 5.15.19-bin, 6.11.2, 6.11.2-dev, 6.11.2-only-plugins-qml
[C.]  #114  qtdeclarative                     5.15.19, 5.15.19-bin, 6.11.1 -> 5.15.19, 5.15.19-bin, 6.11.2
[U.]  #115  qtgraphs                          6.11.1 -> 6.11.2
[U.]  #116  qtmultimedia                      6.11.1 -> 6.11.2
[U.]  #117  qtquick3d                         6.11.1 -> 6.11.2
[U.]  #118  qtquicktimeline                   6.11.1 -> 6.11.2
[U.]  #119  qtshadertools                     6.11.1 -> 6.11.2
[U.]  #120  qtspeech                          6.11.1 -> 6.11.2
[C.]  #121  qtsvg                             5.15.19, 

_… PR body truncated to stay under GitHub's size limit; see the closure-diff-* artifacts for full diffs._\n